### PR TITLE
fix: add custom models from dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,166 @@
+# Ungate — architecture and project structure
+
+## Purpose
+
+Ungate is a Cursor extension that lets you use Claude, ChatGPT, and MiniMax subscriptions instead of paying for API tokens. It consists of a VS Code extension, a local HTTP proxy (Fastify), a Svelte WebUI, and a shared types/constants library.
+
+## Monorepo (pnpm workspace)
+
+```
+ungate/
+├── apps/
+│   ├── api/          # Local proxy server (Fastify + TypeScript)
+│   ├── extension/    # VS Code / Cursor extension
+│   └── web/          # Web UI (dashboard) in Svelte
+├── packages/
+│   ├── shared/       # Shared types, schemas, constants, helpers
+│   └── dev-kit/      # Linter, vitest configs
+└── scripts/          # Utilities (build, tunnel, check-tunnels)
+```
+
+## Data flow
+
+Cursor → Cloudflare Tunnel → Ungate API → Provider API. Cursor cannot call localhost, so a public tunnel URL is required. Ungate listens on a custom OpenAI Base URL, transforms requests into the target provider format and back.
+
+## apps/api — proxy server
+
+Fastify server, spawned by the extension as a child Node.js process.
+
+**Entry points:**
+- `/v1/chat/completions` — OpenAI-compatible endpoint, accepts requests from Cursor
+- `/v1/messages` — Anthropic-compatible endpoint (direct proxy)
+- `/v1/analytics` — request statistics
+- `/v1/auth/*` — OAuth routes (Claude, ChatGPT)
+- `/v1/models` — model list
+- `/v1/settings` — settings
+
+**Architecture:**
+- `src/server.ts` — Fastify initialization, plugin registration
+- `src/config.ts` — static configuration (URLs, OAuth, beta parameters)
+- `src/plugins/auth.ts` — preHandler for API-key authentication
+
+**Routing (`src/routes/`):**
+- `openai.ts` — main router: determines provider by model (MiniMax → mapped → Claude). Branch order matters and must stay consistent.
+- `anthropic.ts` — direct proxy to Anthropic API with OAuth token
+- `analytics.ts`, `auth.ts`, `health.ts`, `models.ts`, `settings.ts`
+
+**Provider selection (`src/orchestration/openai/model-routing.ts`):**
+- MiniMax: model name prefix or `model_mappings` entry pointing to MiniMax upstream
+- OpenAI-mapped: `model_mappings` entry pointing to OpenAI (ChatGPT Codex)
+- Claude (Anthropic): default fallback path
+- Each model ID maps to one provider (configured per-row in `model_mappings`), not a global setting.
+
+**Proxy clients (`src/proxy/`):**
+- `anthropic-client.ts` — requests to Anthropic Claude Code API via OAuth. Tool name mapping (Cursor → Claude Code), 401 retry with token refresh, 400 error diagnostics, logging for rare `illegal value` errors
+- `openai-client.ts` — requests to ChatGPT Codex API (`/responses`). Streaming format converter for both `function_call` and `custom_tool_call` variants
+- `minimax-client.ts` — requests to MiniMax API
+- `proxy-client.ts` — wrapper
+- `tool-mapper.ts` — bidirectional tool name mapping (Cursor ↔ Claude Code)
+- `request-builder.ts` — request body preparation for Claude Code (headers, stainless headers, beta params)
+
+**OpenAI orchestration (`src/orchestration/openai/`):**
+- `model-routing.ts` — provider determination by model ID
+- `provider-handlers/` — handlers for Claude, OpenAI, MiniMax
+- `streaming-gateway.ts` — stream management
+- `error-mapper.ts`, `error-messages.ts` — error mapping to OpenAI format
+
+**Adapters (`src/adapter/`):**
+- `anthropic-to-openai.ts` — Anthropic response → OpenAI format conversion (including streaming tool calls)
+- `openai-to-anthropic.ts` — OpenAI request → Anthropic conversion
+- `xml-tool-parser.ts` — XML tool use parsing
+
+**Streaming (`src/streaming/`):**
+- `openai-stream-handler.ts` — reverse tool name mapping in streams
+- `minimax-stream-handler.ts` — MiniMax streaming with `<think>`/`</think>` tag parsing (split tags across chunks via `pendingTag` state)
+
+**Codex responses (`src/proxy/responses-stream-mapper/`):**
+- SSE stream parsing from ChatGPT Codex `/responses` into OpenAI chat.completion.chunk
+- Handles both streaming variants: `function_call` + `response.function_call_arguments.*` and `custom_tool_call` + `response.custom_tool_call_input.*`
+- `stream-state.ts`, `stream-openai-chunks.ts`, `responses-event-router.ts`, `stream-assistant-text.ts`, `process-responses-chunk.ts`, `stream-diagnostics.ts`
+
+**Codex input normalization (`src/proxy/responses-input-normalizer/`):**
+- OpenAI chat completion → Codex `/responses` payload transformation
+- `input-shape.ts`, `build-body.ts`, `input-text.ts`, `resolve-model.ts`, `types.ts`
+
+**Database (`src/database/`):**
+- SQLite via Drizzle ORM + better-sqlite3
+- Tables: `app_settings` (port, apiKey, quiet, extraInstruction), `provider_settings` (per-provider OAuth tokens, refresh tokens, expiry), `model_mappings` (id, label, provider, upstreamModel, reasoningBudget), `requests` (analytics)
+- Migrations: `apps/api/drizzle/` — idempotent (`CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`)
+
+**Types (`src/types/`):**
+- `openai.ts`, `anthropic.ts`, `anthropic-stream.ts`, `proxy.ts`, `auth.ts`
+
+**Tools (`src/tools/`):**
+- `translator.ts` — tool name translation in responses
+- `normalizer.ts` — parameter normalization (string→array)
+
+**Metrics (`src/metrics/`):**
+- `completion-request-telemetry.ts` — request recording, response headers
+- `index.ts` — barrel export
+
+**Auth (`src/auth/`):**
+- OAuth PKCE flow for Anthropic: `startLogin()` generates verifier/challenge, `completeLogin()` exchanges code for tokens. Manual `CODE#STATE` entry required (Anthropic rejects localhost redirect_uri for claude.ai OAuth).
+
+## apps/extension — VS Code extension
+
+User entry point. Manages the API server and tunnel lifecycle.
+
+- `extension.ts` — activate/deactivate
+- `extension-controller.ts` — main controller: manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
+- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex
+- `tunnel-manager.ts` — Cloudflare tunnel (cloudflared) management. Quick tunnel only, no named tunnel config (avoids 404 conflicts). Not auto-started, only on explicit user action. Auto-restarts on port change if already running
+- `dashboard.ts` — WebView dashboard (Svelte UI). Reads `index.html` from `web/dist/`, rewrites `/assets/` to `vscode-resource:` URIs, injects `window.__PORT__`. Handshake: frontend sends `webview-ready` before extension sends initial state
+- `extension-status-bar.ts` — status bar (API + tunnel state)
+- `extension-commands.ts` — command registration (openDashboard, copyTunnelUrl, restartTunnel, toggleKeyFix)
+- `openai-key-fix.ts` — auto-enable OpenAI API Key in Cursor settings. Uses `aiSettings.usingOpenAIKey.toggle` command. SQLite writes to `state.vscdb` do not work — Cursor does not re-read reactive storage
+- `runtime-state/` — multi-window coordination via file-based state. Windows heartbeat, leader election, command queue
+
+**Native dependencies:**
+- better-sqlite3: prebuilt binary downloaded at first run from GitHub Releases matching host Node ABI (not Electron). VSIX ships only JS wrapper + bindings
+- cloudflared: binary downloaded to `~/.ungate/bin/`, managed by tsup bundling
+
+**Logs:**
+- Two ring buffers (500 entries each): API (stdout/stderr) and tunnel (stderr)
+- Health check against `/health` every second, three states: running, stopped, error
+
+## apps/web — Svelte Web UI
+
+Dashboard for managing providers, tunnel, settings.
+
+- Svelte 5 (runes), SvelteKit-like structure
+- `src/shared/api.ts` — HTTP client to API
+- `src/shared/vscode.ts` — `acquireVsCodeApi()` singleton
+- `src/features/settings/` — settings and providers (settings-store, settings-ui-store, provider-store)
+- `src/features/tunnel/` — tunnel management (tunnel-store)
+- `src/features/analytics/` — request statistics (analytics-store)
+- `src/features/logs/` — log viewer (logs-store)
+
+## packages/shared — shared library
+
+Types, constants, Zod schemas, helpers.
+
+- `src/types/` — `settings.ts`, `runtime.ts`, `tunnel.ts`, `analytics.ts`, `log.ts`
+- `src/constants/` — `routes.ts`
+- `src/enums/` — `common.ts`
+- `src/helpers/` — `model-provider.ts`, `provider-labels.ts`, `utils.ts`
+- `src/schemas/` — `runtime.ts`
+- `src/guards/` — `settings.ts`
+- Two entry points: `index.ts` (server-side) and `frontend.ts` (browser-safe subset)
+
+## Key mechanisms
+
+**Claude OAuth authentication:** acquires token via Anthropic OAuth PKCE flow, stores in SQLite. Refreshes token on 401. Anthropic requires exact request fingerprint: `?beta=true` URL suffix, `User-Agent: claude-cli/2.1.9`, full `x-stainless-*` headers, `anthropic-dangerous-direct-browser-access: true`, three `anthropic-beta` feature flags (oauth, claude-code, interleaved-thinking). Manual `CODE#STATE` entry required — Anthropic does not accept localhost as redirect_uri for claude.ai OAuth.
+
+**System prompt conflict:** Claude Code's system prompt describing tools conflicts with Cursor's actual `input_schema`. The prompt must be minimal (just identity) and delegate tool shape to `input_schema`. The `extraInstruction` field in `app_settings` reinforces this priority. Full removal breaks API contract (empty blocks error), long prompts cause `invalid arguments` on large plans.
+
+**Tool mapping:** Cursor tool names (Shell, LS, StrReplace) are mapped to Claude Code names (Bash, Glob, Edit) on outbound requests and reverse-mapped in responses. Required for Anthropic OAuth whitelist — Anthropic validates tool names server-side and only allows standard Claude Code names. Mapping covers: Bash↔Shell, Read↔Read, Write↔Write, Edit↔StrReplace, Edit↔Delete, Glob↔LS, Grep↔Grep, WebFetch↔WebFetch, WebSearch↔WebSearch.
+
+**Multi-window:** multiple Cursor windows sync via a file-based runtime state in `~/.ungate/`. One window is the leader (runs the API), others read state. Heartbeat-based liveness, command queue for coordinated actions (start/restart/stop tunnel, restart API). Tunnel owner window handles tunnel lifecycle.
+
+**OpenAI Key Fix:** Cursor periodically resets the OpenAI API Key field in settings. Ungate automatically restores it via `aiSettings.usingOpenAIKey.toggle` command. Direct SQLite writes to `state.vscdb` do not work — Cursor never re-reads reactive storage. Only the leader window runs the fix loop, state is shared via runtime state file.
+
+**Codex streaming variants:** ChatGPT Codex `/responses` has two tool streaming formats — classic `function_call` + `response.function_call_arguments.*` and extended `custom_tool_call` + `response.custom_tool_call_input.*`. Both must be mapped to OpenAI `tool_calls`. Stream mapper processes both. OmniRoute only handles `function_call` — `custom_tool_call` is Ungate-specific.
+
+**MiniMax reasoning:** MiniMax M2.7 streams `<think>`/`</think>` tags as reasoning content. Split tags across chunks are reassembled via `pendingTag` state in `minimax-stream-handler.ts`. Cursor renders this as collapsed "Planning next moves" (non-expandable). Non-streaming responses use `【 Reasoning: ... 】` / `<output>` format (separate parser, not yet implemented).
+
+**Cursor architectural constraint:** Requests go through Cursor backend (`api2.cursor.sh`), not from the local machine. This means localhost never works as OpenAI Base URL — a public tunnel is always required. Cursor 3.0 regression: built-in model names can bypass the custom base URL entirely, requiring custom model IDs from Ungate's model registry.

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,3 +1,6 @@
 import { startServer } from './server';
 
