### PR TITLE
Add GPT models support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h3 align="center">Ungate</h3>
 
 <p align="center">
-  Use Claude subscription and MiniMax in Cursor through a local proxy that translates OpenAI-style requests into provider-native APIs.
+  A Cursor-first extension for using Claude, ChatGPT, and MiniMax subscriptions in Cursor through a local proxy that translates OpenAI-style requests into provider-native APIs.
 </p>
 
 <p align="center">
@@ -16,7 +16,9 @@
 
 ## Why
 
-Cursor can connect to OpenAI-compatible APIs, but provider-specific flows still get in the way. Claude subscriptions work through OAuth, not Anthropic API keys. MiniMax works through its own API and has provider-specific streaming behavior. Ungate hides those differences behind one local proxy and one Cursor-compatible endpoint.
+Cursor can connect to OpenAI-compatible APIs, but each provider still has its own auth flow, model mapping, and streaming behavior. Claude and ChatGPT subscriptions use OAuth instead of direct API keys. MiniMax uses its own provider credentials. Ungate hides those differences behind one local proxy and one Cursor-compatible endpoint.
+
+Ungate is not a general-purpose AI gateway. It is a Cursor-first extension focused on one job: getting Claude, GPT, and MiniMax working in Cursor with less setup and less operational overhead than a standalone multi-provider router.
 
 ## How it works
 
@@ -28,17 +30,19 @@ Workaround: use custom model IDs from the Ungate `Models` section instead of Cur
 
 The extension starts the proxy as a child process and shows its settings in a Webview panel. From there you configure the provider, copy the public proxy URL, and copy the proxy API key that Cursor uses to authenticate to your local proxy.
 
+Ungate is about a shorter Cursor-specific setup path: install one extension, let it manage the local API lifecycle, configure providers in one place, and avoid running a separate gateway stack just to use Claude, GPT, or MiniMax in Cursor.
+
 ## Features
 
 - [x] OpenAI-to-provider request translation
 - [x] Streaming responses
 - [x] Tool calls mapping
 - [x] Image support
-- [x] OAuth authentication via Claude account
+- [x] OAuth authentication via Claude or ChatGPT account
 - [x] MiniMax API key authentication
 - [x] MiniMax `<think>...</think>` reasoning separation
 - [x] Request analytics
-- [x] Analytics split by provider: Claude and MiniMax
+- [x] Analytics split by provider: Claude, OpenAI, and MiniMax
 - [x] Built-in web UI panel
 
 ## Installation
@@ -59,13 +63,14 @@ Or search `@id:orchidfiles.ungate` in the Extensions panel.
 2. Click the `Ungate :<port>` item in the status bar to open the Ungate panel.
 3. Choose the provider you want to use.
 4. For Claude, sign in with your Claude account through OAuth.
-5. For MiniMax, enter your MiniMax API key and choose a Base URL: `Global`, `China`, or `Custom`.
-6. In the Tunnel section, click `Start tunnel`, then copy the public URL shown in the panel.
-7. Paste it into Cursor Settings → Models → OpenAI Base URL.
-8. Copy the proxy API key from the same panel and paste it into Cursor Settings → Models → OpenAI API Key.
-9. In the Ungate `Models` section, copy the model IDs you want and add them as custom models in Cursor.
-10. If you use MiniMax, add `MiniMax-M2.7` as a custom model in Cursor.
-11. Select one of your custom models in Cursor and start chatting.
+5. For ChatGPT, sign in with your ChatGPT account through OAuth.
+6. For MiniMax, enter your MiniMax API key and choose a Base URL: `Global`, `China`, or `Custom`.
+7. In the Tunnel section, click `Start tunnel`, then copy the public URL shown in the panel.
+8. Paste it into Cursor Settings → Models → OpenAI Base URL.
+9. Copy the proxy API key from the same panel and paste it into Cursor Settings → Models → OpenAI API Key.
+10. In the Ungate `Models` section, copy the model IDs you want and add them as custom models in Cursor.
+11. If you use MiniMax, add `MiniMax-M2.7` as a custom model in Cursor.
+12. Select one of your custom models in Cursor and start chatting.
 
 ## Development
 

--- a/apps/api/drizzle/_0003.sql
+++ b/apps/api/drizzle/_0003.sql
@@ -1,0 +1,12 @@
+-- Migration 0003: add account_id to provider_settings
+ALTER TABLE provider_settings ADD COLUMN account_id text;
+--> statement-breakpoint
+INSERT OR IGNORE INTO model_mappings (id, label, provider, upstream_model, enabled, sort_order, reasoning_budget)
+VALUES
+	('gpt-5.4', 'GPT-5.4', 'openai', 'gpt-5.4', true, 100, NULL),
+	('gpt-5.4-mini', 'GPT-5.4 Mini', 'openai', 'gpt-5.4-mini', true, 101, NULL),
+	('gpt-5.3-codex', 'GPT-5.3 Codex', 'openai', 'gpt-5.3-codex', true, 102, 'medium'),
+	('gpt-5.3-codex-high', 'GPT-5.3 Codex High', 'openai', 'gpt-5.3-codex-high', true, 103, 'high'),
+	('gpt-5.3-codex-low', 'GPT-5.3 Codex Low', 'openai', 'gpt-5.3-codex-low', true, 104, 'low'),
+	('gpt-5.1-codex-mini', 'GPT-5.1 Codex Mini', 'openai', 'gpt-5.1-codex-mini', true, 105, 'medium'),
+	('gpt-5.1-codex-mini-high', 'GPT-5.1 Codex Mini High', 'openai', 'gpt-5.1-codex-mini-high', true, 106, 'high');

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1775298057762,
       "tag": "_0002",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1775314500000,
