### PR TITLE
Add GPT-5.6 model tiers and preserve dashboard state

### DIFF
--- a/apps/api/drizzle/_0007.sql
+++ b/apps/api/drizzle/_0007.sql
@@ -1,0 +1,44 @@
+-- Migration 0007: add GPT-5.6 OpenAI model mappings
+ALTER TABLE model_mappings ADD COLUMN service_tier text;
+--> statement-breakpoint
+WITH candidates(id, label, provider, upstream_model, reasoning_budget, service_tier, sort_offset) AS (
+	VALUES
+		('gpt-5.6-luna-medium', 'GPT-5.6 Luna Medium', 'openai', 'gpt-5.6-luna', 'medium', 'default', 1),
+		('gpt-5.6-luna-fast-medium', 'GPT-5.6 Luna Fast Medium', 'openai', 'gpt-5.6-luna', 'medium', 'priority', 2),
+		('gpt-5.6-terra-medium', 'GPT-5.6 Terra Medium', 'openai', 'gpt-5.6-terra', 'medium', 'default', 3),
+		('gpt-5.6-terra-fast-medium', 'GPT-5.6 Terra Fast Medium', 'openai', 'gpt-5.6-terra', 'medium', 'priority', 4),
+		('gpt-5.6-sol-medium', 'GPT-5.6 Sol Medium', 'openai', 'gpt-5.6-sol', 'medium', 'default', 5),
+		('gpt-5.6-sol-fast-medium', 'GPT-5.6 Sol Fast Medium', 'openai', 'gpt-5.6-sol', 'medium', 'priority', 6)
+),
+base_sort_order(value) AS (
+	SELECT COALESCE(MAX(sort_order), -1)
+	FROM model_mappings
+),
+resolved_candidates AS (
+	SELECT
+		candidate.id,
+		candidate.label,
+		candidate.provider,
+		candidate.upstream_model,
+		(SELECT value FROM base_sort_order) + candidate.sort_offset AS sort_order,
+		candidate.reasoning_budget,
+		candidate.service_tier
+	FROM candidates AS candidate
+)
+INSERT OR IGNORE INTO model_mappings (id, label, provider, upstream_model, sort_order, reasoning_budget, service_tier)
+SELECT candidate.id, candidate.label, candidate.provider, candidate.upstream_model, candidate.sort_order, candidate.reasoning_budget, candidate.service_tier
+FROM resolved_candidates AS candidate
+WHERE NOT EXISTS (
+	SELECT 1
+	FROM model_mappings AS existing
+	WHERE existing.provider = candidate.provider
+		AND existing.upstream_model = candidate.upstream_model
+		AND (
+			existing.reasoning_budget = candidate.reasoning_budget
+			OR (existing.reasoning_budget IS NULL AND candidate.reasoning_budget IS NULL)
+		)
+		AND (
+			existing.service_tier = candidate.service_tier
+			OR (existing.service_tier IS NULL AND candidate.service_tier = 'default')
+		)
+);

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1782345600000,
       "tag": "_0006",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1785283200000,
+      "tag": "_0007",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/drizzle/meta/_snapshot.json
+++ b/apps/api/drizzle/meta/_snapshot.json
@@ -155,6 +155,13 @@
           "primaryKey": false,
           "notNull": false,
           "autoincrement": false
+        },
+        "service_tier": {
+          "name": "service_tier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
         }
       },
       "indexes": {},

--- a/apps/api/src/database/model-mappings.ts
+++ b/apps/api/src/database/model-mappings.ts
@@ -2,9 +2,11 @@ import { cloneDeep, orderBy, trim } from 'lodash-es';
 
 import {
 	isModelMappingProvider,
+	isModelServiceTier,
 	isReasoningBudgetTier,
 	type ModelMappingConfig,
 	type ModelMappingProvider,
+	type ModelServiceTier,
 	type ReasoningBudgetTier
 } from '@ungate/shared';
 
@@ -25,6 +27,7 @@ export class ModelMappings {
 			const trimmedLabel = trim(model.label);
 			const trimmedUpstreamModel = trim(model.upstreamModel);
 			let reasoningBudget: ReasoningBudgetTier | null = null;
+			let serviceTier: ModelServiceTier | null = null;
 			let provider: ModelMappingProvider = 'claude';
 
 			if (isModelMappingProvider(model.provider)) {
@@ -33,6 +36,10 @@ export class ModelMappings {
 
 			if (isReasoningBudgetTier(model.reasoningBudget)) {
 				reasoningBudget = model.reasoningBudget;
+			}
+
+			if (isModelServiceTier(model.serviceTier)) {
+				serviceTier = model.serviceTier;
 			}
 
 			if (!trimmedId || !trimmedLabel || !trimmedUpstreamModel) {
@@ -45,7 +52,8 @@ export class ModelMappings {
 				provider,
 				upstreamModel: trimmedUpstreamModel,
 				sortOrder: index,
-				reasoningBudget
+				reasoningBudget,
+				serviceTier
 			});
 		}
 
@@ -63,7 +71,8 @@ export class ModelMappings {
 				provider: isModelMappingProvider(row.provider) ? row.provider : 'claude',
 				upstreamModel: row.upstreamModel,
 				sortOrder: row.sortOrder,
-				reasoningBudget: isReasoningBudgetTier(row.reasoningBudget) ? row.reasoningBudget : null
+				reasoningBudget: isReasoningBudgetTier(row.reasoningBudget) ? row.reasoningBudget : null,
+				serviceTier: isModelServiceTier(row.serviceTier) ? row.serviceTier : null
 			})),
 			['sortOrder'],
 			['asc']