-startServer().catch(console.error);
+startServer().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { isModelMappingProvider, isReasoningBudgetTier, type AppSettings } from '@ungate/shared';
 
 import { Settings } from '../database/app-settings';
+import { logger } from '../utils/logger';
 
 import type { FastifyPluginCallback } from 'fastify';
 
@@ -20,7 +21,7 @@ const ModelMappingUpdateSchema = z
 			z.string().refine((value) => isReasoningBudgetTier(value), { message: 'Invalid reasoningBudget' })
 		])
 	})
-	.strict();
+	.strip();
 
 const SettingsUpdateSchema = z
 	.object({
@@ -30,7 +31,7 @@ const SettingsUpdateSchema = z
 		extraInstruction: z.union([z.string(), z.null()]).optional(),
 		models: z.array(ModelMappingUpdateSchema).optional()
 	})
-	.strict();
+	.strip();
 
 function validateSettingsUpdate(payload: unknown): { ok: true; value: Partial<AppSettings> } | { ok: false; error: string } {
 	const result = SettingsUpdateSchema.safeParse(payload);
@@ -56,6 +57,8 @@ const plugin: FastifyPluginCallback = (app) => {
 		const validation = validateSettingsUpdate(request.body);
 
 		if (!validation.ok) {
+			logger.error(`Settings update failed: ${validation.error}`);
+
 			return reply.code(400).send({ ok: false, error: validation.error });
 		}
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -15,7 +15,10 @@ import openaiPlugin from './routes/openai';
 import settingsPlugin from './routes/settings';
 
 export async function startServer(): Promise<void> {
+	globalThis.console.log('[startup] getDb...');
 	getDb();
+
+	globalThis.console.log('[startup] Settings.get...');
 	const settings = Settings.get();
 	const config = getConfig(settings);
 	setQuietMode(config.quietMode);
@@ -23,8 +26,10 @@ export async function startServer(): Promise<void> {
 	const app = Fastify({ logger: false });
 	app.decorate('config', config);
 
+	globalThis.console.log('[startup] register cors...');
 	await app.register(cors, { origin: '*' });
 
+	globalThis.console.log('[startup] register plugins...');
 	await app.register(healthPlugin);
 	await app.register(authPlugin);
 	await app.register(anthropicPlugin);
@@ -32,6 +37,8 @@ export async function startServer(): Promise<void> {
 	await app.register(modelsPlugin);
 	await app.register(analyticsPlugin);
 	await app.register(settingsPlugin);
+
+	globalThis.console.log(`[startup] listen ${config.port}...`);
 	await app.listen({ port: config.port, host: '0.0.0.0' });
 
 	// Always print port to stdout — extension parses this to detect the running port.

--- a/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
+++ b/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
@@ -41,6 +41,43 @@ describe('routes: health/settings/models/analytics', () => {
 		await app.close();
 	});
 
+	it('strips unknown fields from model payload and saves successfully', async () => {
+		settingsUpdateMock.mockReturnValueOnce(undefined);
+
+		const app = await withPlugin(settingsPlugin);
+		const res = await app.inject({
+			method: 'POST',
+			url: '/settings',
+			payload: {
+				models: [
+					{
+						id: 'test-model',
+						label: 'Test Model',
+						provider: 'claude',
+						upstreamModel: 'claude-test-model',
+						sortOrder: 0,
+						reasoningBudget: null,
+						enabled: true
+					}
+				]
+			}
+		});
+		expect(res.statusCode).toBe(200);
+		expect(settingsUpdateMock).toHaveBeenCalledWith({
+			models: [
+				{
+					id: 'test-model',
+					label: 'Test Model',
+					provider: 'claude',
+					upstreamModel: 'claude-test-model',
+					sortOrder: 0,
+					reasoningBudget: null
+				}
+			]
+		});
+		await app.close();
+	});
+
 	it('settings get and post delegate to Settings', async () => {
 		settingsGetMock.mockReturnValueOnce({
 			port: 4783,

--- a/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
+++ b/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import settingsPlugin from 'src/routes/settings';
+
+import { withPlugin } from '../test-harness';
+
+describe('routes: settings (real database)', () => {
+	it('strips unknown fields and saves model to database', async () => {
+		const app = await withPlugin(settingsPlugin);
+
+		const postRes = await app.inject({
+			method: 'POST',
+			url: '/settings',
+			payload: {
+				quiet: false,
+				models: [
+					{
+						id: 'my-custom-model',
+						label: 'My Custom Model',
+						provider: 'claude',
+						upstreamModel: 'claude-sonnet-4-7',
+						sortOrder: 0,
+						reasoningBudget: null,
+						enabled: true
+					}
+				]
+			}
+		});
+		expect(postRes.statusCode).toBe(200);
+
+		const getRes = await app.inject({ method: 'GET', url: '/settings' });
+		expect(getRes.statusCode).toBe(200);
+
+		const body = getRes.json();
+		const saved = body.models.find((m: { id: string }) => m.id === 'my-custom-model');
+
+		expect(saved).toBeDefined();
+		expect(saved).not.toHaveProperty('enabled');
+
+		await app.close();
+	});
+});

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.4 - 2026-07-27
+
+- Fix adding custom models from dashboard returning 400
+- Fix native binding loading failure on first run after upgrade
+- Show API error details in dashboard when saving settings fails
+
 ## 1.7.3 - 2026-06-25
 
 - Fix Anthropic provider errors with non-JSON bodies so upstream failures return a normal error response instead of crashing the API

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "ungate",
 	"displayName": "Ungate",
 	"description": "Use Claude, GPT, or MiniMax subscriptions in Cursor instead of paying for API tokens",
-	"version": "1.7.3",
+	"version": "1.7.4",
 	"publisher": "orchidfiles",
 	"license": "MIT",
 	"pricing": "Free",

--- a/apps/extension/src/api-server.ts
+++ b/apps/extension/src/api-server.ts
@@ -195,7 +195,7 @@ export class ApiServer {
 
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
-			UNGATE_BETTER_SQLITE3_NATIVE_BINDING: BetterSqlite3Installer.getInstalledBinaryPath(cwd),
+			UNGATE_BETTER_SQLITE3_NATIVE_BINDING: BetterSqlite3Installer.resolveBindingPath(cwd),
 			...(isDev ? { DB_PATH: path.join(os.homedir(), '.ungate', 'data-dev.db') } : { DRIZZLE_PATH: path.join(cwd, 'drizzle') })
 		};
 

--- a/apps/extension/src/utils/better-sqlite3-installer.ts
+++ b/apps/extension/src/utils/better-sqlite3-installer.ts
@@ -47,6 +47,13 @@ export class BetterSqlite3Installer {
 		return installedBinaryPath;
 	}
 
+	static resolveBindingPath(apiDir: string): string {
+		const installed = this.getInstalledBinaryPath(apiDir);
+		if (fs.existsSync(installed)) return installed;
+
+		return this.getBinaryPath(apiDir);
+	}
+
 	static async ensureInstalled(apiDir: string, runtime: string, callbacks: InstallCallbacks): Promise<void> {
 		if (RuntimeStateStore.isApiStartSuppressed()) {
 			const runtimeState = RuntimeStateStore.read();

--- a/apps/extension/tests/unit/api-server-health-check.test.ts
+++ b/apps/extension/tests/unit/api-server-health-check.test.ts
@@ -67,6 +67,9 @@ vi.mock('../../src/utils/better-sqlite3-installer', () => {
 			ensureInstalled: (...args: unknown[]) => ensureInstalledMock(...args),
 			getInstalledBinaryPath: vi.fn(
 				() => '/tmp/ungate-extension/bundled/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node'
+			),
+			resolveBindingPath: vi.fn(
+				() => '/tmp/ungate-extension/bundled/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node'
 			)
 		}
 	};

--- a/apps/web/src/features/settings/ModelsSection.svelte
+++ b/apps/web/src/features/settings/ModelsSection.svelte
@@ -18,9 +18,10 @@ interface Props {
 	saving: boolean;
 	saved: boolean;
 	restarting: boolean;
+	error: string | null;
 }
 
-let { selectedProvider, models, onModelsChange, onSave, saving, saved, restarting }: Props = $props();
+let { selectedProvider, models, onModelsChange, onSave, saving, saved, restarting, error }: Props = $props();
 
 let copiedId = $state<string | null>(null);
 let confirmDeleteModelId = $state<string | null>(null);
@@ -94,8 +95,7 @@ function addModel() {
 			provider: selectedProvider,
 			upstreamModel: '',
 			sortOrder: models.length,
-			reasoningBudget: null,
-			enabled: true
+			reasoningBudget: null
 		}
 	]);
 
@@ -216,6 +216,12 @@ $effect(() => {
 			</button>
 		</div>
 	</div>
+
+	{#if error}
+		<div class="card preset-tonal-error p-3 text-sm">
+			{error}
+		</div>
+	{/if}
 
 	<div class="space-y-3">
 		{#if visibleModels().length === 0}

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -213,6 +213,7 @@ $effect(() => {
 			<ModelsSection
 				selectedProvider={uiStore.selectedProvider}
 				models={models}
+				error={store.error}
 				onSave={handleSaveWithoutRestart}
 				saving={store.saving}
 				saved={store.saved}

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -85,7 +85,13 @@ export class Api {
 		});
 
 		if (!response.ok) {
-			throw new Error(`POST ${path} failed: ${response.status}`);
+			let detail = '';
+			try {
+				const body = (await response.json()) as { error?: string };
+				detail = body.error ?? '';
+			} catch {}
+
+			throw new Error(`POST ${path} failed: ${response.status}${detail ? ` — ${detail}` : ''}`);
 		}
 
 		return response.json() as Promise<T>;


### PR DESCRIPTION
- POST /settings no longer rejects unknown fields, fixing 400 when adding custom models
- BetterSqlite3Installer.resolveBindingPath() falls back to default binary path when .installed file is missing
- Dashboard shows inline server error when saving settings fails
- Integration test covering real DB path with unknown field stripping