+      "tag": "_0003",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/auth/base-provider.ts
+++ b/apps/api/src/auth/base-provider.ts
@@ -1,10 +1,11 @@
-export type AIProviderName = 'claude' | 'minimax';
+export type AIProviderName = 'claude' | 'minimax' | 'openai';
 
 export interface OAuthCredentials {
 	accessToken: string;
-	refreshToken: string;
-	expiresAt: number;
-	email?: string;
+	refreshToken?: string | null;
+	expiresAt?: number | null;
+	email?: string | null;
+	accountId?: string | null;
 }
 
 export interface AIProvider {

--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -1,11 +1,13 @@
 import { ClaudeProvider } from './claude-provider';
 import { MiniMaxProvider } from './minimax-provider';
+import { OpenAIProvider } from './openai-provider';
 
 import type { AIProvider, AIProviderName } from './base-provider';
 
 const providers: Record<string, AIProvider> = {
 	claude: new ClaudeProvider(),
-	minimax: new MiniMaxProvider()
+	minimax: new MiniMaxProvider(),
+	openai: new OpenAIProvider()
 };
 
 export function getProvider(name: AIProviderName): AIProvider {

--- a/apps/api/src/auth/openai-oauth.ts
+++ b/apps/api/src/auth/openai-oauth.ts
@@ -1,0 +1,397 @@
+import { randomBytes } from 'node:crypto';
+import { createServer, type Server, type ServerResponse } from 'node:http';
+
+import { logger } from 'src/utils/logger';
+
+import { config } from '../config';
+import { ProviderSettings } from '../database/provider-settings';
+
+import type { OAuthCredentials } from './base-provider';
+
+interface CodexAuthInfo {
+	chatgpt_account_id: string;
+	chatgpt_plan_type: string;
+	chatgpt_user_id: string;
+	user_id: string;
+	organizations: {
+		id: string;
+		is_default: boolean;
+		role: string;
+		title: string;
+	}[];
+}
+
+interface PkceSession {
+	codeVerifier: string;
+	state: string;
+	expiresAt: number;
+}
+
+export class OpenAIOAuth {
+	private static readonly pkceStore = new Map<string, PkceSession>();
+	private static callbackServer: Server | null = null;
+	private static callbackServerTimeout: NodeJS.Timeout | null = null;
+
+	static {
+		setInterval(() => {
+			const now = Date.now();
+			for (const [sessionId, session] of this.pkceStore) {
+				if (now >= session.expiresAt) {
+					this.pkceStore.delete(sessionId);
+				}
+			}
+		}, 60_000);
+	}
+
+	static async startLogin(): Promise<{ authUrl: string; sessionId: string }> {
+		const { verifier, challenge } = await this.generatePkce();
+		const sessionId = this.base64urlEncode(randomBytes(32));
+
+		this.pkceStore.set(sessionId, {
+			codeVerifier: verifier,
+			state: verifier,
+			expiresAt: Date.now() + 10 * 60 * 1000
+		});
+
+		const cfg = config.openai.oauth;
+		const redirectUri = cfg.redirectUri;
+		await this.startCallbackServer();
+
+		const params = new URLSearchParams({
+			response_type: 'code',
+			client_id: cfg.clientId,
+			redirect_uri: redirectUri,
+			scope: cfg.scope,
+			code_challenge: challenge,
+			code_challenge_method: cfg.codeChallengeMethod,
+			...cfg.extraParams,
+			state: sessionId
+		});
+
+		return { authUrl: `${cfg.authorizeUrl}?${params}`, sessionId };
+	}
+
+	static async completeLogin(code: string, sessionId: string): Promise<{ ok: boolean; email?: string; error?: string }> {
+		const session = this.pkceStore.get(sessionId);
+
+		if (!session) {
+			return { ok: false, error: 'Session not found or expired' };
+		}
+
+		if (Date.now() >= session.expiresAt) {
+			this.pkceStore.delete(sessionId);
+
+			return { ok: false, error: 'Session expired' };
+		}
+
+		this.pkceStore.delete(sessionId);
+
+		const cfg = config.openai.oauth;
+		const redirectUri = cfg.redirectUri;
+
+		try {
+			const response = await fetch(cfg.tokenUrl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+				body: new URLSearchParams({
+					grant_type: 'authorization_code',
+					client_id: cfg.clientId,
+					code,
+					redirect_uri: redirectUri,
+					code_verifier: session.codeVerifier
+				})
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				logger.error('Token exchange failed:', response.status, errorText);
+
+				return { ok: false, error: `Token exchange failed: ${response.status}` };
+			}
+
+			const json = await response.json();
+			const tokens = json as Record<string, unknown>;
+			const idToken = (tokens.id_token as string) || null;
+			let email: string | null = null;
+			let accountId: string | null = null;
+
+			if (idToken) {
+				const parsed = this.parseIdToken(idToken);
+				email = parsed.email;
+				accountId = this.resolveWorkspace(parsed.authInfo);
+			}
+
+			const expiresAt = Date.now() + ((tokens.expires_in as number) || 3600) * 1000;
+
+			ProviderSettings.upsertOAuth('openai', {
+				accessToken: tokens.access_token as string,
+				refreshToken: (tokens.refresh_token as string) || '',
+				expiresAt,
+				email: email ?? undefined,
+				accountId: accountId ?? undefined
+			});
+
+			logger.log('✓ OpenAI OAuth login complete', email ? `(${email})` : '');
+
+			return { ok: true, email: email ?? undefined };
+		} catch (error) {
+			logger.error('completeLogin error:', error);
+
+			return { ok: false, error: String(error) };
+		}
+	}
+
+	static async getValidToken(): Promise<OAuthCredentials | null> {
+		const creds = ProviderSettings.get('openai');
+
+		if (!creds) return null;
+
+		const bufferMs = 60_000;
+
+		if (Date.now() < (creds.expiresAt ?? 0) - bufferMs) {
+			return creds;
+		}
+
+		return this.refreshToken(creds.refreshToken ?? '');
+	}
+
+	static async refreshToken(refreshTokenValue: string): Promise<OAuthCredentials | null> {
+		try {
+			logger.log('Refreshing OpenAI token...');
+
+			const cfg = config.openai.oauth;
+			const response = await fetch(cfg.tokenUrl, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/x-www-form-urlencoded', Accept: 'application/json' },
+				body: new URLSearchParams({
+					grant_type: 'refresh_token',
+					client_id: cfg.clientId,
+					refresh_token: refreshTokenValue
+				})
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				logger.error('Token refresh failed:', response.status, errorText);
+
+				return null;
+			}
+
+			const json = await response.json();
+			const tokens = json as Record<string, unknown>;
+			const expiresAt = Date.now() + ((tokens.expires_in as number) || 3600) * 1000;
+
+			const existing = ProviderSettings.get('openai');
+			const credentials: OAuthCredentials = {
+				accessToken: tokens.access_token as string,
+				refreshToken: (tokens.refresh_token as string | null) ?? refreshTokenValue,
+				expiresAt,
+				email: existing?.email ?? undefined,
+				accountId: existing?.accountId ?? undefined
+			};
+
+			ProviderSettings.upsertOAuth('openai', credentials);
+			logger.log('OpenAI token refreshed successfully');
+
+			return credentials;
+		} catch (error) {
+			logger.error('Failed to refresh token:', error);
+
+			return null;
+		}
+	}
+
+	static getAuthStatus(): { authenticated: boolean; email?: string } {
+		const creds = ProviderSettings.get('openai');
+
+		return { authenticated: !!creds?.accessToken, email: creds?.email ?? undefined };
+	}
+
+	static logout(): void {
+		ProviderSettings.remove('openai');
+		logger.log('✓ OpenAI OAuth logged out, tokens deleted');
+	}
+
+	private static async startCallbackServer(): Promise<void> {
+		await this.stopCallbackServer();
+
+		const callbackUrl = new URL(config.openai.oauth.redirectUri);
+		const port = parseInt(callbackUrl.port, 10);
+		const path = callbackUrl.pathname;
+
+		const server = createServer((request, response) => {
+			void this.handleCallbackRequest(request.url, path, response);
+		});
+
+		await new Promise<void>((resolve, reject) => {
+			server.once('error', reject);
+			server.listen(port, '127.0.0.1', () => {
+				server.off('error', reject);
+				resolve();
+			});
+		});
+
+		this.callbackServer = server;
+		this.callbackServerTimeout = setTimeout(
+			() => {
+				void this.stopCallbackServer();
+			},
+			10 * 60 * 1000
+		);
+	}
+
+	private static async stopCallbackServer(): Promise<void> {
+		if (this.callbackServerTimeout) {
+			clearTimeout(this.callbackServerTimeout);
+			this.callbackServerTimeout = null;
+		}
+
+		if (!this.callbackServer) {
+			return;
+		}
+
+		const server = this.callbackServer;
+		this.callbackServer = null;
+
+		await new Promise<void>((resolve) => {
+			server.close(() => {
+				resolve();
+			});
+		});
+	}
+
+	private static async handleCallbackRequest(
+		requestUrl: string | undefined,
+		path: string,
+		response: ServerResponse
+	): Promise<void> {
+		if (!requestUrl) {
+			response.statusCode = 400;
+			response.setHeader('Content-Type', 'text/html; charset=utf-8');
+			response.end('<html><body><h1>Missing request URL</h1></body></html>');
+
+			return;
+		}
+
+		const url = new URL(requestUrl, config.openai.oauth.redirectUri);
+
+		if (url.pathname !== path) {
+			response.statusCode = 404;
+			response.setHeader('Content-Type', 'text/html; charset=utf-8');
+			response.end('<html><body><h1>Not found</h1></body></html>');
+
+			return;
+		}
+
+		const code = url.searchParams.get('code');
+		const sessionId = url.searchParams.get('state');
+
+		if (!code || !sessionId) {
+			response.statusCode = 400;
+			response.setHeader('Content-Type', 'text/html; charset=utf-8');
+			response.end('<html><body><h1>Missing code or session</h1><p>Please close this window and try again.</p></body></html>');
+
+			return;
+		}
+
+		const result = await this.completeLogin(code, sessionId);
+		response.setHeader('Content-Type', 'text/html; charset=utf-8');
+
+		if (result.ok) {
+			response.end(
+				'<html><body><h1>Connected!</h1><p>You can close this window.</p><script>window.close()</script></body></html>'
+			);
+		} else {
+			response.statusCode = 400;
+			response.end(`<html><body><h1>Error</h1><p>${result.error ?? 'Unknown error'}</p></body></html>`);
+		}
+
+		await this.stopCallbackServer();
+	}
+
+	private static base64urlEncode(buf: Buffer): string {
+		return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+	}
+
+	private static async generatePkce(): Promise<{ verifier: string; challenge: string }> {
+		const verifier = this.base64urlEncode(randomBytes(32));
+		const enc = new TextEncoder();
+		const digest = await crypto.subtle.digest('SHA-256', enc.encode(verifier));
+		const challenge = this.base64urlEncode(Buffer.from(digest));
+
+		return { verifier, challenge };
+	}
+
+	private static base64Decode(str: string): string {
+		let base64 = str;
+
+		switch (base64.length % 4) {
+			case 2:
+				base64 += '==';
+				break;
+			case 3:
+				base64 += '=';
+				break;
+		}
+
+		base64 = base64.replace(/-/g, '+').replace(/_/g, '/');
+		const binary = atob(base64);
+		const bytes = new Uint8Array(binary.length);
+
+		for (let i = 0; i < binary.length; i++) {
+			bytes[i] = binary.charCodeAt(i);
+		}
+
+		return new TextDecoder('utf-8', { fatal: false }).decode(bytes);
+	}
+
+	private static parseIdToken(idToken: string): { email: string | null; authInfo: CodexAuthInfo | null } {
+		try {
+			const parts = idToken.split('.');
+
+			if (parts.length !== 3) {
+				return { email: null, authInfo: null };
+			}
+
+			const decoded = JSON.parse(this.base64Decode(parts[1]));
+			const email = (decoded as { email?: string }).email ?? null;
+			const authInfo = (decoded as Record<string, CodexAuthInfo>)['https://api.openai.com/auth'] ?? null;
+
+			return { email, authInfo };
+		} catch {
+			return { email: null, authInfo: null };
+		}
+	}
+
+	private static resolveWorkspace(authInfo: CodexAuthInfo | null): string | null {
+		if (!authInfo) return null;
+
+		let workspaceId = authInfo.chatgpt_account_id || null;
+		const planType = (authInfo.chatgpt_plan_type || '').toLowerCase();
+		const organizations = authInfo.organizations || [];
+
+		if (organizations.length > 0) {
+			const teamOrg = organizations.find((org) => {
+				const title = (org.title || '').toLowerCase();
+				const role = (org.role || '').toLowerCase();
+
+				return (
+					!org.is_default &&
+					(title.includes('team') ||
+						title.includes('business') ||
+						title.includes('workspace') ||
+						title.includes('org') ||
+						role === 'admin' ||
+						role === 'member')
+				);
+			});
+
+			if (planType.includes('team') || planType.includes('chatgptteam')) {
+			} else if (teamOrg && (planType === 'free' || planType === '')) {
+				workspaceId = teamOrg.id;
+			}
+		}
+
+		return workspaceId;
+	}
+}

--- a/apps/api/src/auth/openai-provider.ts
+++ b/apps/api/src/auth/openai-provider.ts
@@ -1,0 +1,27 @@
+import { ProviderSettings } from '../database/provider-settings';
+
+import type { AIProvider } from './base-provider';
+
+export class OpenAIProvider implements AIProvider {
+	readonly name = 'openai' as const;
+
+	getAuthHeader(): string | null {
+		const creds = ProviderSettings.get('openai');
+
+		if (!creds?.accessToken) {
+			return null;
+		}
+
+		return `Bearer ${creds.accessToken}`;
+	}
+
+	isAuthenticated(): boolean {
+		const creds = ProviderSettings.get('openai');
+
+		return !!creds?.accessToken;
+	}
+
+	logout(): void {
+		ProviderSettings.remove('openai');
+	}
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -24,6 +24,22 @@ export const config = {
 	},
 	claudeCode: {
 		systemPrompt: "You are Claude Code, Anthropic's official CLI for Claude."
+	},
+	openai: {
+		oauth: {
+			authorizeUrl: 'https://auth.openai.com/oauth/authorize',
+			tokenUrl: 'https://auth.openai.com/oauth/token',
+			redirectUri: 'http://localhost:1455/auth/callback',
+			clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
+			scope: 'openid profile email offline_access',
+			codeChallengeMethod: 'S256',
+			extraParams: {
+				id_token_add_organizations: 'true',
+				codex_cli_simplified_flow: 'true',
+				originator: 'codex_cli_rs'
+			}
+		},
+		codexUrl: 'https://chatgpt.com/backend-api/codex'
 	}
 } as const;
 

--- a/apps/api/src/database/analytics.ts
+++ b/apps/api/src/database/analytics.ts
@@ -17,6 +17,7 @@ export class Analytics {
 				totalRequests: sql<number>`COUNT(*)`,
 				claudeRequests: sql<number>`SUM(CASE WHEN ${requests.source} = 'claude' THEN 1 ELSE 0 END)`,
 				minimaxRequests: sql<number>`SUM(CASE WHEN ${requests.source} = 'minimax' THEN 1 ELSE 0 END)`,
+				openaiRequests: sql<number>`SUM(CASE WHEN ${requests.source} = 'openai' THEN 1 ELSE 0 END)`,
 				errorRequests: sql<number>`SUM(CASE WHEN ${requests.source} = 'error' THEN 1 ELSE 0 END)`,
 				totalInputTokens: sql<number>`SUM(${requests.inputTokens})`,
 				totalOutputTokens: sql<number>`SUM(${requests.outputTokens})`
@@ -29,6 +30,7 @@ export class Analytics {
 			totalRequests: totals?.totalRequests ?? 0,
 			claudeRequests: totals?.claudeRequests ?? 0,
 			minimaxRequests: totals?.minimaxRequests ?? 0,
+			openaiRequests: totals?.openaiRequests ?? 0,
 			errorRequests: totals?.errorRequests ?? 0,
 			totalInputTokens: totals?.totalInputTokens ?? 0,
 			totalOutputTokens: totals?.totalOutputTokens ?? 0,

--- a/apps/api/src/database/model-mappings.ts
+++ b/apps/api/src/database/model-mappings.ts
@@ -18,6 +18,10 @@ export class ModelMappings {
 			return true;
 		}
 
+		if (value === 'openai') {
+			return true;
+		}
+
 		return false;
 	}
 
@@ -90,6 +94,42 @@ export class ModelMappings {
 			.sort((a, b) => a.sortOrder - b.sortOrder);
 
 		return this.clone(models);
+	}
+
+	static resolveForChatCompletion(requestedModel: string): ModelMappingConfig | null {
+		const enabled = this.list().filter((m) => m.enabled);
+		const t = requestedModel.trim();
+
+		if (!t) {
+			return null;
+		}
+
+		const byId = enabled.find((m) => m.id === t);
+
+		if (byId) {
+			return byId;
+		}
+
+		const byUpstream = enabled.find((m) => m.upstreamModel === t);
+
+		if (byUpstream) {
+			return byUpstream;
+		}
+
+		const lower = t.toLowerCase();
+		const byIdInsensitive = enabled.find((m) => m.id.toLowerCase() === lower);
+
+		if (byIdInsensitive) {
+			return byIdInsensitive;
+		}
+
+		const byUpstreamInsensitive = enabled.find((m) => m.upstreamModel.toLowerCase() === lower);
+
+		if (byUpstreamInsensitive) {
+			return byUpstreamInsensitive;
+		}
+
+		return null;
 	}
 
 	static replace(models: ModelMappingConfig[]): void {

--- a/apps/api/src/database/provider-settings.ts
+++ b/apps/api/src/database/provider-settings.ts
@@ -33,7 +33,7 @@ export class ProviderSettings {
 			.run();
 	}
 
-	static upsertOAuth(provider: 'claude', data: OAuthCredentials): void {
+	static upsertOAuth(provider: AIProviderName, data: OAuthCredentials): void {
 		const db = getDb();
 
 		db.insert(providerSettings)
@@ -43,6 +43,7 @@ export class ProviderSettings {
 				refreshToken: data.refreshToken,
 				expiresAt: data.expiresAt,
 				email: data.email ?? null,
+				accountId: data.accountId ?? null,
 				createdAt: Date.now()
 			})
 			.onConflictDoUpdate({
@@ -51,7 +52,8 @@ export class ProviderSettings {
 					accessToken: data.accessToken,
 					refreshToken: data.refreshToken,
 					expiresAt: data.expiresAt,
-					email: data.email ?? null
+					email: data.email ?? null,
+					accountId: data.accountId ?? null
 				}
 			})
 			.run();

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -16,6 +16,7 @@ export const providerSettings = sqliteTable('provider_settings', {
 	refreshToken: text(),
 	expiresAt: integer(),
 	email: text(),
+	accountId: text(),
 	createdAt: integer().notNull(),
 	baseUrl: text()
 });

--- a/apps/api/src/proxy/codex-chat-input.ts
+++ b/apps/api/src/proxy/codex-chat-input.ts
@@ -1,0 +1,421 @@
+import type { OpenAIMessage, OpenAIContentPart, OpenAIToolCall } from '../types/openai';
+
+function textFromContentPartField(v: unknown): string {
+	if (typeof v === 'string') {
+		return v;
+	}
+
+	if (typeof v === 'number' || typeof v === 'boolean') {
+		return String(v);
+	}
+
+	return '';
+}
+
+function convertContentPart(
+	part: OpenAIContentPart | string | Record<string, unknown>,
+	role: 'user' | 'assistant'
+): Record<string, unknown> | null {
+	if (typeof part === 'string') {
+		return {
+			type: role === 'assistant' ? 'output_text' : 'input_text',
+			text: part
+		};
+	}
+
+	if (!part || typeof part !== 'object') {
+		return null;
+	}
+
+	const p = part as Record<string, unknown>;
+	const partType = typeof p.type === 'string' ? p.type : '';
+
+	if (partType === 'text') {
+		return {
+			type: role === 'assistant' ? 'output_text' : 'input_text',
+			text: textFromContentPartField(p.text)
+		};
+	}
+
+	/** History from Cursor / Responses often uses native part types, not Chat `text`. */
+	if (partType === 'output_text' || partType === 'input_text') {
+		const text = textFromContentPartField(p.text);
+
+		return {
+			type: role === 'assistant' ? 'output_text' : 'input_text',
+			text
+		};
+	}
+
+	if (partType === 'image_url') {
+		const raw = p.image_url;
+		const url = typeof raw === 'string' ? raw : (raw as { url?: string } | undefined)?.url;
+
+		if (url) {
+			const block: Record<string, unknown> = { type: 'input_image', image_url: url };
+
+			if (typeof raw === 'object' && raw !== null && 'detail' in raw) {
+				const detail = (raw as { detail?: string }).detail;
+
+				if (detail !== undefined) {
+					block.detail = detail;
+				}
+			}
+
+			return block;
+		}
+
+		return null;
+	}
+
+	if (partType === 'input_audio' && p.input_audio && typeof p.input_audio === 'object') {
+		const audio = p.input_audio as { format?: string };
+
+		return {
+			type: role === 'assistant' ? 'output_text' : 'input_text',
+			text: `[Audio input: format=${audio?.format ?? 'unknown'}]`
+		};
+	}
+
+	if (partType === 'file' && p.file && typeof p.file === 'object') {
+		const file = p.file as { file_id?: string; filename?: string };
+		const block: Record<string, unknown> = { type: 'input_file' };
+
+		if (file.file_id !== undefined) {
+			block.file_id = file.file_id;
+		}
+
+		if (file.filename !== undefined) {
+			block.filename = file.filename;
+		}
+
+		return block;
+	}
+
+	return {
+		type: role === 'assistant' ? 'output_text' : 'input_text',
+		text: `[Unknown content type: ${JSON.stringify(part)}]`
+	};
+}
+
+function convertMessageContent(content: OpenAIMessage['content'], role: 'user' | 'assistant'): Record<string, unknown>[] {
+	if (content === null || content === undefined) {
+		return [];
+	}
+
+	if (typeof content === 'string') {
+		if (!content.trim()) {
+			return [];
+		}
+
+		return [
+			{
+				type: role === 'assistant' ? 'output_text' : 'input_text',
+				text: content
+			}
+		];
+	}
+
+	if (Array.isArray(content)) {
+		const parts: Record<string, unknown>[] = [];
+
+		for (const item of content) {
+			const converted = convertContentPart(item, role);
+
+			if (converted) {
+				parts.push(converted);
+			}
+		}
+
+		return parts;
+	}
+
+	return [
+		{
+			type: role === 'assistant' ? 'output_text' : 'input_text',
+			text: JSON.stringify(content)
+		}
+	];
+}
+
+function convertToolCallsToFunctionCalls(toolCalls: OpenAIToolCall[]): Record<string, unknown>[] {
+	const out: Record<string, unknown>[] = [];
+
+	for (const toolCall of toolCalls) {
+		const args = toolCall.function?.arguments ?? '{}';
+		const name = toolCall.function?.name ?? 'unknown';
+
+		out.push({
+			type: 'function_call',
+			name,
+			arguments: typeof args === 'string' ? args : JSON.stringify(args),
+			call_id: toolCall.id || `call_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`
+		});
+	}
+
+	return out;
+}
+
+function normalizeRoleForCodex(role: string | undefined): string {
+	if (!role) {
+		return '';
+	}
+
+	const r = role.trim().toLowerCase();
+
+	if (r === 'human') {
+		return 'user';
+	}
+
+	return r;
+}
+
+function convertSingleMessage(msg: OpenAIMessage): Record<string, unknown>[] {
+	const items: Record<string, unknown>[] = [];
+	const role = normalizeRoleForCodex(msg.role);
+
+	if (role === 'system') {
+		const contentParts = convertMessageContent(msg.content, 'user');
+
+		if (contentParts.length > 0) {
+			items.push({
+				type: 'message',
+				role: 'developer',
+				content: contentParts
+			});
+		}
+
+		return items;
+	}
+
+	if (role === 'developer') {
+		const contentParts = convertMessageContent(msg.content, 'user');
+
+		if (contentParts.length > 0) {
+			items.push({
+				type: 'message',
+				role: 'developer',
+				content: contentParts
+			});
+		}
+
+		return items;
+	}
+
+	if (role === 'user') {
+		const contentParts = convertMessageContent(msg.content, 'user');
+
+		if (contentParts.length > 0) {
+			items.push({
+				type: 'message',
+				role: 'user',
+				content: contentParts
+			});
+		}
+
+		return items;
+	}
+
+	if (role === 'assistant') {
+		const contentParts = convertMessageContent(msg.content, 'assistant');
+
+		if (contentParts.length > 0) {
+			items.push({
+				type: 'message',
+				role: 'assistant',
+				content: contentParts
+			});
+		}
+
+		if (msg.tool_calls && msg.tool_calls.length > 0) {
+			items.push(...convertToolCallsToFunctionCalls(msg.tool_calls));
+		}
+
+		return items;
+	}
+
+	if (role === 'tool') {
+		const callId = msg.tool_call_id;
+		const output = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? '');
+
+		if (callId) {
+			items.push({
+				type: 'function_call_output',
+				call_id: callId,
+				output
+			});
+		}
+
+		return items;
+	}
+
+	if (role === 'function') {
+		const callRef = msg.name ?? `func_${Date.now()}`;
+		const output = typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content ?? '');
+
+		items.push({
+			type: 'function_call_output',
+			call_id: callRef,
+			output
+		});
+
+		return items;
+	}
+
+	const fallbackContent = convertMessageContent(msg.content, 'user');
+
+	if (fallbackContent.length > 0) {
+		items.push({
+			type: 'message',
+			role: 'user',
+			content: fallbackContent
+		});
+	}
+
+	return items;
+}
+
+export function buildCodexInputFromOpenAIMessages(messages: OpenAIMessage[]): Record<string, unknown>[] {
+	const developerItems: Record<string, unknown>[] = [];
+	const mainItems: Record<string, unknown>[] = [];
+
+	for (const msg of messages) {
+		const converted = convertSingleMessage(msg);
+
+		for (const item of converted) {
+			if (item.type === 'message' && item.role === 'developer') {
+				developerItems.push(item);
+
+				continue;
+			}
+
+			mainItems.push(item);
+		}
+	}
+
+	return [...developerItems, ...mainItems];
+}
+
+/**
+ * Codex Responses input: assistant message content may only use output_text / refusal,
+ * not input_text (OpenAI chat-style parts often use input_text or text).
+ */
+export function normalizeCodexInputAssistantTextBlocks(input: Record<string, unknown>[]): Record<string, unknown>[] {
+	return input.map((item) => {
+		if (item.type !== 'message' || item.role !== 'assistant') {
+			return item;
+		}
+
+		const content = item.content;
+
+		if (!Array.isArray(content)) {
+			return item;
+		}
+
+		const newContent = content.map((part) => {
+			if (!part || typeof part !== 'object') {
+				return part;
+			}
+
+			const p = part as Record<string, unknown>;
+			const t = p.type;
+
+			if (t === 'input_text' || t === 'text') {
+				return { ...p, type: 'output_text' };
+			}
+
+			return part;
+		});
+
+		return { ...item, content: newContent };
+	});
+}
+
+/**
+ * Build Codex `input` from `body.input` when it mixes Responses items (`type: message` | …)
+ * and plain chat objects (`role` + `content` without `type`). A single array of only one style
+ * still works; previously a mix caused both parsers to return empty and history was dropped.
+ */
+export function expandBodyInputToCodexItems(input: unknown): Record<string, unknown>[] | null {
+	if (!Array.isArray(input) || input.length === 0) {
+		return null;
+	}
+
+	const developerItems: Record<string, unknown>[] = [];
+	const mainItems: Record<string, unknown>[] = [];
+
+	const pushItems = (converted: Record<string, unknown>[]) => {
+		for (const item of converted) {
+			if (item.type === 'message' && item.role === 'developer') {
+				developerItems.push(item);
+			} else {
+				mainItems.push(item);
+			}
+		}
+	};
+
+	for (const item of input) {
+		if (!item || typeof item !== 'object') {
+			return null;
+		}
+
+		const o = item as Record<string, unknown>;
+		const t = o.type;
+
+		if (t === 'function_call' || t === 'function_call_output' || t === 'custom_tool_call' || t === 'custom_tool_call_output') {
+			mainItems.push({ ...o });
+
+			continue;
+		}
+
+		if (t === 'message') {
+			pushItems([{ ...o }]);
+
+			continue;
+		}
+
+		if (typeof o.role === 'string' && (t === undefined || t === null)) {
+			pushItems(convertSingleMessage(item as OpenAIMessage));
+
+			continue;
+		}
+
+		return null;
+	}
+
+	return [...developerItems, ...mainItems];
+}
+
+export function coerceOpenAIMessagesFromRequestBody(body: { messages?: OpenAIMessage[]; input?: unknown }): OpenAIMessage[] {
+	const msgs = body.messages;
+
+	if (Array.isArray(msgs) && msgs.length > 0) {
+		return msgs;
+	}
+
+	const raw = body.input;
+
+	if (!Array.isArray(raw) || raw.length === 0) {
+		return [];
+	}
+
+	const allChatShape = raw.every((item) => {
+		if (!item || typeof item !== 'object') {
+			return false;
+		}
+
+		const o = item as Record<string, unknown>;
+
+		if (typeof o.role !== 'string') {
+			return false;
+		}
+
+		return o.type === undefined || o.type === null;
+	});
+
+	if (!allChatShape) {
+		return [];
+	}
+
+	return raw as OpenAIMessage[];
+}

--- a/apps/api/src/proxy/openai-client.ts
+++ b/apps/api/src/proxy/openai-client.ts
@@ -1,0 +1,204 @@
+import { logger } from 'src/utils/logger';
+
+import { config } from '../config';
+import { Settings } from '../database/app-settings';
+import { ProviderSettings } from '../database/provider-settings';
+
+import { buildChatGptResponsesBody, resolveChatGptModel } from './responses-input-normalizer';
+import { createResponsesStreamState, logResponsesStreamFinished, processResponsesChunk } from './responses-stream-mapper';
+
+import type { OpenAIChatRequest } from '../types/openai';
+import type { RequestContext } from '../types/proxy';
+
+/** Codex `/responses` requires non-empty `instructions` (api_error otherwise). */
+const CODEX_INSTRUCTIONS_FALLBACK =
+	'You are a coding assistant integrated with the user editor. Follow the conversation and use tools when appropriate.';
+
+const ENV_CHATGPT_INSTRUCTIONS = process.env.CHATGPT_INSTRUCTIONS?.trim();
+
+export async function proxyOpenAIRequest(body: OpenAIChatRequest): Promise<{ response: Response; context: RequestContext }> {
+	const startTime = Date.now();
+	const model = body.model;
+	const resolvedModel = resolveChatGptModel(model);
+	const normalizedModel = resolvedModel.model;
+
+	const creds = ProviderSettings.get('openai');
+	if (!creds?.accessToken) {
+		return {
+			response: new Response(
+				JSON.stringify({ error: { message: 'Not authenticated with OpenAI', type: 'authentication_error' } }),
+				{
+					status: 401,
+					headers: { 'Content-Type': 'application/json' }
+				}
+			),
+			context: { model, source: 'error', startTime, reverseToolMapping: {}, inputTokens: 0, outputTokens: 0 }
+		};
+	}
+
+	const accountId = creds.accountId;
+	if (!accountId) {
+		return {
+			response: new Response(
+				JSON.stringify({
+					error: { message: 'ChatGPT account id missing. Re-login to refresh your ChatGPT token.', type: 'authentication_error' }
+				}),
+				{
+					status: 401,
+					headers: { 'Content-Type': 'application/json' }
+				}
+			),
+			context: { model, source: 'error', startTime, reverseToolMapping: {}, inputTokens: 0, outputTokens: 0 }
+		};
+	}
+
+	const extraInstruction = Settings.get().extraInstruction;
+	const buildResult = buildChatGptResponsesBody(body, model, {
+		extraInstruction,
+		envInstructions: ENV_CHATGPT_INSTRUCTIONS,
+		instructionsFallback: CODEX_INSTRUCTIONS_FALLBACK
+	});
+	const requestBody = buildResult.payload;
+	const incomingToolCount = Array.isArray(body.tools) ? body.tools.length : 0;
+
+	logger.log(
+		`[Codex] upstreamModel=${model} chatMessages=${buildResult.debug.chatMessages} inputField=${buildResult.debug.inputField} codexItems=${buildResult.debug.codexItems} fromBodyInput=${buildResult.debug.fromBodyInput}`
+	);
+
+	logger.log(`OpenAI Codex proxy: ${model} → ${normalizedModel} tools=${incomingToolCount} stream=${body.stream ?? false}`);
+
+	const response = await fetch(`${config.openai.codexUrl}/responses`, {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/json',
+			authorization: `Bearer ${creds.accessToken}`,
+			'chatgpt-account-id': accountId,
+			originator: 'codex_cli_rs',
+			accept: 'text/event-stream'
+		},
+		body: JSON.stringify(requestBody)
+	});
+
+	if (!response.ok) {
+		const errorText = await response.text();
+		logger.error('ChatGPT Codex upstream error:', response.status, errorText);
+
+		let errorMessage = `ChatGPT API error (${response.status})`;
+
+		try {
+			const errBody = JSON.parse(errorText) as {
+				error?: { message?: string };
+				message?: string;
+				detail?: string;
+			};
+
+			if (errBody.error?.message) {
+				errorMessage = errBody.error.message;
+			} else if (errBody.message) {
+				errorMessage = errBody.message;
+			} else if (errBody.detail) {
+				errorMessage = errBody.detail;
+			}
+		} catch {
+			if (errorText.trim()) {
+				errorMessage = `${errorMessage}: ${errorText.slice(0, 500)}`;
+			}
+		}
+
+		return {
+			response: new Response(JSON.stringify({ error: { message: errorMessage, type: 'api_error' } }), {
+				status: response.status,
+				headers: { 'Content-Type': 'application/json' }
+			}),
+			context: { model, source: 'error', startTime, reverseToolMapping: {}, inputTokens: 0, outputTokens: 0 }
+		};
+	}
+
+	const stream = body.stream ?? false;
+	const state = createResponsesStreamState(normalizedModel);
+
+	if (stream) {
+		const reader = response.body!.getReader();
+		const decoder = new TextDecoder();
+
+		const streamBody = new ReadableStream({
+			async start(controller) {
+				while (true) {
+					const { done, value } = await reader.read();
+					if (done) break;
+					const text = decoder.decode(value, { stream: true });
+					const results = processResponsesChunk(state, text);
+					for (const result of results) {
+						if (result.type === 'chunk') {
+							controller.enqueue(`data: ${JSON.stringify(result.data)}\n\n`);
+						} else if (result.type === 'done') {
+							controller.enqueue('data: [DONE]\n\n');
+						}
+					}
+				}
+				reader.releaseLock();
+				logResponsesStreamFinished(state, 'stream');
+				controller.close();
+			}
+		});
+
+		return {
+			response: new Response(streamBody, {
+				status: 200,
+				headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache', connection: 'keep-alive' }
+			}),
+			context: { model, source: 'openai', startTime, reverseToolMapping: {}, inputTokens: 0, outputTokens: 0 }
+		};
+	}
+
+	// Non-streaming
+	let fullContent = '';
+	const reader = response.body!.getReader();
+	const decoder = new TextDecoder();
+	while (true) {
+		const { done, value } = await reader.read();
+		if (done) break;
+		const text = decoder.decode(value, { stream: true });
+		const results = processResponsesChunk(state, text);
+
+		for (const result of results) {
+			const chunkData = result.data as
+				| {
+						choices?: {
+							delta?: {
+								content?: string | null;
+							};
+						}[];
+				  }
+				| undefined;
+
+			if (result.type === 'chunk' && chunkData?.choices?.[0]?.delta) {
+				const delta = chunkData.choices[0].delta;
+				if (typeof delta.content === 'string') {
+					fullContent += delta.content;
+				}
+			}
+		}
+	}
+	reader.releaseLock();
+
+	logResponsesStreamFinished(state, 'buffer');
+
+	return {
+		response: new Response(
+			JSON.stringify({
+				id: state.id,
+				object: 'chat.completion',
+				created: state.created,
+				model: normalizedModel,
+				choices: [{ index: 0, message: { role: 'assistant', content: fullContent || null }, finish_reason: 'stop' }],
+				usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 }
+			}),
+			{
+				status: 200,
+				headers: { 'Content-Type': 'application/json' }
+			}
+		),
+		context: { model, source: 'openai', startTime, reverseToolMapping: {}, inputTokens: 0, outputTokens: 0 }
+	};
+}

--- a/apps/api/src/proxy/proxy-client.ts
+++ b/apps/api/src/proxy/proxy-client.ts
@@ -2,6 +2,7 @@ import { openaiToAnthropic } from '../adapter/openai-to-anthropic';
 
 import { proxyRequest as proxyAnthropicRequest } from './anthropic-client';
 import { proxyMiniMaxRequest } from './minimax-client';
+import { proxyOpenAIRequest as proxyCodexRequest } from './openai-client';
 
 import type { AIProviderName } from '../auth/base-provider';
 import type { AnthropicRequest } from '../types';
@@ -31,11 +32,16 @@ export async function proxyRequest(
 }
 
 export async function proxyOpenAIRequest(
-	openaiBody: OpenAIChatRequest
+	openaiBody: OpenAIChatRequest,
+	provider?: AIProviderName
 ): Promise<{ response: Response; context: RequestContext }> {
-	const provider = detectProvider(openaiBody.model);
+	const resolved = provider ?? detectProvider(openaiBody.model);
 
-	if (provider === 'minimax') {
+	if (resolved === 'openai') {
+		return proxyCodexRequest(openaiBody);
+	}
+
+	if (resolved === 'minimax') {
 		return proxyMiniMaxRequest(openaiBody) as unknown as { response: Response; context: RequestContext };
 	}
 

--- a/apps/api/src/proxy/responses-input-normalizer.ts
+++ b/apps/api/src/proxy/responses-input-normalizer.ts
@@ -1,0 +1,491 @@
+import {
+	buildCodexInputFromOpenAIMessages,
+	coerceOpenAIMessagesFromRequestBody,
+	expandBodyInputToCodexItems,
+	normalizeCodexInputAssistantTextBlocks
+} from './codex-chat-input';
+
+import type { OpenAIChatRequest, OpenAIMessage } from '../types/openai';
+
+export type CodexReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+
+export interface ResolvedChatGptModel {
+	model: string;
+	reasoningEffort?: CodexReasoningEffort;
+}
+
+export interface BuildResponsesBodyOptions {
+	extraInstruction?: string;
+	envInstructions?: string;
+	instructionsFallback: string;
+}
+
+export interface BuildResponsesBodyResult {
+	payload: Record<string, unknown>;
+	debug: {
+		chatMessages: number;
+		inputField: number;
+		codexItems: number;
+		fromBodyInput: boolean;
+	};
+}
+
+export function resolveChatGptModel(model: string): ResolvedChatGptModel {
+	if (!model) {
+		return { model: 'gpt-5.4' };
+	}
+
+	const effortLevels: CodexReasoningEffort[] = ['none', 'low', 'medium', 'high', 'xhigh'];
+
+	for (const effort of effortLevels) {
+		if (model.endsWith(`-${effort}`)) {
+			return {
+				model: model.slice(0, -`-${effort}`.length),
+				reasoningEffort: effort
+			};
+		}
+	}
+
+	if (model === 'gpt-5.4' || model === 'gpt-5.4-mini') {
+		return { model };
+	}
+
+	if (model === 'gpt-5.3-codex') {
+		return { model, reasoningEffort: 'medium' };
+	}
+
+	if (model === 'gpt-5.1-codex-mini') {
+		return { model, reasoningEffort: 'medium' };
+	}
+
+	if (model.includes('codex')) {
+		return { model };
+	}
+
+	if (model.startsWith('gpt-5.4')) {
+		return { model: 'gpt-5.4' };
+	}
+
+	if (model.startsWith('gpt-5.3')) {
+		return { model: 'gpt-5.3-codex', reasoningEffort: 'medium' };
+	}
+
+	if (model.startsWith('gpt-5.1')) {
+		return { model: 'gpt-5.1-codex-mini', reasoningEffort: 'medium' };
+	}
+
+	return { model: 'gpt-5.4' };
+}
+
+function normalizeMessageRole(role: string | undefined): string {
+	if (!role) {
+		return '';
+	}
+
+	const r = role.trim().toLowerCase();
+
+	if (r === 'human') {
+		return 'user';
+	}
+
+	return r;
+}
+
+function flattenOpenAIUserContentToText(content: OpenAIMessage['content']): string | null {
+	if (content === null || content === undefined) {
+		return null;
+	}
+
+	if (typeof content === 'string') {
+		const t = content.trim();
+
+		if (t.length > 0) {
+			return t;
+		}
+
+		return null;
+	}
+
+	if (Array.isArray(content)) {
+		const parts: string[] = [];
+		let sawImage = false;
+
+		for (const block of content) {
+			if (!block || typeof block !== 'object') {
+				continue;
+			}
+
+			const b = block as unknown as Record<string, unknown>;
+			const partType = typeof b.type === 'string' ? b.type : '';
+
+			if (partType === 'image_url' || partType === 'input_image') {
+				sawImage = true;
+
+				continue;
+			}
+
+			if ((partType === 'text' || partType === 'input_text') && typeof b.text === 'string' && b.text.trim()) {
+				parts.push(b.text.trim());
+
+				continue;
+			}
+
+			if (typeof b.text === 'string' && b.text.trim()) {
+				parts.push(b.text.trim());
+			}
+		}
+
+		if (parts.length > 0) {
+			return parts.join('\n');
+		}
+
+		if (sawImage) {
+			return null;
+		}
+
+		if (content.length > 0) {
+			return JSON.stringify(content);
+		}
+
+		return null;
+	}
+
+	const obj = content as unknown as Record<string, unknown>;
+
+	if (typeof obj.text === 'string' && obj.text.trim()) {
+		return obj.text.trim();
+	}
+
+	return null;
+}
+
+function codexPromptHasActionableUserContent(items: Record<string, unknown>[]): boolean {
+	for (const item of items) {
+		if (item.type === 'function_call' || item.type === 'function_call_output') {
+			return true;
+		}
+
+		if (item.type !== 'message' || item.role !== 'user') {
+			continue;
+		}
+
+		const parts = item.content as Record<string, unknown>[] | undefined;
+
+		if (!Array.isArray(parts)) {
+			continue;
+		}
+
+		for (const p of parts) {
+			if (!p || typeof p !== 'object') {
+				continue;
+			}
+
+			if (p.type === 'input_image') {
+				return true;
+			}
+
+			if (p.type === 'input_text' && typeof p.text === 'string' && p.text.trim().length > 0) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+function extractLastUserMessageText(messages: OpenAIMessage[]): string | null {
+	for (let i = messages.length - 1; i >= 0; i--) {
+		const msg = messages[i];
+
+		if (normalizeMessageRole(msg.role) !== 'user') {
+			continue;
+		}
+
+		const text = flattenOpenAIUserContentToText(msg.content);
+
+		if (text) {
+			return text;
+		}
+	}
+
+	return null;
+}
+
+function patchLastEmptyUserFromRaw(input: Record<string, unknown>[], messages: OpenAIMessage[]): Record<string, unknown>[] {
+	const latestText = extractLastUserMessageText(messages);
+
+	if (!latestText) {
+		return input;
+	}
+
+	let lastUserIdx = -1;
+
+	for (let i = input.length - 1; i >= 0; i--) {
+		const it = input[i];
+
+		if (it.type === 'message' && it.role === 'user') {
+			lastUserIdx = i;
+
+			break;
+		}
+	}
+
+	if (lastUserIdx < 0) {
+		return [
+			...input,
+			{
+				type: 'message',
+				role: 'user',
+				content: [{ type: 'input_text', text: latestText }]
+			}
+		];
+	}
+
+	const userItem = input[lastUserIdx];
+	const parts = (userItem.content as Record<string, unknown>[] | undefined) ?? [];
+
+	const hasUserPayload = parts.some((p) => {
+		if (!p || typeof p !== 'object') {
+			return false;
+		}
+
+		if (p.type === 'input_image') {
+			return true;
+		}
+
+		if (p.type === 'input_text' && typeof p.text === 'string' && p.text.trim().length > 0) {
+			return true;
+		}
+
+		return false;
+	});
+
+	if (hasUserPayload) {
+		return input;
+	}
+
+	const out = [...input];
+
+	out[lastUserIdx] = {
+		...userItem,
+		content: [{ type: 'input_text', text: latestText }]
+	};
+
+	return out;
+}
+
+function extractFallbackUserText(messages: OpenAIMessage[]): string {
+	const chunks: string[] = [];
+
+	for (const msg of messages) {
+		const role = normalizeMessageRole(msg.role);
+
+		if (role === 'system' || role === 'developer') {
+			continue;
+		}
+
+		if (typeof msg.content === 'string' && msg.content.trim()) {
+			chunks.push(msg.content.trim());
+
+			continue;
+		}
+
+		if (Array.isArray(msg.content)) {
+			const chunkCountBefore = chunks.length;
+
+			for (const block of msg.content) {
+				if (!block || typeof block !== 'object') {
+					continue;
+				}
+
+				const b = block as unknown as Record<string, unknown>;
+				const partType = typeof b.type === 'string' ? b.type : '';
+
+				if ((partType === 'text' || partType === 'input_text') && typeof b.text === 'string' && b.text.trim()) {
+					chunks.push(b.text.trim());
+
+					continue;
+				}
+
+				if (typeof b.text === 'string' && b.text.trim()) {
+					chunks.push(b.text.trim());
+				}
+			}
+
+			if (chunks.length === chunkCountBefore && msg.content.length > 0) {
+				chunks.push(JSON.stringify(msg.content));
+			}
+		}
+	}
+
+	if (chunks.length === 0) {
+		return '.';
+	}
+
+	return chunks.join('\n\n');
+}
+
+function mapToolChoiceToCodex(
+	toolChoice: OpenAIChatRequest['tool_choice'] | undefined,
+	hasTools: boolean
+): string | Record<string, unknown> | undefined {
+	if (!hasTools) {
+		return undefined;
+	}
+
+	if (toolChoice === undefined || toolChoice === null) {
+		return 'auto';
+	}
+
+	if (typeof toolChoice === 'string') {
+		return toolChoice;
+	}
+
+	const tc = toolChoice as {
+		type?: string;
+		function?: { name?: string };
+		name?: string;
+	};
+
+	if (tc.type === 'function') {
+		if (tc.function?.name) {
+			return {
+				type: 'function',
+				name: tc.function.name
+			};
+		}
+
+		if (tc.name) {
+			return {
+				type: 'function',
+				name: tc.name
+			};
+		}
+	}
+
+	const passthrough: Record<string, unknown> = { ...tc };
+
+	return passthrough;
+}
+
+function filterOrphanFunctionCallOutputs(input: Record<string, unknown>[]): Record<string, unknown>[] {
+	const knownCallIds = new Set<string>();
+
+	for (const item of input) {
+		if (
+			(item.type === 'function_call' || item.type === 'custom_tool_call') &&
+			typeof item.call_id === 'string' &&
+			item.call_id.length > 0
+		) {
+			knownCallIds.add(item.call_id);
+		}
+	}
+
+	return input.filter((item) => {
+		if ((item.type === 'function_call_output' || item.type === 'custom_tool_call_output') && typeof item.call_id === 'string') {
+			return knownCallIds.has(item.call_id);
+		}
+
+		return true;
+	});
+}
+
+export function buildChatGptResponsesBody(
+	body: OpenAIChatRequest,
+	requestedModel: string,
+	options: BuildResponsesBodyOptions
+): BuildResponsesBodyResult {
+	const messages = coerceOpenAIMessagesFromRequestBody(body);
+	const resolvedModel = resolveChatGptModel(requestedModel);
+	const explicitReasoning = body.reasoning as { effort?: CodexReasoningEffort } | undefined;
+	const reasoningEffort = explicitReasoning?.effort ?? body.reasoning_effort ?? resolvedModel.reasoningEffort;
+
+	const expandedInput = expandBodyInputToCodexItems(body.input);
+
+	let input: Record<string, unknown>[];
+
+	if (expandedInput) {
+		input = expandedInput;
+	} else {
+		input = buildCodexInputFromOpenAIMessages(messages);
+	}
+
+	const usedExpandedInput = expandedInput !== null;
+	let finalInput = filterOrphanFunctionCallOutputs(input);
+
+	if (!usedExpandedInput) {
+		finalInput = patchLastEmptyUserFromRaw(finalInput, messages);
+	}
+
+	if (!codexPromptHasActionableUserContent(finalInput)) {
+		const fallbackText = extractFallbackUserText(messages);
+
+		if (finalInput.length === 0) {
+			finalInput = [
+				{
+					type: 'message',
+					role: 'user',
+					content: [{ type: 'input_text', text: fallbackText }]
+				}
+			];
+		} else {
+			finalInput = [
+				...finalInput,
+				{
+					type: 'message',
+					role: 'user',
+					content: [{ type: 'input_text', text: fallbackText }]
+				}
+			];
+		}
+	}
+
+	if (finalInput.length === 0) {
+		finalInput = [
+			{
+				type: 'message',
+				role: 'user',
+				content: [{ type: 'input_text', text: 'Hello.' }]
+			}
+		];
+	}
+
+	finalInput = normalizeCodexInputAssistantTextBlocks(finalInput);
+
+	const rawTools = Array.isArray(body.tools) ? body.tools : [];
+	const hasTools = rawTools.length > 0;
+
+	const payload: Record<string, unknown> = {
+		model: resolvedModel.model,
+		input: finalInput,
+		stream: true,
+		store: false
+	};
+
+	if (options.extraInstruction?.trim()) {
+		payload.instructions = options.extraInstruction.trim();
+	} else if (options.envInstructions?.trim()) {
+		payload.instructions = options.envInstructions.trim();
+	} else {
+		payload.instructions = options.instructionsFallback;
+	}
+
+	if (reasoningEffort) {
+		payload.reasoning = { effort: reasoningEffort };
+	}
+
+	if (hasTools) {
+		payload.tools = rawTools;
+		payload.tool_choice = mapToolChoiceToCodex(body.tool_choice, true) ?? 'auto';
+		payload.parallel_tool_calls = false;
+	}
+
+	const debug = {
+		chatMessages: messages.length,
+		inputField: Array.isArray(body.input) ? body.input.length : 0,
+		codexItems: input.length,
+		fromBodyInput: usedExpandedInput
+	};
+
+	return { payload, debug };
+}

--- a/apps/api/src/proxy/responses-stream-mapper.ts
+++ b/apps/api/src/proxy/responses-stream-mapper.ts
@@ -1,0 +1,564 @@
+import { logger } from 'src/utils/logger';
+
+const TOOL_ARGS_STREAM_CHUNK = 96;
+
+interface PendingFunctionCallState {
+	callId: string;
+	openAiIndex: number;
+	argsBuffer: string;
+	deferred: boolean;
+}
+
+interface StreamState {
+	buffer: string;
+	id: string;
+	model: string;
+	created: number;
+	roleSent: boolean;
+	sawTextDelta: boolean;
+	toolCallsSeen: boolean;
+	toolCallIndex: number;
+	processedItemIds: Set<string>;
+	pendingFunctionCalls: Map<number, PendingFunctionCallState>;
+	sseKindCounts: Map<string, number>;
+	outputItemTypeAdded: Map<string, number>;
+	outputItemTypeDone: Map<string, number>;
+}
+
+export interface StreamProcessResult {
+	type: 'chunk' | 'done';
+	data?: Record<string, unknown>;
+}
+
+function readNumericOutputIndex(payload: Record<string, unknown>): number | undefined {
+	for (const key of ['output_index', 'item_index'] as const) {
+		const v = payload[key];
+
+		if (typeof v === 'number' && Number.isFinite(v)) {
+			return v;
+		}
+
+		if (typeof v === 'string' && /^\d+$/.test(v)) {
+			return parseInt(v, 10);
+		}
+	}
+
+	return undefined;
+}
+
+function extractCodexStreamToolItemName(item: Record<string, unknown>): string {
+	if (typeof item.name === 'string' && item.name.trim().length > 0) {
+		return item.name.trim();
+	}
+
+	const custom = item.custom;
+
+	if (custom && typeof custom === 'object') {
+		const nm = (custom as Record<string, unknown>).name;
+
+		if (typeof nm === 'string' && nm.trim().length > 0) {
+			return nm.trim();
+		}
+	}
+
+	return '';
+}
+
+function toolArgumentsStringFromItem(item: Record<string, unknown>): string {
+	if (item.arguments != null) {
+		return typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments);
+	}
+
+	if (item.input != null) {
+		return typeof item.input === 'string' ? item.input : JSON.stringify(item.input);
+	}
+
+	return '';
+}
+
+function createChunk(
+	state: StreamState,
+	delta: Record<string, unknown>,
+	finishReason: string | null,
+	usage?: Record<string, number>
+): Record<string, unknown> {
+	const chunk: Record<string, unknown> = {
+		id: state.id,
+		object: 'chat.completion.chunk',
+		created: state.created,
+		model: state.model,
+		choices: [{ index: 0, delta, finish_reason: finishReason }]
+	};
+
+	if (usage) {
+		chunk.usage = usage;
+	}
+
+	return chunk;
+}
+
+function coalesceResponsesTextDelta(payload: Record<string, unknown>): string | null {
+	const d = payload.delta;
+
+	if (typeof d === 'string' && d.length > 0) {
+		return d;
+	}
+
+	if (d && typeof d === 'object') {
+		const text = (d as Record<string, unknown>).text;
+
+		if (typeof text === 'string' && text.length > 0) {
+			return text;
+		}
+	}
+
+	return null;
+}
+
+function extractAssistantTextFromResponseOutput(resp: Record<string, unknown> | undefined): string | null {
+	if (!resp) {
+		return null;
+	}
+
+	const output = resp.output;
+
+	if (!Array.isArray(output)) {
+		return null;
+	}
+
+	const parts: string[] = [];
+
+	for (const item of output) {
+		if (!item || typeof item !== 'object') {
+			continue;
+		}
+
+		const rec = item as Record<string, unknown>;
+
+		if (rec.type !== 'message' || rec.role !== 'assistant') {
+			continue;
+		}
+
+		const content = rec.content;
+
+		if (!Array.isArray(content)) {
+			continue;
+		}
+
+		for (const block of content) {
+			if (!block || typeof block !== 'object') {
+				continue;
+			}
+
+			const b = block as Record<string, unknown>;
+
+			if (b.type === 'output_text' && typeof b.text === 'string') {
+				parts.push(b.text);
+			}
+		}
+	}
+
+	const joined = parts.join('');
+
+	if (joined.length === 0) {
+		return null;
+	}
+
+	return joined;
+}
+
+function emitOpenAIToolCallStreamChunks(state: StreamState, item: Record<string, unknown>, results: StreamProcessResult[]): void {
+	state.toolCallsSeen = true;
+	const toolCallId =
+		(typeof item.call_id === 'string' && item.call_id) ||
+		(typeof item.id === 'string' && item.id) ||
+		`call_${state.toolCallIndex}`;
+	const argsStr = toolArgumentsStringFromItem(item);
+	const index = state.toolCallIndex;
+	state.toolCallIndex += 1;
+	const name = extractCodexStreamToolItemName(item) || 'unknown';
+
+	const firstDelta: Record<string, unknown> = {
+		tool_calls: [
+			{
+				index,
+				id: toolCallId,
+				type: 'function',
+				function: { name, arguments: '' }
+			}
+		]
+	};
+
+	if (!state.roleSent) {
+		firstDelta.role = 'assistant';
+		state.roleSent = true;
+	}
+
+	results.push({ type: 'chunk', data: createChunk(state, firstDelta, null) });
+
+	const argChunks = argsStr.length > 0 ? Math.ceil(argsStr.length / TOOL_ARGS_STREAM_CHUNK) : 0;
+	void argChunks;
+
+	for (let i = 0; i < argsStr.length; i += TOOL_ARGS_STREAM_CHUNK) {
+		const frag = argsStr.slice(i, i + TOOL_ARGS_STREAM_CHUNK);
+
+		results.push({
+			type: 'chunk',
+			data: createChunk(state, { tool_calls: [{ index, function: { arguments: frag } }] }, null)
+		});
+	}
+}
+
+function bumpOutputItemType(map: Map<string, number>, item: Record<string, unknown>): void {
+	const t = typeof item.type === 'string' && item.type.length > 0 ? item.type : '?';
+	map.set(t, (map.get(t) ?? 0) + 1);
+}
+
+function noteCodexSseKind(state: StreamState, kind: string | undefined): void {
+	const k = kind ?? '(no-type)';
+	state.sseKindCounts.set(k, (state.sseKindCounts.get(k) ?? 0) + 1);
+}
+
+export function createResponsesStreamState(model: string): StreamState {
+	return {
+		buffer: '',
+		id: `chatcmpl-${Date.now().toString(36)}`,
+		model,
+		created: Math.floor(Date.now() / 1000),
+		roleSent: false,
+		sawTextDelta: false,
+		toolCallsSeen: false,
+		toolCallIndex: 0,
+		processedItemIds: new Set(),
+		pendingFunctionCalls: new Map(),
+		sseKindCounts: new Map(),
+		outputItemTypeAdded: new Map(),
+		outputItemTypeDone: new Map()
+	};
+}
+
+export function processResponsesChunk(state: StreamState, chunk: string): StreamProcessResult[] {
+	state.buffer += chunk;
+	const results: StreamProcessResult[] = [];
+	const parts = state.buffer.split('\n\n');
+	state.buffer = parts.pop() ?? '';
+
+	for (const part of parts) {
+		const lines = part.split('\n');
+
+		for (const line of lines) {
+			if (!line.startsWith('data:')) {
+				continue;
+			}
+
+			const data = line.slice(5).trim();
+
+			if (!data || data === '[DONE]') {
+				continue;
+			}
+
+			let payload: Record<string, unknown>;
+
+			try {
+				payload = JSON.parse(data);
+			} catch {
+				continue;
+			}
+
+			const kind = payload?.type as string | undefined;
+			noteCodexSseKind(state, kind);
+
+			if (kind === 'response.created' && (payload.response as Record<string, unknown>)?.id) {
+				state.id = `chatcmpl-${String((payload.response as Record<string, unknown>).id).replace(/^resp_/, '')}`;
+				continue;
+			}
+
+			if (kind === 'response.output_item.added' && payload.item && typeof payload.item === 'object') {
+				const addedItem = payload.item as Record<string, unknown>;
+				bumpOutputItemType(state.outputItemTypeAdded, addedItem);
+
+				if (addedItem.type === 'function_call' || addedItem.type === 'custom_tool_call') {
+					const outputIndex = readNumericOutputIndex(payload) ?? state.toolCallIndex;
+					const nameRaw = extractCodexStreamToolItemName(addedItem);
+					const callId =
+						(typeof addedItem.call_id === 'string' && addedItem.call_id) ||
+						(typeof addedItem.id === 'string' && addedItem.id) ||
+						`call_${Date.now()}_${outputIndex}`;
+
+					state.pendingFunctionCalls.set(outputIndex, {
+						callId,
+						openAiIndex: outputIndex,
+						argsBuffer: '',
+						deferred: !nameRaw
+					});
+					state.toolCallsSeen = true;
+
+					if (nameRaw) {
+						const delta: Record<string, unknown> = {
+							tool_calls: [
+								{
+									index: outputIndex,
+									id: callId,
+									type: 'function',
+									function: { name: nameRaw, arguments: '' }
+								}
+							]
+						};
+
+						if (!state.roleSent) {
+							delta.role = 'assistant';
+							state.roleSent = true;
+						}
+
+						results.push({ type: 'chunk', data: createChunk(state, delta, null) });
+					}
+				}
+
+				continue;
+			}
+
+			if (kind === 'response.function_call_arguments.delta' || kind === 'response.custom_tool_call_input.delta') {
+				const outIdx = readNumericOutputIndex(payload);
+
+				if (outIdx === undefined) {
+					logger.warn(`[Codex tool] ${kind} missing output_index/item_index keys=`, Object.keys(payload).join(','));
+					continue;
+				}
+
+				const rawArgDelta = payload.delta;
+				let deltaStr = '';
+
+				if (typeof rawArgDelta === 'string') {
+					deltaStr = rawArgDelta;
+				} else if (typeof rawArgDelta === 'number' || typeof rawArgDelta === 'boolean') {
+					deltaStr = String(rawArgDelta);
+				} else if (rawArgDelta != null && typeof rawArgDelta === 'object') {
+					const o = rawArgDelta as Record<string, unknown>;
+					const nested = o.text ?? o.input ?? o.delta;
+
+					if (typeof nested === 'string') {
+						deltaStr = nested;
+					}
+				}
+
+				if (!deltaStr) {
+					continue;
+				}
+
+				const pending = state.pendingFunctionCalls.get(outIdx);
+
+				if (!pending) {
+					logger.warn(`[Codex tool] arguments.delta outIdx=${outIdx} but no matching output_item.added (index mismatch?)`);
+					continue;
+				}
+
+				pending.argsBuffer += deltaStr;
+
+				if (pending.deferred) {
+					continue;
+				}
+
+				const argDelta: Record<string, unknown> = {
+					tool_calls: [{ index: pending.openAiIndex, function: { arguments: deltaStr } }]
+				};
+
+				if (!state.roleSent) {
+					argDelta.role = 'assistant';
+					state.roleSent = true;
+				}
+
+				results.push({ type: 'chunk', data: createChunk(state, argDelta, null) });
+
+				continue;
+			}
+
+			if (kind === 'response.output_text.delta') {
+				const text = coalesceResponsesTextDelta(payload);
+
+				if (text) {
+					const delta: Record<string, unknown> = { content: text };
+
+					if (!state.roleSent) {
+						delta.role = 'assistant';
+						state.roleSent = true;
+					}
+
+					state.sawTextDelta = true;
+					results.push({ type: 'chunk', data: createChunk(state, delta, null) });
+				}
+
+				continue;
+			}
+
+			if (kind === 'response.output_text.done' && typeof payload.text === 'string' && payload.text.length > 0) {
+				if (!state.sawTextDelta) {
+					const delta: Record<string, unknown> = { content: payload.text };
+
+					if (!state.roleSent) {
+						delta.role = 'assistant';
+						state.roleSent = true;
+					}
+
+					state.sawTextDelta = true;
+					results.push({ type: 'chunk', data: createChunk(state, delta, null) });
+				}
+
+				continue;
+			}
+
+			if (kind === 'response.output_item.done' && payload.item && typeof payload.item === 'object') {
+				const item = payload.item as Record<string, unknown>;
+				bumpOutputItemType(state.outputItemTypeDone, item);
+				const itemId =
+					(typeof item.id === 'string' && item.id) ||
+					(typeof item.call_id === 'string' && item.call_id) ||
+					`${String(item.type)}_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+
+				if (state.processedItemIds.has(itemId)) {
+					continue;
+				}
+
+				state.processedItemIds.add(itemId);
+
+				if (item.type === 'message' && item.role === 'assistant' && !state.sawTextDelta) {
+					const blocks = Array.isArray(item.content) ? item.content : [];
+					const textParts: string[] = [];
+
+					for (const b of blocks) {
+						if (!b || typeof b !== 'object') {
+							continue;
+						}
+
+						const block = b as Record<string, unknown>;
+
+						if (block.type === 'output_text' && typeof block.text === 'string') {
+							textParts.push(block.text);
+						}
+					}
+
+					const text = textParts.join('');
+
+					if (text) {
+						const delta: Record<string, unknown> = { content: text };
+
+						if (!state.roleSent) {
+							delta.role = 'assistant';
+							state.roleSent = true;
+						}
+
+						state.sawTextDelta = true;
+						results.push({ type: 'chunk', data: createChunk(state, delta, null) });
+					}
+				} else if (item.type === 'function_call' || item.type === 'custom_tool_call') {
+					const outputIndex = readNumericOutputIndex(payload) ?? state.toolCallIndex;
+					const pending = state.pendingFunctionCalls.get(outputIndex);
+					const callId =
+						(typeof item.call_id === 'string' && item.call_id.length > 0 && item.call_id) ||
+						(typeof item.id === 'string' && item.id.length > 0 && item.id) ||
+						(pending?.callId ?? `call_${state.toolCallIndex}`);
+					const doneName = extractCodexStreamToolItemName(item);
+					const argsStr = toolArgumentsStringFromItem(item);
+
+					if (pending) {
+						state.pendingFunctionCalls.delete(outputIndex);
+						state.toolCallsSeen = true;
+						const openIdx = pending.openAiIndex;
+						const buffered = pending.argsBuffer;
+
+						if (pending.deferred) {
+							const fnName = doneName || 'unknown';
+							const combinedArgs = argsStr || buffered;
+							const fcDelta: Record<string, unknown> = {
+								tool_calls: [
+									{
+										index: openIdx,
+										id: callId,
+										type: 'function',
+										function: { name: fnName, arguments: combinedArgs }
+									}
+								]
+							};
+
+							if (!state.roleSent) {
+								fcDelta.role = 'assistant';
+								state.roleSent = true;
+							}
+
+							results.push({ type: 'chunk', data: createChunk(state, fcDelta, null) });
+							state.toolCallIndex = Math.max(state.toolCallIndex, openIdx + 1);
+						} else {
+							state.toolCallIndex = Math.max(state.toolCallIndex, openIdx + 1);
+
+							if (argsStr.length > 0 && buffered.length === 0) {
+								results.push({
+									type: 'chunk',
+									data: createChunk(
+										state,
+										{
+											tool_calls: [{ index: openIdx, function: { arguments: argsStr } }]
+										},
+										null
+									)
+								});
+							}
+						}
+					} else {
+						emitOpenAIToolCallStreamChunks(state, item, results);
+					}
+				}
+
+				continue;
+			}
+
+			if (kind === 'response.completed') {
+				const resp = payload.response as Record<string, unknown> | undefined;
+
+				if (!state.sawTextDelta && !state.toolCallsSeen) {
+					const fallbackText = extractAssistantTextFromResponseOutput(resp);
+
+					if (fallbackText) {
+						const delta: Record<string, unknown> = { content: fallbackText };
+
+						if (!state.roleSent) {
+							delta.role = 'assistant';
+							state.roleSent = true;
+						}
+
+						state.sawTextDelta = true;
+						results.push({ type: 'chunk', data: createChunk(state, delta, null) });
+					}
+				}
+
+				const usage = resp?.usage as Record<string, number> | undefined;
+				const finish = state.toolCallsSeen ? 'tool_calls' : 'stop';
+				const mappedUsage = usage
+					? {
+							prompt_tokens: usage.input_tokens ?? usage.prompt_tokens ?? 0,
+							completion_tokens: usage.output_tokens ?? usage.completion_tokens ?? 0,
+							total_tokens: usage.total_tokens ?? 0
+						}
+					: undefined;
+
+				results.push({ type: 'chunk', data: createChunk(state, {}, finish, mappedUsage) });
+				results.push({ type: 'done' });
+			}
+		}
+	}
+
+	return results;
+}
+
+export function logResponsesStreamFinished(state: StreamState, how: 'stream' | 'buffer'): void {
+	const entries = [...state.sseKindCounts.entries()].sort((a, b) => b[1] - a[1]);
+	const top = entries
+		.slice(0, 24)
+		.map(([t, n]) => `${t}:${n}`)
+		.join(' ');
+	const summary = top.length > 900 ? `${top.slice(0, 900)}…` : top;
+	const addedTypes = [...state.outputItemTypeAdded.entries()].map(([t, n]) => `${t}:${n}`).join(',');
+	const doneTypes = [...state.outputItemTypeDone.entries()].map(([t, n]) => `${t}:${n}`).join(',');
+
+	logger.log(
+		`[Codex stream] ${how} done toolCallsSeen=${state.toolCallsSeen} toolCallIndex=${state.toolCallIndex} text=${state.sawTextDelta} kinds=${state.sseKindCounts.size} output_item.added[${addedTypes || '-'}] output_item.done[${doneTypes || '-'}] ${summary || 'NO_SSE_PARSED'}`
+	);
+}

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,4 +1,5 @@
 import { OAuth } from '../auth/oauth';
+import { OpenAIOAuth } from '../auth/openai-oauth';
 import { config } from '../config';
 import { ProviderSettings } from '../database/provider-settings';
 
@@ -56,6 +57,39 @@ const plugin: FastifyPluginCallback = (app) => {
 
 	app.post('/auth/minimax/logout', (_request, reply) => {
 		ProviderSettings.remove('minimax');
+
+		return reply.send({ ok: true });
+	});
+
+	app.get('/auth/openai/start', async (_request, reply) => {
+		const result = await OpenAIOAuth.startLogin();
+
+		return reply.send(result);
+	});
+
+	app.get('/auth/openai/callback', async (request, reply) => {
+		const { code, state: sessionId } = request.query as { code?: string; state?: string };
+		if (!code || !sessionId) {
+			return reply
+				.type('text/html')
+				.send('<html><body><h1>Missing code or session</h1><p>Please close this window and try again.</p></body></html>');
+		}
+		const result = await OpenAIOAuth.completeLogin(code, sessionId);
+		if (result.ok) {
+			return reply
+				.type('text/html')
+				.send('<html><body><h1>Connected!</h1><p>You can close this window.</p><script>window.close()</script></body></html>');
+		}
+
+		return reply.type('text/html').send(`<html><body><h1>Error</h1><p>${result.error ?? 'Unknown error'}</p></body></html>`);
+	});
+
+	app.get('/auth/openai/status', (_request, reply) => {
+		return reply.send(OpenAIOAuth.getAuthStatus());
+	});
+
+	app.post('/auth/openai/logout', (_request, reply) => {
+		OpenAIOAuth.logout();
 
 		return reply.send({ ok: true });
 	});

--- a/apps/api/src/routes/openai.ts
+++ b/apps/api/src/routes/openai.ts
@@ -2,12 +2,13 @@ import { logger } from 'src/utils/logger';
 
 import { AnthropicToOpenai } from '../adapter/anthropic-to-openai';
 import { openaiToAnthropic } from '../adapter/openai-to-anthropic';
-import { Settings } from '../database/app-settings';
+import { ModelMappings } from '../database/model-mappings';
 import { Requests } from '../database/requests';
 import { HeadersExtractor } from '../handlers/headers-extractor';
 import { apiKeyAuth } from '../plugins/auth';
 import { proxyRequest } from '../proxy/anthropic-client';
 import { proxyMiniMaxRequest } from '../proxy/minimax-client';
+import { proxyOpenAIRequest } from '../proxy/proxy-client';
 import { MiniMaxStreamHandler } from '../streaming/minimax-stream-handler';
 import { OpenAIStreamHandler } from '../streaming/openai-stream-handler';
 
@@ -27,8 +28,7 @@ const plugin: FastifyPluginCallback = (app) => {
 		try {
 			const openaiBody = request.body as OpenAIChatRequest;
 
-			const settings = Settings.get();
-			const resolvedModel = settings.models.find((m) => m.id === openaiBody.model) ?? null;
+			const resolvedModel = ModelMappings.resolveForChatCompletion(openaiBody.model);
 
 			const isMiniMax = resolvedModel?.provider === 'minimax' || isMiniMaxModel(openaiBody.model);
 
@@ -113,6 +113,69 @@ const plugin: FastifyPluginCallback = (app) => {
 				reply.header('openai-version', '2020-10-01');
 
 				return reply.send(openaiResponse);
+			}
+
+			if (resolvedModel && String(resolvedModel.provider) === 'openai') {
+				const { response, context } = await proxyOpenAIRequest(
+					{
+						...openaiBody,
+						model: resolvedModel.upstreamModel,
+						...(resolvedModel.reasoningBudget ? { reasoning: { effort: resolvedModel.reasoningBudget } } : {})
+					},
+					'openai'
+				);
+
+				if (!response.ok) {
+					const errBody = await response.json().catch(() => ({ error: { message: `HTTP ${response.status}` } }));
+					const err = errBody as { error?: { message?: string; type?: string } };
+					const errorMessage = err?.error?.message ?? 'Unknown error';
+					const latencyMs = Date.now() - context.startTime;
+
+					Requests.record({
+						model: context.model,
+						source: 'error',
+						inputTokens: 0,
+						outputTokens: 0,
+						stream: false,
+						latencyMs,
+						error: errorMessage
+					});
+
+					reply.header('x-request-id', `req_${Date.now()}`);
+					reply.header('openai-processing-ms', latencyMs.toString());
+					reply.header('openai-version', '2020-10-01');
+
+					return reply.code(response.status).send({ error: { message: errorMessage, type: 'api_error' } });
+				}
+
+				if (openaiBody.stream) {
+					for (const [key, value] of response.headers.entries()) {
+						if (key.toLowerCase() !== 'content-encoding') {
+							reply.header(key, value);
+						}
+					}
+					reply.code(response.status);
+
+					return reply.send(response.body);
+				}
+
+				const responseJson = await response.json();
+				const latencyMs = Date.now() - context.startTime;
+
+				Requests.record({
+					model: context.model,
+					source: context.source,
+					inputTokens: context.inputTokens ?? 0,
+					outputTokens: context.outputTokens ?? 0,
+					stream: false,
+					latencyMs
+				});
+
+				reply.header('x-request-id', `req_${Date.now()}`);
+				reply.header('openai-processing-ms', latencyMs.toString());
+				reply.header('openai-version', '2020-10-01');
+
+				return reply.send(responseJson);
 			}
 
 			HeadersExtractor.logRequestDetails(request.headers, request.url, request.method, 'OpenAI /v1/chat/completions');

--- a/apps/api/src/types/openai.ts
+++ b/apps/api/src/types/openai.ts
@@ -1,5 +1,5 @@
 export interface OpenAIMessage {
-	role: 'system' | 'user' | 'assistant' | 'tool';
+	role: 'system' | 'user' | 'assistant' | 'tool' | 'developer' | 'function';
 	content: string | OpenAIContentPart[] | null;
 	tool_calls?: OpenAIToolCall[];
 	tool_call_id?: string;
@@ -21,6 +21,7 @@ export interface OpenAITool {
 		name: string;
 		description?: string;
 		parameters?: Record<string, unknown>;
+		strict?: boolean;
 	};
 }
 
@@ -36,6 +37,8 @@ export interface OpenAIToolCall {
 export interface OpenAIChatRequest {
 	model: string;
 	messages: OpenAIMessage[];
+	/** Some clients send the thread as `input` (chat roles or Responses items) instead of `messages`. */
+	input?: unknown;
 	max_tokens?: number;
 	max_completion_tokens?: number;
 	temperature?: number;
@@ -47,6 +50,10 @@ export interface OpenAIChatRequest {
 	user?: string;
 	tools?: OpenAITool[];
 	tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function: { name: string } };
+	reasoning_effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+	reasoning?: {
+		effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+	};
 }
 
 export interface OpenAIChatResponse {

--- a/apps/api/tests/responses-stream-mapper.test.ts
+++ b/apps/api/tests/responses-stream-mapper.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { createResponsesStreamState, processResponsesChunk } from '../src/proxy/responses-stream-mapper';
+
+function encodeSse(events: Record<string, unknown>[]): string {
+	return events.map((e) => `data: ${JSON.stringify(e)}\n\n`).join('');
+}
+
+function collectChunks(events: Record<string, unknown>[]) {
+	const state = createResponsesStreamState('gpt-5.3-codex');
+	const out = processResponsesChunk(state, encodeSse(events));
+	const chunks = out.filter((x) => x.type === 'chunk').map((x) => x.data!);
+	const finish = chunks.at(-1)?.choices as { finish_reason?: string }[] | undefined;
+	const toolDeltas = chunks.flatMap(
+		(c) => (c.choices as { delta?: { tool_calls?: unknown[] } }[] | undefined)?.[0]?.delta?.tool_calls ?? []
+	).length;
+
+	return {
+		chunks,
+		finishReason: finish?.[0]?.finish_reason ?? null,
+		toolDeltas
+	};
+}
+
+describe('responses-stream-mapper replay', () => {
+	it('handles text-only stream', () => {
+		const events = [
+			{ type: 'response.created', response: { id: 'resp_text' } },
+			{ type: 'response.output_text.delta', delta: 'hello' },
+			{ type: 'response.completed', response: { usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 } } }
+		];
+		const got = collectChunks(events);
+
+		expect(got.finishReason).toBe('stop');
+		expect(got.toolDeltas).toBe(0);
+	});
+
+	it('handles function_call added + arguments delta + done', () => {
+		const events = [
+			{ type: 'response.created', response: { id: 'resp_fc' } },
+			{
+				type: 'response.output_item.added',
+				output_index: 0,
+				item: { id: 'fc_1', type: 'function_call', call_id: 'call_1', name: 'ReadFile', arguments: '' }
+			},
+			{
+				type: 'response.function_call_arguments.delta',
+				output_index: 0,
+				delta: '{"path":"a.txt"}'
+			},
+			{
+				type: 'response.output_item.done',
+				output_index: 0,
+				item: { id: 'fc_1', type: 'function_call', call_id: 'call_1', name: 'ReadFile', arguments: '{"path":"a.txt"}' }
+			},
+			{ type: 'response.completed', response: {} }
+		];
+		const got = collectChunks(events);
+
+		expect(got.finishReason).toBe('tool_calls');
+		expect(got.toolDeltas).toBeGreaterThan(0);
+	});
+
+	it('handles custom_tool_call with custom_tool_call_input delta', () => {
+		const events = [
+			{ type: 'response.created', response: { id: 'resp_custom' } },
+			{
+				type: 'response.output_item.added',
+				output_index: 1,
+				item: { id: 'ctc_1', type: 'custom_tool_call', call_id: 'call_custom_1', custom: { name: 'EditFile' } }
+			},
+			{
+				type: 'response.custom_tool_call_input.delta',
+				output_index: 1,
+				delta: '{"path":"a.txt","edit":"x"}'
+			},
+			{
+				type: 'response.output_item.done',
+				output_index: 1,
+				item: {
+					id: 'ctc_1',
+					type: 'custom_tool_call',
+					call_id: 'call_custom_1',
+					custom: { name: 'EditFile' },
+					input: { path: 'a.txt', edit: 'x' }
+				}
+			},
+			{ type: 'response.completed', response: {} }
+		];
+		const got = collectChunks(events);
+
+		expect(got.finishReason).toBe('tool_calls');
+		expect(got.toolDeltas).toBeGreaterThan(0);
+	});
+
+	it('handles mixed text + custom_tool_call stream', () => {
+		const events = [
+			{ type: 'response.created', response: { id: 'resp_mix' } },
+			{ type: 'response.output_text.delta', delta: 'prep' },
+			{
+				type: 'response.output_item.added',
+				output_index: 2,
+				item: { id: 'ctc_2', type: 'custom_tool_call', call_id: 'call_custom_2', custom: { name: 'WriteFile' } }
+			},
+			{
+				type: 'response.custom_tool_call_input.delta',
+				output_index: 2,
+				delta: '{"path":"b.txt","content":"ok"}'
+			},
+			{
+				type: 'response.output_item.done',
+				output_index: 2,
+				item: {
+					id: 'ctc_2',
+					type: 'custom_tool_call',
+					call_id: 'call_custom_2',
+					custom: { name: 'WriteFile' },
+					input: { path: 'b.txt', content: 'ok' }
+				}
+			},
+			{ type: 'response.completed', response: {} }
+		];
+		const got = collectChunks(events);
+
+		expect(got.finishReason).toBe('tool_calls');
+		expect(got.toolDeltas).toBeGreaterThan(0);
+	});
+});

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,8 +1,8 @@
 {
 	"name": "ungate",
 	"displayName": "Ungate",
-	"description": "Use your Claude subscription or MiniMax in Cursor from one extension",
-	"version": "1.2.0",
+	"description": "Use Claude, GPT, or MiniMax subscriptions in Cursor from one extension",
+	"version": "1.3.0",
 	"publisher": "orchidfiles",
 	"license": "MIT",
 	"pricing": "Free",
@@ -22,6 +22,8 @@
 	"keywords": [
 		"claude",
 		"anthropic",
+		"chatgpt",
+		"gpt",
 		"minimax",
 		"cursor",
 		"proxy",

--- a/apps/extension/src/dashboard.ts
+++ b/apps/extension/src/dashboard.ts
@@ -17,7 +17,7 @@ export class Dashboard {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
-		private readonly onMessage: (type: string) => void
+		private readonly onMessage: (message: { type: string; url?: string }) => void
 	) {}
 
 	show(): void {
@@ -37,7 +37,7 @@ export class Dashboard {
 				return;
 			}
 
-			this.onMessage((message as { type: string }).type);
+			this.onMessage(message as { type: string; url?: string });
 		});
 
 		this.panel.webview.html = this.buildHtml();

--- a/apps/extension/src/extension.ts
+++ b/apps/extension/src/extension.ts
@@ -42,7 +42,13 @@ function setStatus(state: 'running' | 'stopped' | 'error'): void {
 	statusBar.show();
 }
 
-function handleWebviewMessage(type: string): void {
+function handleWebviewMessage(message: { type: string; url?: string }): void {
+	if (message.type === 'open-external-url' && message.url) {
+		void vscode.env.openExternal(vscode.Uri.parse(message.url));
+
+		return;
+	}
+
 	const handlers: Record<string, () => void> = {
 		'webview-ready': () => dashboard.sendInitialState(tunnelManager.getState()),
 		'restart-server': () => apiServer.restart(),
@@ -75,7 +81,7 @@ function handleWebviewMessage(type: string): void {
 		}
 	};
 
-	handlers[type]?.();
+	handlers[message.type]?.();
 }
 
 export function activate(context: vscode.ExtensionContext): void {

--- a/apps/web/src/features/auth/ChatGPTAuthSection.svelte
+++ b/apps/web/src/features/auth/ChatGPTAuthSection.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+import IconCheck from 'virtual:icons/lucide/check';
+import IconLoader from 'virtual:icons/lucide/loader-circle';
+import IconLogOut from 'virtual:icons/lucide/log-out';
+
+import { Api } from '$shared/api';
+import { postExtensionMessage } from '$shared/vscode';
+
+let authenticated = $state(false);
+let email = $state<string | undefined>(undefined);
+let loading = $state(true);
+let checking = $state(false);
+let error = $state<string | null>(null);
+
+$effect(() => {
+	void loadStatus();
+});
+
+async function loadStatus() {
+	loading = true;
+	error = null;
+
+	try {
+		const status = await Api.authChatGPTStatus();
+		authenticated = status.authenticated;
+		email = status.email;
+	} catch (e) {
+		error = e instanceof Error ? e.message : String(e);
+	}
+
+	loading = false;
+}
+
+async function handleLogin() {
+	error = null;
+	checking = true;
+
+	try {
+		const result = await Api.authChatGPTStart();
+		postExtensionMessage({ type: 'open-external-url', url: result.authUrl });
+		// Poll for auth completion
+		const pollInterval = setInterval(() => {
+			void (async () => {
+				try {
+					const status = await Api.authChatGPTStatus();
+					if (status.authenticated) {
+						clearInterval(pollInterval);
+						authenticated = true;
+						email = status.email;
+						checking = false;
+					}
+				} catch {
+					// Keep polling
+				}
+			})();
+		}, 1000);
+		// Stop polling after 5 minutes
+		setTimeout(() => {
+			clearInterval(pollInterval);
+			if (checking) {
+				checking = false;
+			}
+		}, 300_000);
+	} catch (e) {
+		error = e instanceof Error ? e.message : String(e);
+		checking = false;
+	}
+}
+
+async function handleLogout() {
+	error = null;
+
+	try {
+		await Api.authChatGPTLogout();
+		authenticated = false;
+		email = undefined;
+	} catch (e) {
+		error = e instanceof Error ? e.message : String(e);
+	}
+}
+</script>
+
+<div class="card preset-tonal-surface border border-surface-700/30 p-5 space-y-4">
+	<p class="text-sm font-semibold">ChatGPT Authorization</p>
+
+	{#if loading}
+		<div class="flex items-center gap-2 text-sm text-surface-400">
+			<IconLoader class="size-4 animate-spin" />
+			Checking status...
+		</div>
+	{:else if authenticated}
+		<div class="space-y-3">
+			<div class="flex items-center gap-2 text-sm">
+				<IconCheck class="size-4 text-success-500" />
+				<span>Connected{email ? ` as ${email}` : ''}</span>
+			</div>
+			<button
+				class="btn btn-sm preset-outlined-surface-700 hover:preset-filled-surface-500 w-fit"
+				onclick={handleLogout}>
+				<IconLogOut class="size-4" />
+				Disconnect
+			</button>
+		</div>
+	{:else if checking}
+		<div class="flex items-center gap-2 text-sm text-surface-400">
+			<IconLoader class="size-4 animate-spin" />
+			Waiting for authorization...
+		</div>
+	{:else}
+		<p class="text-sm text-surface-400">Not connected.</p>
+		<button
+			class="btn btn-sm preset-filled-primary-500"
+			onclick={handleLogin}>
+			Connect ChatGPT
+		</button>
+	{/if}
+
+	{#if error}
+		<div class="card preset-tonal-error p-3 text-sm">
+			{error}
+		</div>
+	{/if}
+</div>

--- a/apps/web/src/features/auth/ClaudeAuthSection.svelte
+++ b/apps/web/src/features/auth/ClaudeAuthSection.svelte
@@ -5,6 +5,7 @@ import IconLoader from 'virtual:icons/lucide/loader-circle';
 import IconLogOut from 'virtual:icons/lucide/log-out';
 
 import { Api } from '$shared/api';
+import { postExtensionMessage } from '$shared/vscode';
 
 type Phase = 'idle' | 'pending-code' | 'completing';
 
@@ -44,7 +45,7 @@ async function handleStartLogin() {
 		authUrl = result.authUrl;
 		sessionId = result.sessionId;
 		phase = 'pending-code';
-		window.open(authUrl, '_blank');
+		postExtensionMessage({ type: 'open-external-url', url: authUrl });
 	} catch (e) {
 		error = e instanceof Error ? e.message : String(e);
 	}

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -5,6 +5,7 @@ import IconRotateCcw from 'virtual:icons/lucide/rotate-ccw';
 import IconSave from 'virtual:icons/lucide/save';
 import IconTrash2 from 'virtual:icons/lucide/trash-2';
 
+import ChatGPTAuthSection from '../auth/ChatGPTAuthSection.svelte';
 import ClaudeAuthSection from '../auth/ClaudeAuthSection.svelte';
 import MiniMaxAuthSection from '../auth/MiniMaxAuthSection.svelte';
 import TunnelPanel from '../tunnel/TunnelPanel.svelte';
@@ -28,6 +29,10 @@ function cloneModels(items: ModelMappingConfig[]): ModelMappingConfig[] {
 
 		if (model.provider === 'minimax') {
 			provider = 'minimax';
+		}
+
+		if (model.provider === 'openai') {
+			provider = 'openai';
 		}
 
 		if (reasoningBudget !== 'low' && reasoningBudget !== 'medium' && reasoningBudget !== 'high') {
@@ -99,6 +104,7 @@ function handleSaveAndRestart() {
 <div class="space-y-6">
 	<div class="grid grid-cols-1 gap-4">
 		<ClaudeAuthSection />
+		<ChatGPTAuthSection />
 		<MiniMaxAuthSection />
 	</div>
 
@@ -203,6 +209,7 @@ function handleSaveAndRestart() {
 										bind:value={model.provider}>
 										<option value="claude">Claude</option>
 										<option value="minimax">MiniMax</option>
+										<option value="openai">OpenAI</option>
 									</select>
 								</label>
 

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -103,6 +103,18 @@ export class Api {
 		return this.post('/auth/minimax/logout');
 	}
 
+	static authChatGPTStart(): Promise<{ authUrl: string; sessionId: string }> {
+		return this.get('/auth/openai/start');
+	}
+
+	static authChatGPTStatus(): Promise<{ authenticated: boolean; email?: string }> {
+		return this.get('/auth/openai/status');
+	}
+
+	static authChatGPTLogout(): Promise<{ ok: boolean }> {
+		return this.post('/auth/openai/logout');
+	}
+
 	static async healthCheck(): Promise<boolean> {
 		try {
 			const response = await fetch(`${this.baseUrl()}/health`, { signal: AbortSignal.timeout(1000) });

--- a/apps/web/src/shared/vscode.ts
+++ b/apps/web/src/shared/vscode.ts
@@ -1,5 +1,3 @@
-import type { WebviewToExtension } from '@ungate/shared/frontend';
-
 // acquireVsCodeApi() may only be called once — singleton
 const vscodeApi = (
 	window as Window & {
@@ -7,6 +5,6 @@ const vscodeApi = (
 	}
 ).acquireVsCodeApi?.();
 
-export function postExtensionMessage(message: WebviewToExtension): void {
+export function postExtensionMessage(message: { type: string; [key: string]: unknown }): void {
 	vscodeApi?.postMessage(message);
 }

--- a/packages/shared/src/types/analytics.ts
+++ b/packages/shared/src/types/analytics.ts
@@ -1,11 +1,12 @@
 export type Period = 'hour' | 'day' | 'week' | 'month' | 'all';
 
-export type RequestSource = 'claude' | 'minimax' | 'error';
+export type RequestSource = 'claude' | 'minimax' | 'openai' | 'error';
 
 export interface AnalyticsSummary {
 	totalRequests: number;
 	claudeRequests: number;
 	minimaxRequests: number;
+	openaiRequests: number;
 	errorRequests: number;
 	totalInputTokens: number;
 	totalOutputTokens: number;

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -1,6 +1,6 @@
 export type ClaudeReasoningBudget = 'low' | 'medium' | 'high';
 
-export type ModelMappingProvider = 'claude' | 'minimax';
+export type ModelMappingProvider = 'claude' | 'minimax' | 'openai';
 
 export interface ModelMappingConfig {
 	id: string;


### PR DESCRIPTION
## Summary

This branch expands Ungate beyond Claude and MiniMax by adding ChatGPT account OAuth and OpenAI-backed GPT/Codex model support for Cursor. It introduces the auth flow, model mapping, request translation, and streaming response handling needed to route OpenAI-compatible traffic through the existing local proxy workflow.

## What Changed

- Added ChatGPT OAuth support end to end: provider registration in the API, new `/auth/openai/*` routes, persisted OpenAI account metadata, and a new ChatGPT auth section in the web UI.
- Added OpenAI provider model mappings in the database migration so GPT and Codex variants can be selected and resolved through the existing model registry.
- Implemented OpenAI/Codex request handling in the proxy layer, including input normalization, Codex chat input conversion, OpenAI client calls, and SSE stream mapping back into OpenAI-compatible chat completion output.
- Updated the settings UI and shared API helpers to expose OpenAI as a provider alongside Claude and MiniMax.
- Refined the README to position Ungate as a Cursor-focused extension for Claude, ChatGPT, and MiniMax subscriptions.