### PR TITLE
fix: sanitize Anthropic tool ids from Cursor plan history

### DIFF
--- a/apps/api/src/adapter/openai-to-anthropic.ts
+++ b/apps/api/src/adapter/openai-to-anthropic.ts
@@ -37,6 +37,27 @@ export interface AnthropicModelOverride {
 	reasoningBudget?: ReasoningBudgetTier | null;
 }
 
+// Anthropic rejects tool ids that don't match ^[a-zA-Z0-9_-]+$, and Cursor's plan mode sends
+// ids like "functions.AskUserQuestion:1". The remap has to be deterministic: a tool_use and
+// its tool_result are paired by id, and both arrive on every subsequent turn.
+const ILLEGAL_TOOL_ID_CHARS = /[^a-zA-Z0-9_-]/g;
+
+function sanitizeToolId(id: string): string {
+	return id.replace(ILLEGAL_TOOL_ID_CHARS, '_');
+}
+
+function sanitizeToolBlockId(block: ContentBlock): ContentBlock {
+	if (block.type === 'tool_use' && block.id) {
+		return { ...block, id: sanitizeToolId(block.id) };
+	}
+
+	if (block.type === 'tool_result' && block.tool_use_id) {
+		return { ...block, tool_use_id: sanitizeToolId(block.tool_use_id) };
+	}
+
+	return block;
+}
+
 function convertContent(content: string | OpenAIContentPart[] | ContentBlock[]): string | ContentBlock[] {
 	if (typeof content === 'string') {
 		return content;
@@ -46,13 +67,8 @@ function convertContent(content: string | OpenAIContentPart[] | ContentBlock[]):
 
 	for (const part of content) {
 		// Pass through Anthropic-format blocks directly (Cursor sends these)
-		if ((part as ContentBlock).type === 'tool_use') {
-			blocks.push(part as ContentBlock);
-			continue;
-		}
-
-		if ((part as ContentBlock).type === 'tool_result') {
-			blocks.push(part as ContentBlock);
+		if ((part as ContentBlock).type === 'tool_use' || (part as ContentBlock).type === 'tool_result') {
+			blocks.push(sanitizeToolBlockId(part as ContentBlock));
 			continue;
 		}
 
@@ -120,7 +136,7 @@ export function openaiToAnthropic(request: OpenAIChatRequest, override?: Anthrop
 					}
 					contentBlocks.push({
 						type: 'tool_use',
-						id: toolCall.id,
+						id: sanitizeToolId(toolCall.id),
 						name: toolCall.function.name,
 						input
 					});
@@ -136,7 +152,7 @@ export function openaiToAnthropic(request: OpenAIChatRequest, override?: Anthrop
 			const toolResultContent: ContentBlock[] = [
 				{
 					type: 'tool_result',
-					tool_use_id: msg.tool_call_id ?? '',
+					tool_use_id: sanitizeToolId(msg.tool_call_id ?? ''),
 					content: resultContent
 				}
 			];

--- a/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
+++ b/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
@@ -2,6 +2,16 @@ import { describe, expect, it } from 'vitest';
 
 import { normalizeModelName, openaiToAnthropic } from 'src/adapter/openai-to-anthropic';
 
+import type { AnthropicRequest, ContentBlock } from 'src/types';
+import type { OpenAIChatRequest } from 'src/types/openai';
+
+function findBlock(request: AnthropicRequest, role: 'user' | 'assistant', type: ContentBlock['type']): ContentBlock | undefined {
+	return request.messages
+		.filter((message) => message.role === role)
+		.flatMap((message) => (Array.isArray(message.content) ? message.content : []))
+		.find((block) => block.type === type);
+}
+
 describe('openai-to-anthropic', () => {
 	it('normalizes legacy model names with reasoning budget', () => {
 		expect(normalizeModelName('claude-4.6-opus-high')).toEqual({
@@ -125,6 +135,67 @@ describe('openai-to-anthropic', () => {
 		expect(toolResults).toHaveLength(2);
 		expect(toolResults[0]).toMatchObject({ type: 'tool_result', tool_use_id: 'call_1', content: 'ok1' });
 		expect(toolResults[1]).toMatchObject({ type: 'tool_result', tool_use_id: 'call_2', content: 'ok2' });
+	});
+
+	it('sanitizes tool ids that anthropic rejects and keeps the pair matched', () => {
+		const request: OpenAIChatRequest = {
+			model: 'claude-opus-4-6',
+			messages: [
+				{
+					role: 'assistant',
+					content: 'planning',
+					tool_calls: [
+						{
+							id: 'functions.AskUserQuestion:1',
+							type: 'function',
+							function: { name: 'AskUserQuestion', arguments: '{}' }
+						}
+					]
+				},
+				{ role: 'tool', tool_call_id: 'functions.AskUserQuestion:1', content: 'answered' }
+			]
+		};
+
+		const result = openaiToAnthropic(request);
+
+		const toolUse = findBlock(result, 'assistant', 'tool_use');
+		const toolResult = findBlock(result, 'user', 'tool_result');
+
+		expect(toolUse?.id).toBe('functions_AskUserQuestion_1');
+		expect(toolResult?.tool_use_id).toBe(toolUse?.id);
+		expect(request.messages[0].tool_calls?.[0].id).toBe('functions.AskUserQuestion:1');
+	});
+
+	it('sanitizes tool ids on pass-through anthropic blocks', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-opus-4-6',
+			messages: [
+				{ role: 'assistant', content: [{ type: 'tool_use', id: 'functions.Read:2', name: 'Read', input: { path: 'a' } }] },
+				{ role: 'user', content: [{ type: 'tool_result', tool_use_id: 'functions.Read:2', content: 'ok' }] }
+			]
+		} as unknown as OpenAIChatRequest);
+
+		expect(findBlock(result, 'assistant', 'tool_use')?.id).toBe('functions_Read_2');
+		expect(findBlock(result, 'user', 'tool_result')?.tool_use_id).toBe('functions_Read_2');
+	});
+
+	it('leaves already valid tool ids untouched', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-opus-4-6',
+			messages: [
+				{
+					role: 'assistant',
+					content: 'calling',
+					tool_calls: [
+						{ id: 'toolu_01ABC-xyz', type: 'function', function: { name: 'read_file', arguments: '{}' } }
+					]
+				},
+				{ role: 'tool', tool_call_id: 'toolu_01ABC-xyz', content: 'ok' }
+			]
+		});
+
+		expect(findBlock(result, 'assistant', 'tool_use')?.id).toBe('toolu_01ABC-xyz');
+		expect(findBlock(result, 'user', 'tool_result')?.tool_use_id).toBe('toolu_01ABC-xyz');
 	});
 
 	it('uses max_completion_tokens when max_tokens is absent', () => {


### PR DESCRIPTION
Accepting a plan in Cursor on a Claude model 400s:

```
messages.3.content.0.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'
```

Cursor's plan mode generates tool ids like `functions.AskUserQuestion:1`. Anthropic only accepts `[a-zA-Z0-9_-]`, and the adapter passes ids through verbatim, so every request is rejected once such a call is in the history.

`openai-to-anthropic` now remaps the illegal characters to `_`. Four sites needed it, because Cursor mixes both message shapes in one request: the OpenAI `tool_calls[].id` and `tool_call_id`, plus the pass-through Anthropic `tool_use` / `tool_result` blocks. Those last two branches were identical, so I merged them. Pass-through blocks are copied instead of edited in place, so the request body the route still holds and logs stays untouched.

Two things worth flagging:

- The mapping is lossy: `functions.X:1` and a literal `functions_X_1` collapse to the same id. Determinism is the property that matters here, since a `tool_result` is paired to its `tool_use` by id and both come back on every later turn. A collision needs two ids in one conversation differing only in separator characters.
- `POST /v1/messages` proxies the body straight through, so an Anthropic-native client sending dirty ids still 400s. I left it alone because Cursor reaches us over `/v1/chat/completions`, but happy to cover it too if you'd rather have it in one place.

Full API suite passes (73 unit + 52 integration). Three new cases: dirty ids on both message shapes stay paired after conversion, and already-valid ids are byte-identical.