### PR TITLE
Add Opus 4.8 support and fix reasoning/tool routing

### DIFF
--- a/apps/api/drizzle/_0006.sql
+++ b/apps/api/drizzle/_0006.sql
@@ -1,0 +1,36 @@
+-- Migration 0006: add Opus-4.8 model mappings
+WITH candidates(id, label, provider, upstream_model, reasoning_budget, sort_offset) AS (
+	VALUES
+		('opus-4.8', 'Opus 4.8', 'claude', 'claude-opus-4-8', NULL, 1),
+		('opus-4.8-low', 'Opus 4.8 Low', 'claude', 'claude-opus-4-8', 'low', 2),
+		('opus-4.8-medium', 'Opus 4.8 Medium', 'claude', 'claude-opus-4-8', 'medium', 3),
+		('opus-4.8-high', 'Opus 4.8 High', 'claude', 'claude-opus-4-8', 'high', 4),
+		('opus-4.8-xhigh', 'Opus 4.8 XHigh', 'claude', 'claude-opus-4-8', 'xhigh', 5)
+),
+base_sort_order(value) AS (
+	SELECT COALESCE(MAX(sort_order), -1)
+	FROM model_mappings
+),
+resolved_candidates AS (
+	SELECT
+		candidate.id,
+		candidate.label,
+		candidate.provider,
+		candidate.upstream_model,
+		(SELECT value FROM base_sort_order) + candidate.sort_offset AS sort_order,
+		candidate.reasoning_budget
+	FROM candidates AS candidate
+)
+INSERT OR IGNORE INTO model_mappings (id, label, provider, upstream_model, sort_order, reasoning_budget)
+SELECT candidate.id, candidate.label, candidate.provider, candidate.upstream_model, candidate.sort_order, candidate.reasoning_budget
+FROM resolved_candidates AS candidate
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM model_mappings AS existing
+	WHERE existing.provider = candidate.provider
+		AND existing.upstream_model = candidate.upstream_model
+		AND (
+			existing.reasoning_budget = candidate.reasoning_budget
+			OR (existing.reasoning_budget IS NULL AND candidate.reasoning_budget IS NULL)
+		)
+);

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1777302000000,
       "tag": "_0005",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1782345600000,
