### PR TITLE
fix(claude): handle non-json provider errors

### DIFF
--- a/apps/api/src/orchestration/openai/provider-handlers/claude-chat-handler.ts
+++ b/apps/api/src/orchestration/openai/provider-handlers/claude-chat-handler.ts
@@ -23,7 +23,7 @@ export class ClaudeChatHandler {
 		const { response, context } = await proxyRequest('/v1/messages', anthropicBody, headers);
 
 		if (!response.ok) {
-			const errorJson = await response.json();
+			const errorJson = await response.json().catch(() => ({ error: { message: `HTTP ${response.status}`, type: 'api_error' } }));
 			const payload = CompletionErrorMapper.claudeApiErrorPayload(errorJson);
 			const errorLatencyMs = Date.now() - context.startTime;
 

--- a/apps/api/tests/integration/routes/routes-openai.test.ts
+++ b/apps/api/tests/integration/routes/routes-openai.test.ts
@@ -288,6 +288,29 @@ describe('routes-openai', () => {
 		await app.close();
 	});
 
+	it('handles a non-JSON claude error body without crashing', async () => {
+		resolveForChatCompletionMock.mockReturnValueOnce(null);
+		proxyRequestMock.mockResolvedValueOnce({
+			response: new Response('upstream temporarily unavailable', {
+				status: 529,
+				headers: { 'content-type': 'text/plain' }
+			}),
+			context: { startTime: Date.now(), model: 'claude-sonnet-4-6', source: 'claude', reverseToolMapping: {} }
+		});
+
+		const app = await withPlugin(openaiPlugin, { apiKey: 'secret' });
+		const response = await app.inject({
+			method: 'POST',
+			url: '/v1/chat/completions',
+			headers: { 'x-api-key': 'secret' },
+			payload: { model: 'claude-4.6-sonnet', messages: [{ role: 'user', content: 'hello' }], stream: false }
+		});
+
+		expect(response.statusCode).toBe(529);
+		expect(response.json().error.message).toBe('HTTP 529');
+		await app.close();
+	});
+
 	it('routes to mapped openai with streaming passthrough', async () => {
 		const stream = new ReadableStream({
 			start(controller) {

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.7.3 - 2026-06-25
+
+- Fix Anthropic provider errors with non-JSON bodies so upstream failures return a normal error response instead of crashing the API
+
 ## 1.7.2 - 2026-06-25
 
 - Add Opus-4.8 model support

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "ungate",
 	"displayName": "Ungate",
 	"description": "Use Claude, GPT, or MiniMax subscriptions in Cursor instead of paying for API tokens",
-	"version": "1.7.2",
+	"version": "1.7.3",
 	"publisher": "orchidfiles",
 	"license": "MIT",
 	"pricing": "Free",


### PR DESCRIPTION
## Summary
- Guard Claude/Anthropic upstream error parsing when the provider returns a non-JSON body.
- Return a normal OpenAI-compatible error response with the upstream HTTP status instead of throwing while handling the error path.
- Add an integration regression test for a non-JSON Claude provider error response.

Fixes #23.

## Test plan
- `pnpm --filter ungate test`
- `pnpm --filter @ungate/api test`

Made with [Cursor](https://cursor.com)