### PR TITLE
fix(api): support Node 26 by bumping better-sqlite3 to 12.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ sequenceDiagram
 ## Prerequisites
 
 - Cursor with custom OpenAI provider support enabled.
-- System Node.js installed on the machine. Ungate starts its local API through the system Node runtime.
+- System Node.js installed on the machine. Ungate starts its local API through the system Node runtime. Supported versions: Node 22, 24, 26 (Node 20 and 23 are not supported).
 - Outbound internet access for OAuth and provider APIs.
 - A reachable public tunnel URL because Cursor backend cannot call `localhost`.
 
@@ -181,6 +181,7 @@ DB_PATH=$HOME/.ungate/data-dev.db PORT=4784 node dist/main.js
 | `404` or timeout through tunnel | Tunnel status in Ungate panel | Restart tunnel from dashboard |
 | OAuth session expired | Provider connection status | Reconnect provider in dashboard |
 | Model missing in Cursor | Custom model list in Cursor | Add model ID manually from Ungate `Models` |
+| API never starts, `[native] No prebuilt binary for ABI ...` in logs | Node.js version | Install a supported Node version (22, 24, 26) |
 
 ## Quick facts
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,7 +19,7 @@
 	"dependencies": {
 		"@fastify/cors": "~11.2.0",
 		"@ungate/shared": "workspace:*",
-		"better-sqlite3": "12.9.0",
+		"better-sqlite3": "12.11.1",
 		"date-fns": "~4.1.0",
 		"drizzle-orm": "~0.43.1",
 		"fastify": "~5.8.5",

--- a/apps/extension/CHANGELOG.md
+++ b/apps/extension/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.7.7 - 2026-08-07
+
+- Fix API server failing to start on Node 26 by bumping better-sqlite3 to 12.11.1
+- Drop Node 20 and 23 support; supported runtimes: Node 22, 24, 26
+
 ## 1.7.6 - 2026-08-06
 
 - Fix GPT-5.6 priority-tier models failing when Cursor strips the reasoning tier from the model id

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -2,7 +2,7 @@
 	"name": "ungate",
 	"displayName": "Ungate",
 	"description": "Use Claude, GPT, or MiniMax subscriptions in Cursor instead of paying for API tokens",
-	"version": "1.7.6",
+	"version": "1.7.7",
 	"publisher": "orchidfiles",
 	"license": "MIT",
 	"pricing": "Free",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,14 +27,14 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared
       better-sqlite3:
-        specifier: 12.9.0
-        version: 12.9.0
+        specifier: 12.11.1
+        version: 12.11.1
       date-fns:
         specifier: ~4.1.0
         version: 4.1.0
       drizzle-orm:
         specifier: ~0.43.1
-        version: 0.43.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0)
+        version: 0.43.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1)
       fastify:
         specifier: ~5.8.5
         version: 5.8.5
@@ -2432,9 +2432,9 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  better-sqlite3@12.9.0:
-    resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
-    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
+  better-sqlite3@12.11.1:
+    resolution: {integrity: sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==}
+    engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -7049,7 +7049,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  better-sqlite3@12.9.0:
+  better-sqlite3@12.11.1:
     dependencies:
       bindings: 1.5.0
       prebuild-install: 7.1.3
@@ -7428,10 +7428,10 @@ snapshots:
       esbuild: 0.25.12
       tsx: 4.21.0
 
-  drizzle-orm@0.43.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.9.0):
+  drizzle-orm@0.43.1(@types/better-sqlite3@7.6.13)(better-sqlite3@12.11.1):
     optionalDependencies:
       '@types/better-sqlite3': 7.6.13
-      better-sqlite3: 12.9.0
+      better-sqlite3: 12.11.1
 
   dunder-proto@1.0.1:
     dependencies:

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -4,6 +4,10 @@
 	"type": "module",
 	"scripts": {
 		"tunnel": "tsx tunnel/main.ts",
+		"build-package": "sh build-package/run.sh",
+		"check-tunnels": "sh check-tunnels/run.sh",
+		"reset-sqlite-binary": "sh reset-sqlite-binary/run.sh",
+		"update-node-version": "sh update-node-version/run.sh",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix"
 	},

--- a/scripts/reset-sqlite-binary/run.sh
+++ b/scripts/reset-sqlite-binary/run.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Removes the runtime-installed better-sqlite3 binary so the extension
+# re-downloads it on the next API start (reproduces prebuild failures).
+
+rm -f apps/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node
+echo "removed better_sqlite3.installed.node"