+      "tag": "_0006",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/database/pricing.ts
+++ b/apps/api/src/database/pricing.ts
@@ -4,6 +4,8 @@ interface ModelPricing {
 }
 
 const MODEL_PRICING: Record<string, ModelPricing> = {
+	'claude-opus-4-8': { inputPerMTok: 5.0, outputPerMTok: 25.0 },
+	'claude-opus-4-7': { inputPerMTok: 5.0, outputPerMTok: 25.0 },
 	'claude-opus-4-6': { inputPerMTok: 5.0, outputPerMTok: 25.0 },
 	'claude-opus-4-5': { inputPerMTok: 5.0, outputPerMTok: 25.0 },
 	'claude-opus-4-1': { inputPerMTok: 15.0, outputPerMTok: 75.0 },

--- a/apps/api/src/proxy/anthropic-client.ts
+++ b/apps/api/src/proxy/anthropic-client.ts
@@ -28,10 +28,6 @@ async function makeClaudeCodeRequest(
 	try {
 		const preparedBody = RequestBuilder.prepareClaudeCodeBody(body);
 
-		if ('reasoning_budget' in preparedBody) {
-			delete preparedBody.reasoning_budget;
-		}
-
 		let reverseToolMapping: Record<string, string> = {};
 		if (preparedBody.tools && preparedBody.tools.length > 0) {
 			const mapped = ToolMapper.map(preparedBody.tools);

--- a/apps/api/src/proxy/request-builder.ts
+++ b/apps/api/src/proxy/request-builder.ts
@@ -11,24 +11,16 @@ const VALID_EFFORTS: readonly ThinkingEffort[] = ['low', 'medium', 'high', 'xhig
 
 // Opus 4.7/4.8 reject manual budget_tokens (400). They use adaptive thinking,
 // controlled by the `effort` parameter in a top-level `output_config` object.
-// Map the internal reasoning_budget tier onto an effort level.
+// reasoning_budget is always a tier string ('low' | 'medium' | 'high' | 'xhigh')
+// set from the model mapping; pass it through verbatim as the effort level.
 function resolveEffort(budget: number | string | undefined): ThinkingEffort | null {
-	if (typeof budget === 'string') {
-		const normalized = budget.toLowerCase();
-
-		return (VALID_EFFORTS as readonly string[]).includes(normalized) ? (normalized as ThinkingEffort) : null;
+	if (typeof budget !== 'string') {
+		return null;
 	}
 
-	if (typeof budget === 'number') {
-		if (budget <= 0) return null;
-		if (budget <= 4000) return 'low';
-		if (budget <= 10000) return 'medium';
-		if (budget <= 31999) return 'high';
+	const normalized = budget.toLowerCase();
 
-		return 'xhigh';
-	}
-
-	return null;
+	return (VALID_EFFORTS as readonly string[]).includes(normalized) ? (normalized as ThinkingEffort) : null;
 }
 
 export class RequestBuilder {

--- a/apps/api/src/proxy/request-builder.ts
+++ b/apps/api/src/proxy/request-builder.ts
@@ -5,7 +5,31 @@ import { logger } from 'src/utils/logger';
 import { config } from '../config';
 import { Settings } from '../database/app-settings';
 
-import type { AnthropicRequest, ContentBlock } from '../types';
+import type { AnthropicRequest, ContentBlock, ThinkingEffort } from '../types';
+
+const VALID_EFFORTS: readonly ThinkingEffort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+// Opus 4.7/4.8 reject manual budget_tokens (400). They use adaptive thinking,
+// controlled by the `effort` parameter in a top-level `output_config` object.
+// Map the internal reasoning_budget tier onto an effort level.
+function resolveEffort(budget: number | string | undefined): ThinkingEffort | null {
+	if (typeof budget === 'string') {
+		const normalized = budget.toLowerCase();
+
+		return (VALID_EFFORTS as readonly string[]).includes(normalized) ? (normalized as ThinkingEffort) : null;
+	}
+
+	if (typeof budget === 'number') {
+		if (budget <= 0) return null;
+		if (budget <= 4000) return 'low';
+		if (budget <= 10000) return 'medium';
+		if (budget <= 31999) return 'high';
+
+		return 'xhigh';
+	}
+
+	return null;
+}
 
 export class RequestBuilder {
 	private static getStainlessOS(): string {
@@ -69,7 +93,19 @@ export class RequestBuilder {
 		if ('reasoning_budget' in prepared) {
 			const budgetValue = prepared.reasoning_budget;
 			delete prepared.reasoning_budget;
-			logger.warn(`Removed reasoning_budget (${budgetValue}) — not supported by Claude Code API`);
+
+			// Translate the tier into adaptive thinking + effort. Opus 4.7/4.8 only
+			// support this form; manual budget_tokens returns a 400. `effort` has no
+			// effect without `thinking.type: "adaptive"`, so both must be set.
+			const effort = resolveEffort(budgetValue);
+
+			if (effort) {
+				prepared.thinking = { type: 'adaptive' };
+				prepared.output_config = { ...prepared.output_config, effort };
+				logger.log(`Reasoning budget (${budgetValue}) → adaptive thinking (effort: ${effort})`);
+			} else {
+				logger.log(`Reasoning budget (${budgetValue}) ignored — no matching effort tier`);
+			}
 		}
 
 		const systemPrompts: ContentBlock[] = [];

--- a/apps/api/src/proxy/responses-input-normalizer/build-body.ts
+++ b/apps/api/src/proxy/responses-input-normalizer/build-body.ts
@@ -72,7 +72,7 @@ export class ResponsesBodyBuilder {
 		}
 
 		if (hasTools) {
-			payload.tools = rawTools;
+			payload.tools = rawTools.map((tool) => this.toResponsesTool(tool));
 			payload.tool_choice = this.mapChoice(body.tool_choice, true) ?? 'auto';
 			payload.parallel_tool_calls = false;
 		}
@@ -85,6 +85,36 @@ export class ResponsesBodyBuilder {
 		};
 
 		return { payload, debug };
+	}
+
+	// The Responses API expects function tools in a flattened shape with `name`,
+	// `description`, and `parameters` at the top level — unlike Chat Completions,
+	// which nests them under `function`. Cursor sends the nested form, so flatten
+	// it here; otherwise the upstream rejects with "Missing required parameter:
+	// 'tools[0].name'". Pass through tools that are already flat or non-function.
+	private static toResponsesTool(tool: unknown): Record<string, unknown> {
+		const record = (tool ?? {}) as Record<string, unknown>;
+		const fn = record.function as Record<string, unknown> | undefined;
+
+		if (record.type === 'function' && fn && typeof fn.name === 'string') {
+			const flattened: Record<string, unknown> = {
+				type: 'function',
+				name: fn.name,
+				parameters: fn.parameters ?? { type: 'object', properties: {} }
+			};
+
+			if (typeof fn.description === 'string') {
+				flattened.description = fn.description;
+			}
+
+			if (typeof fn.strict === 'boolean') {
+				flattened.strict = fn.strict;
+			}
+
+			return flattened;
+		}
+
+		return record;
 	}
 
 	private static mapChoice(

--- a/apps/api/src/types/anthropic.ts
+++ b/apps/api/src/types/anthropic.ts
@@ -37,6 +37,17 @@ export interface ImageSource {
 	url?: string;
 }
 
+export type ThinkingEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+export interface ThinkingConfig {
+	type: 'enabled' | 'adaptive' | 'disabled';
+	budget_tokens?: number;
+}
+
+export interface OutputConfig {
+	effort?: ThinkingEffort;
+}
+
 export interface AnthropicRequest {
 	model: string;
 	max_tokens: number;
@@ -51,6 +62,8 @@ export interface AnthropicRequest {
 	tools?: Tool[];
 	tool_choice?: ToolChoice;
 	reasoning_budget?: number | string;
+	thinking?: ThinkingConfig;
+	output_config?: OutputConfig;
 }
 
 export interface Tool {

--- a/apps/api/tests/unit/proxy/proxy-request-builder.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-request-builder.test.ts
@@ -34,7 +34,22 @@ describe('proxy-request-builder', () => {
 		expect(userBlock.cache_control?.ttl).toBeUndefined();
 	});
 
-	it('maps numeric reasoning budget onto an effort tier', () => {
+	it('passes each reasoning tier through verbatim as the effort level', () => {
+		for (const tier of ['low', 'medium', 'high', 'xhigh'] as const) {
+			const prepared = RequestBuilder.prepareClaudeCodeBody({
+				model: 'claude-opus-4-8',
+				max_tokens: 1024,
+				reasoning_budget: tier,
+				messages: [{ role: 'user', content: 'hello' }]
+			});
+
+			expect(prepared.reasoning_budget).toBeUndefined();
+			expect(prepared.thinking).toEqual({ type: 'adaptive' });
+			expect(prepared.output_config).toEqual({ effort: tier });
+		}
+	});
+
+	it('ignores a non-tier reasoning budget without enabling thinking', () => {
 		const prepared = RequestBuilder.prepareClaudeCodeBody({
 			model: 'claude-opus-4-8',
 			max_tokens: 1024,
@@ -43,8 +58,8 @@ describe('proxy-request-builder', () => {
 		});
 
 		expect(prepared.reasoning_budget).toBeUndefined();
-		expect(prepared.thinking).toEqual({ type: 'adaptive' });
-		expect(prepared.output_config).toEqual({ effort: 'medium' });
+		expect(prepared.thinking).toBeUndefined();
+		expect(prepared.output_config).toBeUndefined();
 	});
 
 	it('does not set thinking when no reasoning budget is provided', () => {

--- a/apps/api/tests/unit/proxy/proxy-request-builder.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-request-builder.test.ts
@@ -24,12 +24,38 @@ describe('proxy-request-builder', () => {
 		});
 
 		expect(prepared.reasoning_budget).toBeUndefined();
+		expect(prepared.thinking).toEqual({ type: 'adaptive' });
+		expect(prepared.output_config).toEqual({ effort: 'high' });
 		expect(Array.isArray(prepared.system)).toBe(true);
 		const system = prepared.system as { type: string; text?: string; cache_control?: { ttl?: number } }[];
 		expect(system.some((block) => block.text === 'extra instruction from settings')).toBe(true);
 		expect(system.find((block) => block.text === 'sys')?.cache_control?.ttl).toBeUndefined();
 		const userBlock = (prepared.messages[0].content as { cache_control?: { ttl?: number } }[])[0];
 		expect(userBlock.cache_control?.ttl).toBeUndefined();
+	});
+
+	it('maps numeric reasoning budget onto an effort tier', () => {
+		const prepared = RequestBuilder.prepareClaudeCodeBody({
+			model: 'claude-opus-4-8',
+			max_tokens: 1024,
+			reasoning_budget: 10000,
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(prepared.reasoning_budget).toBeUndefined();
+		expect(prepared.thinking).toEqual({ type: 'adaptive' });
+		expect(prepared.output_config).toEqual({ effort: 'medium' });
+	});
+
+	it('does not set thinking when no reasoning budget is provided', () => {
+		const prepared = RequestBuilder.prepareClaudeCodeBody({
+			model: 'claude-opus-4-8',
+			max_tokens: 1024,
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(prepared.thinking).toBeUndefined();
+		expect(prepared.output_config).toBeUndefined();
 	});
 
 	it('converts string system prompt into system blocks', () => {

--- a/apps/api/tests/unit/proxy/proxy-responses-input-normalizer.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-responses-input-normalizer.test.ts
@@ -69,7 +69,41 @@ describe('proxy-responses-input-normalizer', () => {
 		const input = payload.input as Record<string, unknown>[];
 		expect(input.some((item) => item.type === 'function_call_output' && item.call_id === 'missing')).toBe(false);
 		expect(payload.tool_choice).toEqual({ type: 'function', name: 'Read' });
+		expect(payload.tools).toEqual([{ type: 'function', name: 'Read', parameters: { type: 'object', properties: {} } }]);
 		expect(payload.instructions).toBe('extra');
+	});
+
+	it('flattens chat-completions tools into responses format', () => {
+		const { payload } = ResponsesBodyBuilder.buildBody(
+			{
+				model: 'gpt-5.5',
+				messages: [{ role: 'user', content: 'hello' }],
+				tools: [
+					{
+						type: 'function',
+						function: {
+							name: 'Shell',
+							description: 'Run a shell command',
+							parameters: { type: 'object', properties: { command: { type: 'string' } } },
+							strict: true
+						}
+					}
+				]
+			},
+			'gpt-5.5-xhigh',
+			{ instructionsFallback: 'fallback', extraInstruction: '', envInstructions: '' }
+		);
+
+		expect(payload.tools).toEqual([
+			{
+				type: 'function',
+				name: 'Shell',
+				description: 'Run a shell command',
+				parameters: { type: 'object', properties: { command: { type: 'string' } } },
+				strict: true
+			}
+		]);
+		expect(payload.parallel_tool_calls).toBe(false);
 	});
 
 	it('prefers explicit reasoning over model-derived effort and keeps no tool_choice without tools', () => {

--- a/apps/api/tests/unit/proxy/proxy-responses-input-normalizer.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-responses-input-normalizer.test.ts
@@ -73,7 +73,7 @@ describe('proxy-responses-input-normalizer', () => {
 		expect(payload.instructions).toBe('extra');
 	});
 
-	it('flattens chat-completions tools into responses format', () => {
+	it('flattens chat-completions tools so Codex receives tools[0].name', () => {
 		const { payload } = ResponsesBodyBuilder.buildBody(
 			{
 				model: 'gpt-5.5',
@@ -103,6 +103,8 @@ describe('proxy-responses-input-normalizer', () => {
 				strict: true
 			}
 		]);
+		expect((payload.tools as Record<string, unknown>[])[0].name).toBe('Shell');
+		expect((payload.tools as Record<string, unknown>[])[0].function).toBeUndefined();
 		expect(payload.parallel_tool_calls).toBe(false);
 	});
 

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add Opus-4.8 model support
 - Map reasoning tiers to adaptive thinking + effort for Opus 4.7/4.8 (previously dropped)
+- Fix Codex (GPT-5.5) tool calls failing with "Missing required parameter: 'tools[0].name'" by flattening tools to Responses API format
 
 ## 1.7.1 - 2026-05-25
 

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.2 - 2026-06-25
+
+- Add Opus-4.8 model support
+- Map reasoning tiers to adaptive thinking + effort for Opus 4.7/4.8 (previously dropped)
+
 ## 1.7.1 - 2026-05-25
 
 - Update changelog

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "ungate",
 	"displayName": "Ungate",
 	"description": "Use Claude, GPT, or MiniMax subscriptions in Cursor instead of paying for API tokens",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"publisher": "orchidfiles",
 	"license": "MIT",
 	"pricing": "Free",

--- a/apps/web/src/features/analytics/analytics-store.svelte.ts
+++ b/apps/web/src/features/analytics/analytics-store.svelte.ts
@@ -168,6 +168,10 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
 // Labels map — exact model names from DB (after normalizeModelName).
 // Dated variants are the actual stored names for 4.5 models.
 const MODEL_LABELS: Record<string, string> = {
+	// 4.8 series (used as-is)
+	'claude-opus-4-8': 'Claude Opus 4.8',
+	// 4.7 series (used as-is)
+	'claude-opus-4-7': 'Claude Opus 4.7',
 	// 4.6 series (used as-is)
 	'claude-opus-4-6': 'Claude Opus 4.6',
 	'claude-sonnet-4-6': 'Claude Sonnet 4.6',


### PR DESCRIPTION
## Summary

This PR fixes three related model-routing issues:

- Adds Claude Opus 4.8 as a supported Claude model, including base, low, medium, high, and xhigh mappings (`opus-4.8`, `opus-4.8-low`, `opus-4.8-medium`, `opus-4.8-high`, `opus-4.8-xhigh`) routed to `claude-opus-4-8`.
- Fixes Claude reasoning tiers for Opus 4.7/4.8 by translating Ungate's internal `reasoning_budget` tier into Anthropic's adaptive thinking request shape: `thinking: { type: "adaptive" }` plus `output_config: { effort }`.
- Fixes GPT-5.5/Codex tool calls by flattening Chat Completions tool definitions into the Responses API format so tools include top-level `name`, `description`, and `parameters` fields.

## Previous failures

Before this change, Opus 4.8 reasoning variants routed but dropped the selected tier before calling Claude Code:

```text
[OpenAI→Anthropic] "opus-4.8-high" → "claude-opus-4-8" (reasoning_budget: high) | max_tokens=4096
Removed reasoning_budget (high) — not supported by Claude Code API
```

This made `-low`, `-medium`, `-high`, and `-xhigh` behave like the base model. Opus 4.7/4.8 reject manual `budget_tokens`; the supported API shape is adaptive thinking with an `effort` value.

GPT-5.5 XHigh also failed when tools were present because the Codex Responses endpoint requires flattened function tools:

```text
OpenAI Codex proxy: gpt-5.5 → gpt-5.5 tools=16 stream=true
ChatGPT Codex upstream error: 400 {
  "error": {
    "message": "Missing required parameter: 'tools[0].name'.",
    "type": "invalid_request_error",
    "param": "tools[0].name",
    "code": "missing_required_parameter"
  }
}
```

## Manual verification

Manually tested the rebuilt VSIX locally with both affected paths:

- `opus-4.8-high` now routes to `claude-opus-4-8` and logs the adaptive thinking translation:

```text
[OpenAI→Anthropic] "opus-4.8-high" → "claude-opus-4-8" (reasoning_budget: high) | max_tokens=4096
Reasoning budget (high) → adaptive thinking (effort: high)
✓ Request served via Claude Code
```

- `gpt-5.5-xhigh` now completes through the Codex stream with tools enabled:

```text
[Codex] upstreamModel=gpt-5.5 chatMessages=411 inputField=0 codexItems=552 fromBodyInput=false
OpenAI Codex proxy: gpt-5.5 → gpt-5.5 tools=16 stream=true
[Codex stream] stream done toolCallsSeen=true toolCallIndex=2 text=true ... response.completed:1
```

## Tests

- Added unit coverage for Claude reasoning tier translation, including pass-through of `low`, `medium`, `high`, and `xhigh` as adaptive-thinking effort values.
- Added unit coverage for GPT-5.5/Codex tool flattening to prevent regressions of the `tools[0].name` upstream error.
- Ran the full pre-commit test suite successfully:
  - Extension unit tests: 62 passed
  - API unit tests: 70 passed
  - API integration tests: 45 passed

Closes #14

Made with [Cursor](https://cursor.com)