@@ -122,7 +131,8 @@ export class ModelMappings {
 						provider: model.provider,
 						upstreamModel: model.upstreamModel,
 						sortOrder: model.sortOrder,
-						reasoningBudget: model.reasoningBudget
+						reasoningBudget: model.reasoningBudget,
+						serviceTier: model.serviceTier
 					})
 					.run();
 			}

--- a/apps/api/src/database/pricing.ts
+++ b/apps/api/src/database/pricing.ts
@@ -4,6 +4,11 @@ interface ModelPricing {
 }
 
 const MODEL_PRICING: Record<string, ModelPricing> = {
+	'gpt-5.6-sol': { inputPerMTok: 5.0, outputPerMTok: 30.0 },
+	'gpt-5.6-terra': { inputPerMTok: 2.5, outputPerMTok: 15.0 },
+	'gpt-5.6-luna': { inputPerMTok: 1.0, outputPerMTok: 6.0 },
+	'gpt-5.6': { inputPerMTok: 5.0, outputPerMTok: 30.0 },
+
 	'claude-opus-4-8': { inputPerMTok: 5.0, outputPerMTok: 25.0 },
 	'claude-opus-4-7': { inputPerMTok: 5.0, outputPerMTok: 25.0 },
 	'claude-opus-4-6': { inputPerMTok: 5.0, outputPerMTok: 25.0 },

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -27,7 +27,8 @@ export const modelMappings = sqliteTable('model_mappings', {
 	provider: text().notNull(),
 	upstreamModel: text().notNull(),
 	sortOrder: integer().notNull().default(0),
-	reasoningBudget: text()
+	reasoningBudget: text(),
+	serviceTier: text()
 });
 
 export const requests = sqliteTable('requests', {

--- a/apps/api/src/orchestration/openai/model-routing.ts
+++ b/apps/api/src/orchestration/openai/model-routing.ts
@@ -51,17 +51,23 @@ export class CompletionModelRouting {
 			...openaiBody,
 			model: resolved.upstreamModel
 		};
+		const withServiceTier: OpenAIChatRequest = resolved.serviceTier
+			? {
+					...withModel,
+					service_tier: resolved.serviceTier
+				}
+			: withModel;
 
 		if (resolved.reasoningBudget) {
 			const withReasoning: OpenAIChatRequest = {
-				...withModel,
+				...withServiceTier,
 				reasoning: { effort: resolved.reasoningBudget }
 			};
 
 			return withReasoning;
 		}
 
-		return withModel;
+		return withServiceTier;
 	}
 
 	static toAnthropicRequest(

--- a/apps/api/src/proxy/responses-input-normalizer/build-body.ts
+++ b/apps/api/src/proxy/responses-input-normalizer/build-body.ts
@@ -59,6 +59,10 @@ export class ResponsesBodyBuilder {
 			store: false
 		};
 
+		if (body.service_tier) {
+			payload.service_tier = body.service_tier;
+		}
+
 		if (options.extraInstruction?.trim()) {
 			payload.instructions = options.extraInstruction.trim();
 		} else if (options.envInstructions?.trim()) {

--- a/apps/api/src/proxy/responses-input-normalizer/resolve-model.ts
+++ b/apps/api/src/proxy/responses-input-normalizer/resolve-model.ts
@@ -50,7 +50,7 @@ export class ResponsesModelResolver {
 	}
 
 	private static resolveReasoningSuffix(model: string): ResolvedChatGptModel | null {
-		const effortLevels: CodexReasoningEffort[] = ['none', 'low', 'medium', 'high', 'xhigh'];
+		const effortLevels: CodexReasoningEffort[] = ['none', 'low', 'medium', 'high', 'xhigh', 'max'];
 
 		for (const effort of effortLevels) {
 			if (model.endsWith(`-${effort}`)) {

--- a/apps/api/src/proxy/responses-input-normalizer/types.ts
+++ b/apps/api/src/proxy/responses-input-normalizer/types.ts
@@ -1,4 +1,4 @@
-export type CodexReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+export type CodexReasoningEffort = 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export interface ResolvedChatGptModel {
 	model: string;

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { isModelMappingProvider, isReasoningBudgetTier, type AppSettings } from '@ungate/shared';
+import { isModelMappingProvider, isModelServiceTier, isReasoningBudgetTier, type AppSettings } from '@ungate/shared';
 
 import { Settings } from '../database/app-settings';
 import { logger } from '../utils/logger';
@@ -19,7 +19,10 @@ const ModelMappingUpdateSchema = z
 		reasoningBudget: z.union([
 			z.null(),
 			z.string().refine((value) => isReasoningBudgetTier(value), { message: 'Invalid reasoningBudget' })
-		])
+		]),
+		serviceTier: z
+			.union([z.null(), z.string().refine((value) => isModelServiceTier(value), { message: 'Invalid serviceTier' })])
+			.default(null)
 	})
 	.strip();
 

--- a/apps/api/src/types/openai.ts
+++ b/apps/api/src/types/openai.ts
@@ -48,11 +48,12 @@ export interface OpenAIChatRequest {
 	presence_penalty?: number;
 	frequency_penalty?: number;
 	user?: string;
+	service_tier?: 'default' | 'priority';
 	tools?: OpenAITool[];
 	tool_choice?: 'none' | 'auto' | 'required' | { type: 'function'; function: { name: string } };
-	reasoning_effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+	reasoning_effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 	reasoning?: {
-		effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh';
+		effort?: 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 	};
 }
 

--- a/apps/api/tests/integration/database/database-app-settings.test.ts
+++ b/apps/api/tests/integration/database/database-app-settings.test.ts
@@ -13,7 +13,8 @@ describe('database-app-settings', () => {
 				provider: 'claude' as const,
 				upstreamModel: 'claude-test-default-model',
 				sortOrder: 0,
-				reasoningBudget: null
+				reasoningBudget: null,
+				serviceTier: null
 			}
 		];
 		ModelMappings.replace(expectedModels);
@@ -32,7 +33,8 @@ describe('database-app-settings', () => {
 			provider: 'claude' as const,
 			upstreamModel: 'u',
 			sortOrder: 0,
-			reasoningBudget: null
+			reasoningBudget: null,
+			serviceTier: null
 		};
 
 		Settings.update({

--- a/apps/api/tests/integration/database/database-model-mappings.test.ts
+++ b/apps/api/tests/integration/database/database-model-mappings.test.ts
@@ -11,7 +11,8 @@ describe('database-model-mappings', () => {
 				provider: 'openai',
 				upstreamModel: ' gpt-5.4 ',
 				sortOrder: 0,
-				reasoningBudget: 'high'
+				reasoningBudget: 'max',
+				serviceTier: 'priority'
 			},
 			{
 				id: ' ',
@@ -19,7 +20,8 @@ describe('database-model-mappings', () => {
 				provider: 'claude',
 				upstreamModel: 'x',
 				sortOrder: 1,
-				reasoningBudget: null
+				reasoningBudget: null,
+				serviceTier: null
 			}
 		]);
 
@@ -30,7 +32,8 @@ describe('database-model-mappings', () => {
 			provider: 'openai',
 			upstreamModel: 'gpt-5.4',
 			sortOrder: 0,
-			reasoningBudget: 'high'
+			reasoningBudget: 'max',
+			serviceTier: 'priority'
 		});
 	});
 
@@ -42,7 +45,8 @@ describe('database-model-mappings', () => {
 				provider: 'claude',
 				upstreamModel: 'claude-sonnet-4-6',
 				sortOrder: 2,
-				reasoningBudget: null
+				reasoningBudget: null,
+				serviceTier: null
 			},
 			{
 				id: 'second',
@@ -50,7 +54,8 @@ describe('database-model-mappings', () => {
 				provider: 'claude',
 				upstreamModel: 'claude-second',
 				sortOrder: 3,
-				reasoningBudget: null
+				reasoningBudget: null,
+				serviceTier: null
 			}
 		]);
 

--- a/apps/api/tests/integration/database/database-pricing.test.ts
+++ b/apps/api/tests/integration/database/database-pricing.test.ts
@@ -4,6 +4,9 @@ import { Pricing } from 'src/database/pricing';
 
 describe('database-pricing', () => {
 	it('matches pricing by exact id and prefix', () => {
+		expect(Pricing.getModel('gpt-5.6-sol')).toEqual({ inputPerMTok: 5.0, outputPerMTok: 30.0 });
+		expect(Pricing.getModel('gpt-5.6-terra')).toEqual({ inputPerMTok: 2.5, outputPerMTok: 15.0 });
+		expect(Pricing.getModel('gpt-5.6-luna')).toEqual({ inputPerMTok: 1.0, outputPerMTok: 6.0 });
 		expect(Pricing.getModel('claude-sonnet-4-6')).toEqual({ inputPerMTok: 3.0, outputPerMTok: 15.0 });
 		expect(Pricing.getModel('claude-sonnet-4-6-20250514')).toEqual({ inputPerMTok: 3.0, outputPerMTok: 15.0 });
 		expect(Pricing.getModel('unknown-model')).toEqual({ inputPerMTok: 3.0, outputPerMTok: 15.0 });

--- a/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
+++ b/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
@@ -57,6 +57,7 @@ describe('routes: health/settings/models/analytics', () => {
 						upstreamModel: 'claude-test-model',
 						sortOrder: 0,
 						reasoningBudget: null,
+						serviceTier: null,
 						enabled: true
 					}
 				]
@@ -71,7 +72,8 @@ describe('routes: health/settings/models/analytics', () => {
 					provider: 'claude',
 					upstreamModel: 'claude-test-model',
 					sortOrder: 0,
-					reasoningBudget: null
+					reasoningBudget: null,
+					serviceTier: null
 				}
 			]
 		});

--- a/apps/api/tests/integration/routes/routes-openai.test.ts
+++ b/apps/api/tests/integration/routes/routes-openai.test.ts
@@ -99,7 +99,8 @@ describe('routes-openai', () => {
 		resolveForChatCompletionMock.mockReturnValueOnce({
 			provider: 'openai',
 			upstreamModel: 'gpt-up',
-			reasoningBudget: null
+			reasoningBudget: null,
+			serviceTier: null
 		});
 		proxyOpenAIRequestMock.mockResolvedValueOnce({
 			response: new Response(JSON.stringify({ error: { message: 'upstream failed' } }), { status: 429 }),
@@ -124,7 +125,8 @@ describe('routes-openai', () => {
 		resolveForChatCompletionMock.mockReturnValueOnce({
 			provider: 'openai',
 			upstreamModel: 'gpt-up',
-			reasoningBudget: 'high'
+			reasoningBudget: 'high',
+			serviceTier: 'priority'
 		});
 		proxyOpenAIRequestMock.mockResolvedValueOnce({
 			response: new Response(JSON.stringify({ id: 'chatcmpl-ok', choices: [{ message: { content: 'done' } }] }), {
@@ -157,7 +159,8 @@ describe('routes-openai', () => {
 		expect(proxyOpenAIRequestMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				model: 'gpt-up',
-				reasoning: { effort: 'high' }
+				reasoning: { effort: 'high' },
+				service_tier: 'priority'
 			}),
 			'openai'
 		);
@@ -320,7 +323,8 @@ describe('routes-openai', () => {
 		resolveForChatCompletionMock.mockReturnValueOnce({
 			provider: 'openai',
 			upstreamModel: 'gpt-up',
-			reasoningBudget: null
+			reasoningBudget: null,
+			serviceTier: null
 		});
 		proxyOpenAIRequestMock.mockResolvedValueOnce({
 			response: new Response(stream, {

--- a/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
+++ b/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
@@ -21,6 +21,7 @@ describe('routes: settings (real database)', () => {
 						upstreamModel: 'claude-sonnet-4-7',
 						sortOrder: 0,
 						reasoningBudget: null,
+						serviceTier: null,
 						enabled: true
 					}
 				]

--- a/apps/api/tests/unit/orchestration/openai-model-routing.test.ts
+++ b/apps/api/tests/unit/orchestration/openai-model-routing.test.ts
@@ -11,7 +11,8 @@ function mapping(partial: Partial<ModelMappingConfig> & Pick<ModelMappingConfig,
 		provider: partial.provider,
 		upstreamModel: partial.upstreamModel,
 		sortOrder: partial.sortOrder ?? 0,
-		reasoningBudget: partial.reasoningBudget ?? null
+		reasoningBudget: partial.reasoningBudget ?? null,
+		serviceTier: partial.serviceTier ?? null
 	};
 }
 
@@ -44,18 +45,25 @@ describe('CompletionModelRouting', () => {
 		expect(CompletionModelRouting.isOpenAiMapped(mapping({ provider: 'claude', upstreamModel: 'c' }))).toBe(false);
 	});
 
-	it('builds openai upstream body with optional reasoning effort', () => {
+	it('builds openai upstream body with optional reasoning effort and service tier', () => {
 		const body = { model: 'alias', messages: [], stream: false } as const;
-		const openai = mapping({ provider: 'openai', upstreamModel: 'gpt-real', reasoningBudget: 'high' });
+		const openai = mapping({
+			provider: 'openai',
+			upstreamModel: 'gpt-real',
+			reasoningBudget: 'max',
+			serviceTier: 'priority'
+		});
 		const upstream = CompletionModelRouting.buildOpenAiUpstreamBody(body as never, openai);
 
 		expect(upstream.model).toBe('gpt-real');
-		expect(upstream.reasoning).toEqual({ effort: 'high' });
+		expect(upstream.reasoning).toEqual({ effort: 'max' });
+		expect(upstream.service_tier).toBe('priority');
 
 		const noBudget = mapping({ provider: 'openai', upstreamModel: 'gpt-2', reasoningBudget: null });
 		const plain = CompletionModelRouting.buildOpenAiUpstreamBody(body as never, noBudget);
 
 		expect(plain.model).toBe('gpt-2');
 		expect('reasoning' in plain).toBe(false);
+		expect('service_tier' in plain).toBe(false);
 	});
 });

--- a/apps/api/tests/unit/proxy/proxy-responses-input-normalizer-modules.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-responses-input-normalizer-modules.test.ts
@@ -20,6 +20,21 @@ describe('proxy-responses-input-normalizer-modules', () => {
 			model: 'gpt-5.5',
 			reasoningEffort: 'xhigh'
 		});
+		expect(ResponsesModelResolver.resolveModel('gpt-5.6-sol')).toEqual({
+			model: 'gpt-5.6-sol'
+		});
+		expect(ResponsesModelResolver.resolveModel('gpt-5.6-terra-high')).toEqual({
+			model: 'gpt-5.6-terra',
+			reasoningEffort: 'high'
+		});
+		expect(ResponsesModelResolver.resolveModel('gpt-5.6-luna-xhigh')).toEqual({
+			model: 'gpt-5.6-luna',
+			reasoningEffort: 'xhigh'
+		});
+		expect(ResponsesModelResolver.resolveModel('gpt-5.6-sol-max')).toEqual({
+			model: 'gpt-5.6-sol',
+			reasoningEffort: 'max'
+		});
 	});
 
 	it('maps function tool_choice and keeps passthrough object', () => {

--- a/apps/api/tests/unit/proxy/proxy-responses-input-normalizer.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-responses-input-normalizer.test.ts
@@ -78,6 +78,7 @@ describe('proxy-responses-input-normalizer', () => {
 			{
 				model: 'gpt-5.5',
 				messages: [{ role: 'user', content: 'hello' }],
+				service_tier: 'priority',
 				tools: [
 					{
 						type: 'function',
@@ -94,6 +95,7 @@ describe('proxy-responses-input-normalizer', () => {
 			{ instructionsFallback: 'fallback', extraInstruction: '', envInstructions: '' }
 		);
 
+		expect(payload.service_tier).toBe('priority');
 		expect(payload.tools).toEqual([
 			{
 				type: 'function',

--- a/apps/web/src/App.svelte
+++ b/apps/web/src/App.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+import { onMount, tick } from 'svelte';
 import IconBarChart3 from 'virtual:icons/lucide/bar-chart-3';
 import IconSettings from 'virtual:icons/lucide/settings';
 import IconTerminal from 'virtual:icons/lucide/terminal';
@@ -6,16 +7,99 @@ import IconTerminal from 'virtual:icons/lucide/terminal';
 import AnalyticsPage from '$features/analytics/AnalyticsPage.svelte';
 import LogsPage from '$features/logs/LogsPage.svelte';
 import SettingsPage from '$features/settings/SettingsPage.svelte';
+import { type DashboardPage, getSavedPage, getSavedScrollPosition, savePage, saveScrollPosition } from '$shared/vscode';
 
-type Page = 'analytics' | 'settings' | 'logs';
+let currentPage = $state<DashboardPage>(getSavedPage());
+let restoreFrame: number | null = null;
+let restoreTimers: number[] = [];
 
-let currentPage = $state<Page>('analytics');
-
-const tabs: { id: Page; label: string; icon: typeof IconBarChart3 }[] = [
+const tabs: { id: DashboardPage; label: string; icon: typeof IconBarChart3 }[] = [
 	{ id: 'analytics', label: 'Analytics', icon: IconBarChart3 },
 	{ id: 'settings', label: 'Settings', icon: IconSettings },
 	{ id: 'logs', label: 'Logs', icon: IconTerminal }
 ];
+
+function persistCurrentScrollPosition(): void {
+	saveScrollPosition(currentPage, window.scrollY);
+}
+
+function cancelPendingScrollRestore(): void {
+	if (restoreFrame !== null) {
+		cancelAnimationFrame(restoreFrame);
+		restoreFrame = null;
+	}
+
+	for (const timer of restoreTimers) {
+		clearTimeout(timer);
+	}
+
+	restoreTimers = [];
+}
+
+async function restoreScrollPosition(page: DashboardPage): Promise<void> {
+	await tick();
+	cancelPendingScrollRestore();
+	const scrollPosition = getSavedScrollPosition(page);
+	const restore = () => {
+		if (currentPage !== page) {
+			return;
+		}
+
+		restoreFrame = requestAnimationFrame(() => {
+			window.scrollTo({ top: scrollPosition, behavior: 'auto' });
+			restoreFrame = null;
+		});
+	};
+
+	restore();
+	restoreTimers = [100, 300, 750].map((delay) => window.setTimeout(restore, delay));
+}
+
+async function selectPage(page: DashboardPage): Promise<void> {
+	persistCurrentScrollPosition();
+	currentPage = page;
+	savePage(page);
+	await restoreScrollPosition(page);
+}
+
+onMount(() => {
+	let saveFrame: number | null = null;
+
+	const onScroll = () => {
+		if (saveFrame !== null) {
+			return;
+		}
+
+		saveFrame = requestAnimationFrame(() => {
+			persistCurrentScrollPosition();
+			saveFrame = null;
+		});
+	};
+
+	const onUserScroll = () => {
+		cancelPendingScrollRestore();
+	};
+
+	window.addEventListener('scroll', onScroll, { passive: true });
+	window.addEventListener('wheel', onUserScroll, { passive: true });
+	window.addEventListener('touchstart', onUserScroll, { passive: true });
+	window.addEventListener('keydown', onUserScroll);
+	void restoreScrollPosition(currentPage);
+
+	return () => {
+		window.removeEventListener('scroll', onScroll);
+		window.removeEventListener('wheel', onUserScroll);
+		window.removeEventListener('touchstart', onUserScroll);
+		window.removeEventListener('keydown', onUserScroll);
+		persistCurrentScrollPosition();
+
+		if (saveFrame !== null) {
+			cancelAnimationFrame(saveFrame);
+		}
+
+		cancelPendingScrollRestore();
+	};
+});
 </script>
 
 <div class="min-h-screen bg-surface-950 text-surface-50">
@@ -27,7 +111,7 @@ const tabs: { id: Page; label: string; icon: typeof IconBarChart3 }[] = [
 				{#each tabs as tab}
 					<button
 						class="btn btn-sm gap-1.5 {currentPage === tab.id ? 'preset-filled-primary-500' : 'preset-tonal-surface'}"
-						onclick={() => (currentPage = tab.id)}>
+						onclick={() => void selectPage(tab.id)}>
 						<tab.icon class="size-4" />
 						{tab.label}
 					</button>

--- a/apps/web/src/features/analytics/analytics-store.svelte.ts
+++ b/apps/web/src/features/analytics/analytics-store.svelte.ts
@@ -168,6 +168,11 @@ const PROVIDER_OPTIONS: ProviderOption[] = [
 // Labels map — exact model names from DB (after normalizeModelName).
 // Dated variants are the actual stored names for 4.5 models.
 const MODEL_LABELS: Record<string, string> = {
+	// GPT-5.6 OpenAI series
+	'gpt-5.6': 'GPT-5.6',
+	'gpt-5.6-sol': 'GPT-5.6 Sol',
+	'gpt-5.6-terra': 'GPT-5.6 Terra',
+	'gpt-5.6-luna': 'GPT-5.6 Luna',
 	// 4.8 series (used as-is)
 	'claude-opus-4-8': 'Claude Opus 4.8',
 	// 4.7 series (used as-is)

--- a/apps/web/src/features/settings/ModelsSection.svelte
+++ b/apps/web/src/features/settings/ModelsSection.svelte
@@ -320,7 +320,8 @@ $effect(() => {
 						</div>
 					</div>
 
-					<div class="grid grid-cols-1 gap-4 xl:grid-cols-5 md:grid-cols-2">
+					<div
+						class="grid grid-cols-1 gap-4 {selectedProvider === 'openai' ? 'xl:grid-cols-5' : 'xl:grid-cols-4'} md:grid-cols-2">
 						<label class="label">
 							<span class="label-text text-xs">Model ID</span>
 							<input
@@ -364,22 +365,34 @@ $effect(() => {
 									<option value={option.value ?? ''}>{option.label}</option>
 								{/each}
 							</select>
+							{#if model.reasoningBudget === null}
+								<span class="text-xs text-surface-400 mt-1">No reasoning_budget sent.</span>
+							{:else if model.reasoningBudget === 'none'}
+								<span class="text-xs text-surface-400 mt-1">Only supported by GPT-5.6 models.</span>
+							{/if}
 						</label>
 
-						<label class="label">
-							<span class="label-text text-xs">Service Tier</span>
-							<select
-								class="select text-sm"
-								value={model.serviceTier ?? ''}
-								onchange={(event) => {
-									const value = selectValue(event);
-									updateModelAtIndex(index, 'serviceTier', value ? value : null);
-								}}>
-								{#each serviceTierOptions as option}
-									<option value={option.value ?? ''}>{option.label}</option>
-								{/each}
-							</select>
-						</label>
+						{#if selectedProvider === 'openai'}
+							<label class="label">
+								<span class="label-text text-xs">Service Tier</span>
+								<select
+									class="select text-sm"
+									value={model.serviceTier ?? ''}
+									onchange={(event) => {
+										const value = selectValue(event);
+										updateModelAtIndex(index, 'serviceTier', value ? value : null);
+									}}>
+									{#each serviceTierOptions as option}
+										<option value={option.value ?? ''}>{option.label}</option>
+									{/each}
+								</select>
+								{#if model.serviceTier === null}
+									<span class="text-xs text-surface-400 mt-1">No service_tier sent.</span>
+								{:else}
+									<span class="text-xs text-surface-400 mt-1">Only supported by GPT-5.6 models.</span>
+								{/if}
+							</label>
+						{/if}
 					</div>
 				</div>
 			{/if}

--- a/apps/web/src/features/settings/ModelsSection.svelte
+++ b/apps/web/src/features/settings/ModelsSection.svelte
@@ -3,6 +3,8 @@ import { getProviderLabel, sleep } from '@ungate/shared/frontend';
 import IconCopy from 'virtual:icons/lucide/copy';
 import IconTrash2 from 'virtual:icons/lucide/trash-2';
 
+import { getSavedSettingsModelId, saveSettingsModelId } from '$shared/vscode';
+
 import type { ModelMappingConfig, ModelMappingProvider } from '@ungate/shared/frontend';
 
 interface VisibleModelItem {
@@ -29,11 +31,19 @@ let confirmDeleteIndex = $state<number | null>(null);
 let activeModelIndex = $state<number | null>(null);
 
 const reasoningOptions: { label: string; value: ModelMappingConfig['reasoningBudget'] }[] = [
-	{ label: 'None', value: null },
+	{ label: 'Default', value: null },
+	{ label: 'None', value: 'none' },
 	{ label: 'Low', value: 'low' },
 	{ label: 'Medium', value: 'medium' },
 	{ label: 'High', value: 'high' },
-	{ label: 'XHigh', value: 'xhigh' }
+	{ label: 'XHigh', value: 'xhigh' },
+	{ label: 'Max', value: 'max' }
+];
+
+const serviceTierOptions: { label: string; value: ModelMappingConfig['serviceTier'] }[] = [
+	{ label: 'Default', value: null },
+	{ label: 'Normal', value: 'default' },
+	{ label: 'Fast / Priority', value: 'priority' }
 ];
 
 function withSortOrder(items: ModelMappingConfig[]): ModelMappingConfig[] {
@@ -74,6 +84,14 @@ function modelTitle(item: VisibleModelItem): string {
 	return `Model ${item.index + 1}`;
 }
 
+function modelSelectionId(item: VisibleModelItem): string {
+	return item.model.id.trim() || `#row-${item.index}`;
+}
+
+function saveActiveModel(item: VisibleModelItem): void {
+	saveSettingsModelId(selectedProvider, modelSelectionId(item));
+}
+
 function setActiveModel(index: number) {
 	if (activeModelIndex === index) {
 		activeModelIndex = null;
@@ -82,6 +100,11 @@ function setActiveModel(index: number) {
 	}
 
 	activeModelIndex = index;
+	const active = visibleModels().find((item) => item.index === index);
+
+	if (active) {
+		saveActiveModel(active);
+	}
 }
 
 function addModel() {
@@ -95,11 +118,13 @@ function addModel() {
 			provider: selectedProvider,
 			upstreamModel: '',
 			sortOrder: models.length,
-			reasoningBudget: null
+			reasoningBudget: null,
+			serviceTier: null
 		}
 	]);
 
 	activeModelIndex = nextIndex;
+	saveSettingsModelId(selectedProvider, `#row-${nextIndex}`);
 }
 
 function inputValue(event: Event): string {
@@ -123,6 +148,11 @@ function selectValue(event: Event): string {
 }
 
 function updateModelAtIndex(index: number, key: keyof ModelMappingConfig, value: string | number | null) {
+	if (key === 'id' && activeModelIndex === index) {
+		const modelId = typeof value === 'string' ? value.trim() : '';
+		saveSettingsModelId(selectedProvider, modelId || `#row-${index}`);
+	}
+
 	commit(
 		models.map((model, modelIndex) => {
 			if (modelIndex !== index) {
@@ -130,11 +160,27 @@ function updateModelAtIndex(index: number, key: keyof ModelMappingConfig, value:
 			}
 
 			if (key === 'reasoningBudget') {
-				if (value === 'low' || value === 'medium' || value === 'high' || value === 'xhigh' || value === null) {
+				if (
+					value === 'none' ||
+					value === 'low' ||
+					value === 'medium' ||
+					value === 'high' ||
+					value === 'xhigh' ||
+					value === 'max' ||
+					value === null
+				) {
 					return { ...model, reasoningBudget: value };
 				}
 
 				return { ...model, reasoningBudget: null };
+			}
+
+			if (key === 'serviceTier') {
+				if (value === 'default' || value === 'priority' || value === null) {
+					return { ...model, serviceTier: value };
+				}
+
+				return { ...model, serviceTier: null };
 			}
 
 			return { ...model, [key]: value };
@@ -189,7 +235,11 @@ $effect(() => {
 	const active = visible.find((item) => item.index === activeModelIndex);
 
 	if (!active) {
-		activeModelIndex = visible[0].index;
+		const savedModelId = getSavedSettingsModelId(selectedProvider);
+		const restored = visible.find((item) => modelSelectionId(item) === savedModelId) ?? visible[0];
+
+		activeModelIndex = restored.index;
+		saveActiveModel(restored);
 	}
 });
 </script>
@@ -270,7 +320,7 @@ $effect(() => {
 						</div>
 					</div>
 
-					<div class="grid grid-cols-1 gap-4 xl:grid-cols-4 md:grid-cols-2">
+					<div class="grid grid-cols-1 gap-4 xl:grid-cols-5 md:grid-cols-2">
 						<label class="label">
 							<span class="label-text text-xs">Model ID</span>
 							<input
@@ -311,6 +361,21 @@ $effect(() => {
 									updateModelAtIndex(index, 'reasoningBudget', value ? value : null);
 								}}>
 								{#each reasoningOptions as option}
+									<option value={option.value ?? ''}>{option.label}</option>
+								{/each}
+							</select>
+						</label>
+
+						<label class="label">
+							<span class="label-text text-xs">Service Tier</span>
+							<select
+								class="select text-sm"
+								value={model.serviceTier ?? ''}
+								onchange={(event) => {
+									const value = selectValue(event);
+									updateModelAtIndex(index, 'serviceTier', value ? value : null);
+								}}>
+								{#each serviceTierOptions as option}
 									<option value={option.value ?? ''}>{option.label}</option>
 								{/each}
 							</select>

--- a/apps/web/src/features/settings/SettingsPage.svelte
+++ b/apps/web/src/features/settings/SettingsPage.svelte
@@ -22,6 +22,7 @@ let validationError = $state<string | null>(null);
 function cloneModels(items: ModelMappingConfig[]): ModelMappingConfig[] {
 	return items.map((model, index) => {
 		let reasoningBudget = model.reasoningBudget;
+		let serviceTier = model.serviceTier;
 		let provider: ModelMappingProvider = 'claude';
 
 		if (model.provider === 'minimax') {
@@ -32,11 +33,22 @@ function cloneModels(items: ModelMappingConfig[]): ModelMappingConfig[] {
 			provider = 'openai';
 		}
 
-		if (reasoningBudget !== 'low' && reasoningBudget !== 'medium' && reasoningBudget !== 'high' && reasoningBudget !== 'xhigh') {
+		if (
+			reasoningBudget !== 'none' &&
+			reasoningBudget !== 'low' &&
+			reasoningBudget !== 'medium' &&
+			reasoningBudget !== 'high' &&
+			reasoningBudget !== 'xhigh' &&
+			reasoningBudget !== 'max'
+		) {
 			reasoningBudget = null;
 		}
 
-		return { ...model, provider, reasoningBudget, sortOrder: index };
+		if (serviceTier !== 'default' && serviceTier !== 'priority') {
+			serviceTier = null;
+		}
+
+		return { ...model, provider, reasoningBudget, serviceTier, sortOrder: index };
 	});
 }
 

--- a/apps/web/src/features/settings/settings-ui-store.svelte.ts
+++ b/apps/web/src/features/settings/settings-ui-store.svelte.ts
@@ -1,6 +1,7 @@
 import { getProviderLabel } from '@ungate/shared/frontend';
 
 import { Api } from '$shared/api';
+import { getSavedSettingsProvider, saveSettingsProvider } from '$shared/vscode';
 
 import type { ModelMappingConfig, ModelMappingProvider } from '@ungate/shared/frontend';
 
@@ -19,7 +20,7 @@ interface SettingsUiStore {
 	refreshAuthStates(): Promise<void>;
 }
 
-let selectedProvider = $state<ModelMappingProvider>('claude');
+let selectedProvider = $state<ModelMappingProvider>(getSavedSettingsProvider());
 
 function createAuthStates(state: ProviderAuthState): Record<ModelMappingProvider, ProviderAuthState> {
 	return {
@@ -39,6 +40,7 @@ const providerLabels: Record<ModelMappingProvider, string> = {
 
 function setSelectedProvider(provider: ModelMappingProvider): void {
 	selectedProvider = provider;
+	saveSettingsProvider(provider);
 }
 
 function getProviderModelsCount(models: ModelMappingConfig[]): (provider: ModelMappingProvider) => number {

--- a/apps/web/src/shared/vscode.ts
+++ b/apps/web/src/shared/vscode.ts
@@ -1,10 +1,94 @@
+import type { ModelMappingProvider } from '@ungate/shared/frontend';
+
+export type DashboardPage = 'analytics' | 'settings' | 'logs';
+
+interface WebviewState {
+	currentPage?: DashboardPage;
+	scrollPositions?: Partial<Record<DashboardPage, number>>;
+	selectedSettingsProvider?: ModelMappingProvider;
+	selectedSettingsModelIds?: Partial<Record<ModelMappingProvider, string>>;
+}
+
+interface VsCodeApi {
+	postMessage(message: unknown): void;
+	getState(): unknown;
+	setState(state: WebviewState): void;
+}
+
 // acquireVsCodeApi() may only be called once — singleton
 const vscodeApi = (
 	window as Window & {
-		acquireVsCodeApi?: () => { postMessage: (message: unknown) => void };
+		acquireVsCodeApi?: () => VsCodeApi;
 	}
 ).acquireVsCodeApi?.();
 
+const dashboardPages: DashboardPage[] = ['analytics', 'settings', 'logs'];
+const modelMappingProviders: ModelMappingProvider[] = ['claude', 'minimax', 'openai'];
+
+function readWebviewState(): WebviewState {
+	const state = vscodeApi?.getState();
+
+	if (!state || typeof state !== 'object') {
+		return {};
+	}
+
+	return state as WebviewState;
+}
+
+function updateWebviewState(update: Partial<WebviewState>): void {
+	vscodeApi?.setState({ ...readWebviewState(), ...update });
+}
+
 export function postExtensionMessage(message: { type: string; [key: string]: unknown }): void {
 	vscodeApi?.postMessage(message);
+}
+
+export function getSavedPage(): DashboardPage {
+	const page = readWebviewState().currentPage;
+
+	return page && dashboardPages.includes(page) ? page : 'analytics';
+}
+
+export function savePage(currentPage: DashboardPage): void {
+	updateWebviewState({ currentPage });
+}
+
+export function getSavedScrollPosition(page: DashboardPage): number {
+	const scrollPosition = readWebviewState().scrollPositions?.[page];
+
+	return typeof scrollPosition === 'number' && Number.isFinite(scrollPosition) && scrollPosition >= 0 ? scrollPosition : 0;
+}
+
+export function saveScrollPosition(page: DashboardPage, scrollPosition: number): void {
+	const scrollPositions = {
+		...readWebviewState().scrollPositions,
+		[page]: Math.max(0, scrollPosition)
+	};
+
+	updateWebviewState({ scrollPositions });
+}
+
+export function getSavedSettingsProvider(): ModelMappingProvider {
+	const provider = readWebviewState().selectedSettingsProvider;
+
+	return provider && modelMappingProviders.includes(provider) ? provider : 'claude';
+}
+
+export function saveSettingsProvider(selectedSettingsProvider: ModelMappingProvider): void {
+	updateWebviewState({ selectedSettingsProvider });
+}
+
+export function getSavedSettingsModelId(provider: ModelMappingProvider): string | null {
+	const modelId = readWebviewState().selectedSettingsModelIds?.[provider];
+
+	return typeof modelId === 'string' && modelId ? modelId : null;
+}
+
+export function saveSettingsModelId(provider: ModelMappingProvider, modelId: string): void {
+	const selectedSettingsModelIds = {
+		...readWebviewState().selectedSettingsModelIds,
+		[provider]: modelId
+	};
+
+	updateWebviewState({ selectedSettingsModelIds });
 }

--- a/packages/shared/src/guards/settings.ts
+++ b/packages/shared/src/guards/settings.ts
@@ -1,7 +1,9 @@
 import {
 	MODEL_MAPPING_PROVIDERS,
+	MODEL_SERVICE_TIERS,
 	REASONING_BUDGET_TIERS,
 	type ModelMappingProvider,
+	type ModelServiceTier,
 	type ReasoningBudgetTier
 } from '../types/settings';
 
@@ -11,4 +13,8 @@ export function isModelMappingProvider(value: unknown): value is ModelMappingPro
 
 export function isReasoningBudgetTier(value: unknown): value is ReasoningBudgetTier {
 	return typeof value === 'string' && REASONING_BUDGET_TIERS.includes(value as ReasoningBudgetTier);
+}
+
+export function isModelServiceTier(value: unknown): value is ModelServiceTier {
+	return typeof value === 'string' && MODEL_SERVICE_TIERS.includes(value as ModelServiceTier);
 }

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -1,9 +1,11 @@
-export type ReasoningBudgetTier = 'low' | 'medium' | 'high' | 'xhigh';
+export type ReasoningBudgetTier = 'none' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export type ModelMappingProvider = 'claude' | 'minimax' | 'openai';
+export type ModelServiceTier = 'default' | 'priority';
 
 export const MODEL_MAPPING_PROVIDERS = ['claude', 'minimax', 'openai'] as const;
-export const REASONING_BUDGET_TIERS = ['low', 'medium', 'high', 'xhigh'] as const;
+export const MODEL_SERVICE_TIERS = ['default', 'priority'] as const;
+export const REASONING_BUDGET_TIERS = ['none', 'low', 'medium', 'high', 'xhigh', 'max'] as const;
 
 export interface ModelMappingConfig {
 	id: string;
@@ -12,6 +14,7 @@ export interface ModelMappingConfig {
 	upstreamModel: string;
 	sortOrder: number;
 	reasoningBudget: ReasoningBudgetTier | null;
+	serviceTier: ModelServiceTier | null;
 }
 
 export interface AppSettings {


### PR DESCRIPTION
## Summary
- add GPT-5.6 Sol, Terra, and Luna support with configurable reasoning and OpenAI service tiers
- seed six focused medium-effort defaults covering normal and priority service
- preserve the selected dashboard page, settings provider/model, and per-page scroll position across webview reloads

## Test plan
- [x] Run extension unit tests (62 passed)
- [x] Run API unit tests (70 passed)
- [x] Run API integration tests (48 passed)
- [x] Run `svelte-check` and web ESLint
- [x] Build the web dashboard and package a test VSIX

## Notes
- The repository requires Node 22; local validation ran successfully on Node 20 with engine warnings.

Made with [Cursor](https://cursor.com)