--- a/scripts/update-node-version/run.sh
+++ b/scripts/update-node-version/run.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Bumps the Node version used by non-interactive shells (VS Code tasks, GUI apps).
+# - resolves the target version (arg, "NN", or newest installed in nvm)
+# - installs it via nvm if missing
+# - ensures pnpm is installed in that version
+# - updates ~/.zshenv PATH and the nvm default alias
+
+set -e
+
+NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+
+if [ ! -d "$NVM_DIR/versions/node" ]; then
+	echo "nvm versions dir not found: $NVM_DIR/versions/node" >&2
+	exit 1
+fi
+
+. "$NVM_DIR/nvm.sh"
+
+resolve_version() {
+	target="$1"
+
+	if [ -z "$target" ]; then
+		ls -1 "$NVM_DIR/versions/node" | sed 's/^v//' | sort -V | tail -1
+		return
+	fi
+
+	case "$target" in
+	*.*)
+		echo "$target"
+		;;
+	*)
+		ls -1 "$NVM_DIR/versions/node" | sed 's/^v//' | sort -V | grep "^$target\." | tail -1 || true
+		;;
+	esac
+}
+
+target="${1:-}"
+if [ -z "$target" ]; then
+	printf 'Node version (e.g. 26, 24.15.0): '
+	read -r target
+fi
+
+if [ -z "$target" ]; then
+	echo "no version given" >&2
+	exit 1
+fi
+
+version="$(resolve_version "$target")"
+
+if [ -z "$version" ]; then
+	echo "no installed Node version matches: $1" >&2
+	exit 1
+fi
+
+if [ ! -d "$NVM_DIR/versions/node/v$version" ]; then
+	echo "installing node v$version via nvm..."
+	nvm install "$version"
+fi
+
+bin_dir="$NVM_DIR/versions/node/v$version/bin"
+
+if [ ! -x "$bin_dir/pnpm" ]; then
+	echo "installing pnpm into node v$version..."
+	"$bin_dir/node" "$bin_dir/npm" install -g pnpm
+fi
+
+nvm alias default "$version" >/dev/null
+
+zshenv="$HOME/.zshenv"
+managed='^export PATH="[^"]*versions/node/v[0-9.][0-9.]*/bin:\$PATH"$'
+tmp="$(mktemp)"
+
+if [ -f "$zshenv" ]; then
+	sed -e "\|$managed|d" -e "/^# node for non-interactive shells/d" "$zshenv" >"$tmp"
+else
+	: >"$tmp"
+fi
+
+if [ -s "$tmp" ] && [ "$(tail -c 1 "$tmp" | wc -l | tr -d ' ')" -eq 0 ]; then
+	printf '\n' >>"$tmp"
+fi
+
+if ! grep -q '^export NVM_DIR=' "$tmp"; then
+	printf 'export NVM_DIR="%s"\n' "$HOME/.nvm" >>"$tmp"
+fi
+
+printf '\n# node for non-interactive shells (VS Code tasks, GUI apps)\n' >>"$tmp"
+printf 'export PATH="%s:$PATH"\n' "$bin_dir" >>"$tmp"
+
+mv "$tmp" "$zshenv"
+
+echo "node v$version is now the runtime:"
+echo "  \$HOME/.zshenv -> v$version/bin"
+echo "  nvm default   -> v$version"
+echo "  node: $("$bin_dir/node" -v)  pnpm: $("$bin_dir/pnpm" -v)"


### PR DESCRIPTION
## Problem

API never starts on Node 26 (ABI 147). The installer builds the download URL from the pinned version; 12.9.0's prebuild assets stop at ABI 141, so the download 404s and the API stays in error state.

## Changes

- better-sqlite3 12.9.0 → 12.11.1 (prebuilds for Node 22/24/26)
- Drops Node 20 and 23 — both EOL

## Verification
404 on 12.9.0 ABI 147 URL, 200 on 12.11.1
Tested on Node 22, 24, 26 — works on all three
Tests pass: extension 62, api unit 70, api integration 52

## Also

- scripts/reset-sqlite-binary — deletes the runtime-installed better-sqlite3 binary so the installer re-downloads it, reproducing prebuild failures locally
- scripts/update-node-version — switches the Node version used by the extension and VS Code tasks: prompts for a version, installs it via nvm (and pnpm if missing), rewrites only the managed PATH line in ~/.zshenv