### PR TITLE
fix: resolve chat models when Cursor drops the reasoning suffix

### DIFF
--- a/apps/api/src/database/model-mappings.ts
+++ b/apps/api/src/database/model-mappings.ts
@@ -81,6 +81,24 @@ export class ModelMappings {
 		return this.clone(models);
 	}
 
+	// Cursor drops a trailing reasoning tier from the model id and sends the effort as a
+	// separate field, so a mapping saved as "gpt-5.6-sol-fast-medium" arrives as
+	// "gpt-5.6-sol-fast". Only re-attach a suffix that matches the row's own budget, and
+	// keep sortOrder precedence so the first matching mapping wins.
+	private static findByDroppedReasoningSuffix(mappings: ModelMappingConfig[], lowerRequested: string): ModelMappingConfig | null {
+		for (const mapping of mappings) {
+			if (!mapping.reasoningBudget) {
+				continue;
+			}
+
+			if (mapping.id.toLowerCase() === `${lowerRequested}-${mapping.reasoningBudget}`) {
+				return mapping;
+			}
+		}
+
+		return null;
+	}
+
 	static resolveForChatCompletion(requestedModel: string): ModelMappingConfig | null {
 		const mappings = this.list();
 		const t = requestedModel.trim();
@@ -89,29 +107,29 @@ export class ModelMappings {
 			return null;
 		}
 
-		const byId = mappings.find((m) => m.id === t);
+		const lower = t.toLowerCase();
+
+		// Ids are what users configure in Cursor, so every id match outranks upstream matches.
+		const byId = mappings.find((m) => m.id === t) ?? mappings.find((m) => m.id.toLowerCase() === lower);
 
 		if (byId) {
 			return byId;
 		}
 
-		const byUpstream = mappings.find((m) => m.upstreamModel === t);
+		// Must stay ahead of the upstream match: mappings that differ only by service tier
+		// share one upstream model, so matching upstream first collapses the priority-tier
+		// row onto the default-tier one.
+		const byDroppedSuffix = this.findByDroppedReasoningSuffix(mappings, lower);
+
+		if (byDroppedSuffix) {
+			return byDroppedSuffix;
+		}
+
+		const byUpstream =
+			mappings.find((m) => m.upstreamModel === t) ?? mappings.find((m) => m.upstreamModel.toLowerCase() === lower);
 
 		if (byUpstream) {
 			return byUpstream;
-		}
-
-		const lower = t.toLowerCase();
-		const byIdInsensitive = mappings.find((m) => m.id.toLowerCase() === lower);
-
-		if (byIdInsensitive) {
-			return byIdInsensitive;
-		}
-
-		const byUpstreamInsensitive = mappings.find((m) => m.upstreamModel.toLowerCase() === lower);
-
-		if (byUpstreamInsensitive) {
-			return byUpstreamInsensitive;
 		}
 
 		return null;

--- a/apps/api/tests/integration/database/database-model-mappings.test.ts
+++ b/apps/api/tests/integration/database/database-model-mappings.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { ModelMappings } from 'src/database/model-mappings';
 
@@ -62,5 +62,85 @@ describe('database-model-mappings', () => {
 		expect(ModelMappings.resolveForChatCompletion('sonnet-4.6')?.upstreamModel).toBe('claude-sonnet-4-6');
 		expect(ModelMappings.resolveForChatCompletion('CLAUDE-SONNET-4-6')?.id).toBe('sonnet-4.6');
 		expect(ModelMappings.resolveForChatCompletion('second')?.upstreamModel).toBe('claude-second');
+	});
+
+	describe('when Cursor drops the trailing reasoning tier from the model id', () => {
+		beforeEach(() => {
+			ModelMappings.replace([
+				{
+					id: 'gpt-5.6-sol-medium',
+					label: 'GPT-5.6 Sol Medium',
+					provider: 'openai',
+					upstreamModel: 'gpt-5.6-sol',
+					sortOrder: 0,
+					reasoningBudget: 'medium',
+					serviceTier: 'default'
+				},
+				{
+					id: 'gpt-5.6-sol-fast-medium',
+					label: 'GPT-5.6 Sol Fast Medium',
+					provider: 'openai',
+					upstreamModel: 'gpt-5.6-sol',
+					sortOrder: 1,
+					reasoningBudget: 'medium',
+					serviceTier: 'priority'
+				}
+			]);
+		});
+
+		it('resolves the priority-tier mapping instead of falling through to Claude', () => {
+			const resolved = ModelMappings.resolveForChatCompletion('gpt-5.6-sol-fast');
+
+			expect(resolved?.id).toBe('gpt-5.6-sol-fast-medium');
+			expect(resolved?.serviceTier).toBe('priority');
+		});
+
+		it('resolves the default-tier mapping for the non-fast variant', () => {
+			const resolved = ModelMappings.resolveForChatCompletion('gpt-5.6-sol');
+
+			expect(resolved?.id).toBe('gpt-5.6-sol-medium');
+			expect(resolved?.serviceTier).toBe('default');
+		});
+
+		it('prefers an exact id match over re-attaching a suffix', () => {
+			ModelMappings.replace([
+				{
+					id: 'gpt-5.6-sol',
+					label: 'GPT-5.6 Sol',
+					provider: 'openai',
+					upstreamModel: 'gpt-5.6-sol',
+					sortOrder: 0,
+					reasoningBudget: null,
+					serviceTier: 'default'
+				},
+				{
+					id: 'gpt-5.6-sol-high',
+					label: 'GPT-5.6 Sol High',
+					provider: 'openai',
+					upstreamModel: 'gpt-5.6-sol',
+					sortOrder: 1,
+					reasoningBudget: 'high',
+					serviceTier: 'default'
+				}
+			]);
+
+			expect(ModelMappings.resolveForChatCompletion('gpt-5.6-sol')?.id).toBe('gpt-5.6-sol');
+		});
+
+		it('ignores a suffix that does not match the mapping budget', () => {
+			ModelMappings.replace([
+				{
+					id: 'custom-max',
+					label: 'Custom Max',
+					provider: 'openai',
+					upstreamModel: 'custom-upstream',
+					sortOrder: 0,
+					reasoningBudget: null,
+					serviceTier: null
+				}
+			]);
+
+			expect(ModelMappings.resolveForChatCompletion('custom')).toBeNull();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Selecting one of the seeded `gpt-5.6-*-fast-medium` models in Cursor fails with an error (Cursor surfaces it as "User Provided API Key Rate Limit Exceeded"). The request never reaches OpenAI at all — it gets sent to Anthropic instead.

Cursor strips a trailing reasoning tier from custom model ids and sends the effort as a separate field, so a mapping saved as `gpt-5.6-sol-fast-medium` arrives at `/v1/chat/completions` as `gpt-5.6-sol-fast`. `ModelMappings.resolveForChatCompletion` only matched exact ids and exact upstream models, so that name matched neither the id (`gpt-5.6-sol-fast-medium`) nor the upstream model (`gpt-5.6-sol`). With `resolvedModel === null`, the router in `routes/openai.ts` skips the OpenAI branch and falls through to `ClaudeChatHandler`, which sends `model: "gpt-5.6-sol-fast"` to Anthropic. With no Claude OAuth token configured, `makeClaudeCodeRequest` returns a bare 401 without logging, so the API log just stops after the `[OpenAI→Anthropic]` line.

Observed in logs from a user running 1.7.5:

```
[info] 📥 [OpenAI /v1/chat/completions] Request Details:
[info] [OpenAI→Anthropic] "gpt-5.6-sol-fast" → "gpt-5.6-sol-fast" | max_tokens=4096
```

The `Request Details` block only logs inside `ClaudeChatHandler.handle`, which confirms the fallback path was taken.

This affects all three priority-tier models seeded by migration `_0007.sql` (`gpt-5.6-sol-fast-medium`, `gpt-5.6-terra-fast-medium`, `gpt-5.6-luna-fast-medium`). The non-fast variants only worked by accident: `gpt-5.6-sol-medium` strips to `gpt-5.6-sol`, which happens to hit the upstream-model fallback.

## Changes

- Add `findByDroppedReasoningSuffix`, which re-attaches each mapping's **own** configured reasoning budget to the requested name. Requiring the suffix to equal the row's budget avoids false positives on models that merely end in a tier word, and iterating in `sortOrder` keeps resolution deterministic.
- Order the new step ahead of the upstream-model fallback. This also fixes a latent service-tier bug: mappings that differ only by service tier share one upstream model, so the upstream fallback collapsed the priority-tier row onto whichever row sorted first.
- Group the exact and case-insensitive id lookups together so all id matches outrank upstream matches. This only changes behavior if one mapping's upstream string equals another's id modulo case.

Resolution order is now: exact id → case-insensitive id → suffix-restored id → exact upstream → case-insensitive upstream.

## Test plan

- [x] Four new cases in `database-model-mappings.test.ts` cover the priority-tier resolution, the default-tier variant, exact-id precedence over suffix restoration, and the non-matching-suffix guard.
- [x] Confirmed the new tests fail without the source change (`resolved` comes back `undefined`, reproducing the fallback), and pass with it.
- [x] `pnpm test` green — 52 API integration tests, 70 API unit tests, plus extension tests.
- [x] ESLint and `tsc --noEmit` clean.

Existing resolution tests are unchanged and still pass, so id/upstream/case-insensitive behavior is preserved for all currently-working configurations.

Made with [Cursor](https://cursor.com)