### PR TITLE
fix: finalize interrupted Claude tool streams safely

### DIFF
--- a/apps/api/src/adapter/openai-to-anthropic.ts
+++ b/apps/api/src/adapter/openai-to-anthropic.ts
@@ -185,17 +185,26 @@ export function openaiToAnthropic(request: OpenAIChatRequest, override?: Anthrop
 	if (override) {
 		normalized = { model: override.model };
 
-		if (override.reasoningBudget) {
+		if (override.reasoningBudget && override.reasoningBudget !== 'none') {
 			normalized.reasoningBudget = override.reasoningBudget;
 		}
 	} else {
 		normalized = normalizeModelName(request.model);
 	}
 
-	const maxTokens = request.max_tokens ?? request.max_completion_tokens ?? (normalized.reasoningBudget ? 32_000 : 4096);
+	const requestedMaxTokens = request.max_tokens ?? request.max_completion_tokens;
+	const maxTokens = requestedMaxTokens ?? (normalized.reasoningBudget ? 32_000 : 4096);
+	const maxTokensSource =
+		request.max_tokens !== undefined
+			? 'max_tokens'
+			: request.max_completion_tokens !== undefined
+				? 'max_completion_tokens'
+				: normalized.reasoningBudget
+					? 'thinking-default'
+					: 'default';
 
 	logger.log(
-		`[OpenAI→Anthropic] "${request.model}" → "${normalized.model}"${normalized.reasoningBudget ? ` (reasoning_budget: ${normalized.reasoningBudget})` : ''} | max_tokens=${maxTokens}`
+		`[OpenAI→Anthropic] "${request.model}" → "${normalized.model}"${normalized.reasoningBudget ? ` (reasoning_budget: ${normalized.reasoningBudget})` : ''} | max_tokens=${maxTokens} max_tokens_source=${maxTokensSource}`
 	);
 
 	const result: AnthropicRequest = {

--- a/apps/api/src/adapter/openai-to-anthropic.ts
+++ b/apps/api/src/adapter/openai-to-anthropic.ts
@@ -195,9 +195,9 @@ export function openaiToAnthropic(request: OpenAIChatRequest, override?: Anthrop
 	const requestedMaxTokens = request.max_tokens ?? request.max_completion_tokens;
 	const maxTokens = requestedMaxTokens ?? (normalized.reasoningBudget ? 32_000 : 4096);
 	const maxTokensSource =
-		request.max_tokens !== undefined
+		request.max_tokens != null
 			? 'max_tokens'
-			: request.max_completion_tokens !== undefined
+			: request.max_completion_tokens != null
 				? 'max_completion_tokens'
 				: normalized.reasoningBudget
 					? 'thinking-default'

--- a/apps/api/src/adapter/openai-to-anthropic.ts
+++ b/apps/api/src/adapter/openai-to-anthropic.ts
@@ -192,7 +192,7 @@ export function openaiToAnthropic(request: OpenAIChatRequest, override?: Anthrop
 		normalized = normalizeModelName(request.model);
 	}
 
-	const maxTokens = request.max_tokens ?? request.max_completion_tokens ?? 4096;
+	const maxTokens = request.max_tokens ?? request.max_completion_tokens ?? (normalized.reasoningBudget ? 32_000 : 4096);
 
 	logger.log(
 		`[OpenAI→Anthropic] "${request.model}" → "${normalized.model}"${normalized.reasoningBudget ? ` (reasoning_budget: ${normalized.reasoningBudget})` : ''} | max_tokens=${maxTokens}`

--- a/apps/api/src/streaming/openai-stream-handler.ts
+++ b/apps/api/src/streaming/openai-stream-handler.ts
@@ -56,13 +56,20 @@ export class OpenAIStreamHandler {
 		let cancelled = false;
 		let currentToolCall: ActiveToolCall | null = null;
 
+		const describeOpenTool = (): string => {
+			if (!currentToolCall) {
+				return 'tool=none';
+			}
+
+			return `tool=${currentToolCall.name} toolId=${currentToolCall.id} argsLength=${currentToolCall.inputJson.length}`;
+		};
+
 		return new ReadableStream({
 			async start(controller) {
 				const decoder = new TextDecoder();
 				let buffer = '';
 				let sentStart = false;
 				let toolCallIndex = 0;
-				let completedToolCalls = 0;
 				let finalized = false;
 				let stopReason: AnthropicStopReason | null = null;
 				let finalUsage: StreamUsage | null = null;
@@ -76,14 +83,6 @@ export class OpenAIStreamHandler {
 					} catch {
 						cancelled = true;
 					}
-				};
-
-				const describeOpenTool = (): string => {
-					if (!currentToolCall) {
-						return 'tool=none';
-					}
-
-					return `tool=${currentToolCall.name} toolId=${currentToolCall.id} argsLength=${currentToolCall.inputJson.length}`;
 				};
 
 				const flushToolCall = (mode: 'complete' | 'salvage'): boolean => {
@@ -130,7 +129,6 @@ export class OpenAIStreamHandler {
 					);
 
 					toolCallIndex++;
-					completedToolCalls++;
 					currentToolCall = null;
 
 					return true;
@@ -141,7 +139,7 @@ export class OpenAIStreamHandler {
 						return 'length';
 					}
 
-					if (completedToolCalls > 0) {
+					if (toolCallIndex > 0) {
 						return 'tool_calls';
 					}
 
@@ -156,7 +154,7 @@ export class OpenAIStreamHandler {
 					finalized = true;
 
 					logger.log(
-						`Stream stop_reason=${stopReason ?? 'none'} unexpectedEof=${unexpectedEof} completedToolCalls=${completedToolCalls}`
+						`Stream stop_reason=${stopReason ?? 'none'} unexpectedEof=${unexpectedEof} completedToolCalls=${toolCallIndex}`
 					);
 
 					if (unexpectedEof && currentToolCall) {
@@ -358,13 +356,7 @@ export class OpenAIStreamHandler {
 			},
 			cancel(reason) {
 				cancelled = true;
-				logger.error(
-					`Downstream cancelled stream id=${streamId} reason=${String(reason)} ${
-						currentToolCall
-							? `tool=${currentToolCall.name} toolId=${currentToolCall.id} argsLength=${currentToolCall.inputJson.length}`
-							: 'tool=none'
-					}`
-				);
+				logger.error(`Downstream cancelled stream id=${streamId} reason=${String(reason)} ${describeOpenTool()}`);
 				reader.cancel(reason).catch(() => {});
 			}
 		});

--- a/apps/api/src/streaming/openai-stream-handler.ts
+++ b/apps/api/src/streaming/openai-stream-handler.ts
@@ -66,6 +66,7 @@ export class OpenAIStreamHandler {
 				let finalized = false;
 				let stopReason: AnthropicStopReason | null = null;
 				let finalUsage: StreamUsage | null = null;
+				let salvageFailed = false;
 
 				const safeEnqueue = (data: Uint8Array) => {
 					try {
@@ -90,24 +91,11 @@ export class OpenAIStreamHandler {
 						return false;
 					}
 
-					if (mode === 'salvage') {
-						const raw = currentToolCall.inputJson;
+					if (mode === 'salvage' && !currentToolCall.inputJson) {
+						logger.error(`Incomplete tool call ${describeOpenTool()}`);
+						currentToolCall = null;
 
-						if (!raw) {
-							logger.error(`Incomplete tool call ${describeOpenTool()}`);
-							currentToolCall = null;
-
-							return false;
-						}
-
-						try {
-							JSON.parse(raw);
-						} catch {
-							logger.error(`Incomplete tool call JSON ${describeOpenTool()}`);
-							currentToolCall = null;
-
-							return false;
-						}
+						return false;
 					}
 
 					let finalJson = currentToolCall.inputJson || '{}';
@@ -149,7 +137,7 @@ export class OpenAIStreamHandler {
 				};
 
 				const mapFinishReason = (unexpectedEof: boolean): 'stop' | 'length' | 'tool_calls' => {
-					if (unexpectedEof || stopReason === 'max_tokens' || stopReason === 'model_context_window_exceeded') {
+					if (unexpectedEof || salvageFailed || stopReason === 'max_tokens' || stopReason === 'model_context_window_exceeded') {
 						return 'length';
 					}
 
@@ -320,7 +308,7 @@ export class OpenAIStreamHandler {
 
 								if (event.type === 'message_stop') {
 									if (currentToolCall && stopReason === 'tool_use') {
-										flushToolCall('salvage');
+										salvageFailed = !flushToolCall('salvage');
 									} else if (currentToolCall) {
 										logger.error(`Open tool call at message_stop stop_reason=${stopReason ?? 'none'} ${describeOpenTool()}`);
 										currentToolCall = null;

--- a/apps/api/src/streaming/openai-stream-handler.ts
+++ b/apps/api/src/streaming/openai-stream-handler.ts
@@ -5,13 +5,27 @@ import { Requests } from '../database/requests';
 import { ToolNormalizer } from '../tools/normalizer';
 import { type ToolUseBlock, type StreamResult, type RequestContext } from '../types/proxy';
 
-import type { AnthropicStreamEvent } from '../types/anthropic-stream';
+import type { AnthropicStopReason, AnthropicStreamEvent } from '../types/anthropic-stream';
 
 interface StreamHandlerOptions {
 	reader: ReadableStreamDefaultReader<Uint8Array>;
 	streamId: string;
 	modelName: string;
 	context: RequestContext;
+}
+
+interface ActiveToolCall {
+	id: string;
+	name: string;
+	inputJson: string;
+	index: number;
+}
+
+interface StreamUsage {
+	input_tokens: number;
+	output_tokens: number;
+	cache_read_input_tokens: number;
+	cache_creation_input_tokens: number;
 }
 
 export class OpenAIStreamHandler {
@@ -40,6 +54,7 @@ export class OpenAIStreamHandler {
 		const { reader, streamId, modelName, context } = options;
 
 		let cancelled = false;
+		let currentToolCall: ActiveToolCall | null = null;
 
 		return new ReadableStream({
 			async start(controller) {
@@ -47,18 +62,10 @@ export class OpenAIStreamHandler {
 				let buffer = '';
 				let sentStart = false;
 				let toolCallIndex = 0;
-				let currentToolCall: {
-					id: string;
-					name: string;
-					inputJson: string;
-				} | null = null;
-
-				let finalUsage: {
-					input_tokens: number;
-					output_tokens: number;
-					cache_read_input_tokens: number;
-					cache_creation_input_tokens: number;
-				} | null = null;
+				let completedToolCalls = 0;
+				let finalized = false;
+				let stopReason: AnthropicStopReason | null = null;
+				let finalUsage: StreamUsage | null = null;
 
 				const safeEnqueue = (data: Uint8Array) => {
 					try {
@@ -70,6 +77,137 @@ export class OpenAIStreamHandler {
 					}
 				};
 
+				const describeOpenTool = (): string => {
+					if (!currentToolCall) {
+						return 'tool=none';
+					}
+
+					return `tool=${currentToolCall.name} toolId=${currentToolCall.id} argsLength=${currentToolCall.inputJson.length}`;
+				};
+
+				const flushToolCall = (mode: 'complete' | 'salvage'): boolean => {
+					if (!currentToolCall) {
+						return false;
+					}
+
+					if (mode === 'salvage') {
+						const raw = currentToolCall.inputJson;
+
+						if (!raw) {
+							logger.error(`Incomplete tool call ${describeOpenTool()}`);
+							currentToolCall = null;
+
+							return false;
+						}
+
+						try {
+							JSON.parse(raw);
+						} catch {
+							logger.error(`Incomplete tool call JSON ${describeOpenTool()}`);
+							currentToolCall = null;
+
+							return false;
+						}
+					}
+
+					let finalJson = currentToolCall.inputJson || '{}';
+
+					try {
+						const parsedArgs = JSON.parse(finalJson);
+						const toolUse: ToolUseBlock = {
+							type: 'tool_use',
+							id: currentToolCall.id,
+							name: currentToolCall.name,
+							input: parsedArgs
+						};
+
+						const normalized = ToolNormalizer.normalize(toolUse);
+						if (ToolNormalizer.hasChanged(toolUse, normalized)) {
+							finalJson = JSON.stringify(normalized.input);
+						}
+					} catch {
+						logger.error(`Failed to parse tool args for ${currentToolCall.name}`);
+
+						if (mode === 'salvage') {
+							currentToolCall = null;
+
+							return false;
+						}
+					}
+
+					safeEnqueue(
+						new TextEncoder().encode(
+							AnthropicToOpenai.toolCallChunk(streamId, modelName, toolCallIndex, undefined, undefined, finalJson, null)
+						)
+					);
+
+					toolCallIndex++;
+					completedToolCalls++;
+					currentToolCall = null;
+
+					return true;
+				};
+
+				const mapFinishReason = (unexpectedEof: boolean): 'stop' | 'length' | 'tool_calls' => {
+					if (unexpectedEof || stopReason === 'max_tokens' || stopReason === 'model_context_window_exceeded') {
+						return 'length';
+					}
+
+					if (completedToolCalls > 0) {
+						return 'tool_calls';
+					}
+
+					return 'stop';
+				};
+
+				const finalizeStream = (unexpectedEof: boolean) => {
+					if (finalized || cancelled) {
+						return;
+					}
+
+					finalized = true;
+
+					logger.log(
+						`Stream stop_reason=${stopReason ?? 'none'} unexpectedEof=${unexpectedEof} completedToolCalls=${completedToolCalls}`
+					);
+
+					if (unexpectedEof && currentToolCall) {
+						logger.error(`Unexpected EOF with open tool call ${describeOpenTool()}`);
+						currentToolCall = null;
+					}
+
+					const finishReason = mapFinishReason(unexpectedEof);
+
+					safeEnqueue(new TextEncoder().encode(AnthropicToOpenai.streamChunk(streamId, modelName, undefined, finishReason)));
+
+					if (finalUsage) {
+						safeEnqueue(
+							new TextEncoder().encode(
+								AnthropicToOpenai.streamChunk(streamId, modelName, undefined, undefined, {
+									prompt_tokens: finalUsage.input_tokens,
+									completion_tokens: finalUsage.output_tokens,
+									total_tokens: finalUsage.input_tokens + finalUsage.output_tokens
+								})
+							)
+						);
+
+						Requests.record(
+							{
+								model: context.model,
+								source: context.source,
+								inputTokens: finalUsage.input_tokens,
+								outputTokens: finalUsage.output_tokens,
+								stream: true,
+								latencyMs: Date.now() - context.startTime
+							},
+							finalUsage.cache_read_input_tokens,
+							finalUsage.cache_creation_input_tokens
+						);
+					}
+
+					safeEnqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+				};
+
 				try {
 					while (true) {
 						if (cancelled) break;
@@ -77,7 +215,10 @@ export class OpenAIStreamHandler {
 						const { done, value } = await reader.read();
 
 						if (cancelled) break;
-						if (done) break;
+						if (done) {
+							finalizeStream(true);
+							break;
+						}
 
 						buffer += decoder.decode(value, { stream: true });
 						const lines = buffer.split('\n');
@@ -89,7 +230,7 @@ export class OpenAIStreamHandler {
 
 							const data = line.slice(6);
 							if (data === '[DONE]') {
-								safeEnqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+								finalizeStream(false);
 								continue;
 							}
 
@@ -112,7 +253,7 @@ export class OpenAIStreamHandler {
 									if (block?.type === 'tool_use') {
 										const originalName = context.reverseToolMapping[block.name] ?? block.name;
 
-										currentToolCall = { id: block.id, name: originalName, inputJson: '' };
+										currentToolCall = { id: block.id, name: originalName, inputJson: '', index: event.index };
 
 										safeEnqueue(
 											new TextEncoder().encode(
@@ -130,37 +271,16 @@ export class OpenAIStreamHandler {
 									}
 								}
 
-								if (event.type === 'content_block_stop' && currentToolCall) {
-									let finalJson = currentToolCall.inputJson || '{}';
-
-									try {
-										const parsedArgs = JSON.parse(finalJson);
-										const toolUse: ToolUseBlock = {
-											type: 'tool_use',
-											id: currentToolCall.id,
-											name: currentToolCall.name,
-											input: parsedArgs
-										};
-
-										const normalized = ToolNormalizer.normalize(toolUse);
-										if (ToolNormalizer.hasChanged(toolUse, normalized)) {
-											finalJson = JSON.stringify(normalized.input);
-										}
-									} catch {
-										logger.error(`Failed to parse tool args for ${currentToolCall.name}`);
-									}
-
-									safeEnqueue(
-										new TextEncoder().encode(
-											AnthropicToOpenai.toolCallChunk(streamId, modelName, toolCallIndex, undefined, undefined, finalJson, null)
-										)
-									);
-
-									toolCallIndex++;
-									currentToolCall = null;
+								if (event.type === 'content_block_stop' && event.index === currentToolCall?.index) {
+									flushToolCall('complete');
 								}
 
-								if (event.type === 'content_block_delta' && event.delta?.type === 'input_json_delta' && currentToolCall) {
+								if (
+									currentToolCall &&
+									event.type === 'content_block_delta' &&
+									event.delta?.type === 'input_json_delta' &&
+									event.index === currentToolCall.index
+								) {
 									currentToolCall.inputJson += event.delta.partial_json ?? '';
 									continue;
 								}
@@ -188,43 +308,25 @@ export class OpenAIStreamHandler {
 									};
 								}
 
-								if (event.type === 'message_delta' && event.usage && finalUsage) {
-									finalUsage.output_tokens = event.usage.output_tokens ?? 0;
+								if (event.type === 'message_delta') {
+									if (event.delta?.stop_reason) {
+										stopReason = event.delta.stop_reason;
+									}
+
+									if (event.usage && finalUsage) {
+										finalUsage.output_tokens = event.usage.output_tokens ?? 0;
+									}
 								}
 
 								if (event.type === 'message_stop') {
-									const finishReason = toolCallIndex > 0 ? 'tool_calls' : 'stop';
-
-									safeEnqueue(
-										new TextEncoder().encode(AnthropicToOpenai.streamChunk(streamId, modelName, undefined, finishReason))
-									);
-
-									if (finalUsage) {
-										safeEnqueue(
-											new TextEncoder().encode(
-												AnthropicToOpenai.streamChunk(streamId, modelName, undefined, undefined, {
-													prompt_tokens: finalUsage.input_tokens,
-													completion_tokens: finalUsage.output_tokens,
-													total_tokens: finalUsage.input_tokens + finalUsage.output_tokens
-												})
-											)
-										);
-
-										Requests.record(
-											{
-												model: context.model,
-												source: context.source,
-												inputTokens: finalUsage.input_tokens,
-												outputTokens: finalUsage.output_tokens,
-												stream: true,
-												latencyMs: Date.now() - context.startTime
-											},
-											finalUsage.cache_read_input_tokens,
-											finalUsage.cache_creation_input_tokens
-										);
+									if (currentToolCall && stopReason === 'tool_use') {
+										flushToolCall('salvage');
+									} else if (currentToolCall) {
+										logger.error(`Open tool call at message_stop stop_reason=${stopReason ?? 'none'} ${describeOpenTool()}`);
+										currentToolCall = null;
 									}
 
-									safeEnqueue(new TextEncoder().encode('data: [DONE]\n\n'));
+									finalizeStream(false);
 								}
 							} catch (parseError) {
 								if (!cancelled) {
@@ -268,6 +370,13 @@ export class OpenAIStreamHandler {
 			},
 			cancel(reason) {
 				cancelled = true;
+				logger.error(
+					`Downstream cancelled stream id=${streamId} reason=${String(reason)} ${
+						currentToolCall
+							? `tool=${currentToolCall.name} toolId=${currentToolCall.id} argsLength=${currentToolCall.inputJson.length}`
+							: 'tool=none'
+					}`
+				);
 				reader.cancel(reason).catch(() => {});
 			}
 		});

--- a/apps/api/src/types/anthropic-stream.ts
+++ b/apps/api/src/types/anthropic-stream.ts
@@ -3,6 +3,10 @@
  * Used for SSE parsing in openai-stream-handler.ts.
  */
 
+import type { AnthropicStopReason } from './anthropic';
+
+export type { AnthropicStopReason };
+
 export interface AnthropicUsage {
 	input_tokens: number;
 	output_tokens: number;
@@ -40,5 +44,9 @@ export type AnthropicStreamEvent =
 	| { type: 'content_block_start'; index: number; content_block: AnthropicStreamBlock }
 	| { type: 'content_block_delta'; index: number; delta: AnthropicStreamDelta }
 	| { type: 'content_block_stop'; index: number }
-	| { type: 'message_delta'; usage: { output_tokens: number } }
+	| {
+			type: 'message_delta';
+			delta?: { stop_reason?: AnthropicStopReason | null };
+			usage?: { output_tokens: number };
+	  }
 	| { type: 'message_stop' };

--- a/apps/api/src/types/anthropic.ts
+++ b/apps/api/src/types/anthropic.ts
@@ -77,13 +77,22 @@ export interface ToolChoice {
 	name?: string;
 }
 
+export type AnthropicStopReason =
+	| 'end_turn'
+	| 'max_tokens'
+	| 'stop_sequence'
+	| 'tool_use'
+	| 'pause_turn'
+	| 'refusal'
+	| 'model_context_window_exceeded';
+
 export interface AnthropicResponse {
 	id: string;
 	type: 'message';
 	role: 'assistant';
 	content: ContentBlock[];
 	model: string;
-	stop_reason: 'end_turn' | 'max_tokens' | 'stop_sequence' | 'tool_use' | null;
+	stop_reason: AnthropicStopReason | null;
 	stop_sequence: string | null;
 	usage: {
 		input_tokens: number;

--- a/apps/api/src/types/openai.ts
+++ b/apps/api/src/types/openai.ts
@@ -39,8 +39,8 @@ export interface OpenAIChatRequest {
 	messages: OpenAIMessage[];
 	/** Some clients send the thread as `input` (chat roles or Responses items) instead of `messages`. */
 	input?: unknown;
-	max_tokens?: number;
-	max_completion_tokens?: number;
+	max_tokens?: number | null;
+	max_completion_tokens?: number | null;
 	temperature?: number;
 	top_p?: number;
 	stream?: boolean;

--- a/apps/api/tests/integration/streaming/streaming-openai-stream-handler.test.ts
+++ b/apps/api/tests/integration/streaming/streaming-openai-stream-handler.test.ts
@@ -156,6 +156,33 @@ describe('streaming-openai-stream-handler', () => {
 		expect(output).toContain('"finish_reason":"tool_calls"');
 	});
 
+	it('finishes as length when a tool_use salvage cannot parse the arguments', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const response = createResponseWithSse([
+			'data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}',
+			'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu10","name":"Write"}}',
+			'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":\\"a.ts\\""}}',
+			'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":5}}',
+			'data: {"type":"message_stop"}'
+		]);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st10', 'model10', {
+			model: 'model10',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: {}
+		});
+
+		const output = await readStream(stream);
+		errorSpy.mockRestore();
+
+		expect(output).toContain('"name":"Write"');
+		expect(output).not.toContain('\\"path\\":\\"a.ts\\"');
+		expect(output).toContain('"finish_reason":"length"');
+		expect(output).not.toContain('"finish_reason":"stop"');
+		expect(output).not.toContain('"finish_reason":"tool_calls"');
+	});
+
 	it('does not emit truncated JSON and finishes as length on max_tokens', async () => {
 		const response = createResponseWithSse([
 			'data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}',

--- a/apps/api/tests/integration/streaming/streaming-openai-stream-handler.test.ts
+++ b/apps/api/tests/integration/streaming/streaming-openai-stream-handler.test.ts
@@ -107,4 +107,175 @@ describe('streaming-openai-stream-handler', () => {
 			})
 		).toThrowError('No response body');
 	});
+
+	it('emits arguments, tool_calls, usage, and DONE once for a completed tool stream', async () => {
+		const response = createResponseWithSse([
+			'data: {"type":"message_start","message":{"usage":{"input_tokens":2,"output_tokens":0}}}',
+			'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu1","name":"Read"}}',
+			'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":\\"a.ts\\"}"}}',
+			'data: {"type":"content_block_stop","index":0}',
+			'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":4}}',
+			'data: {"type":"message_stop"}'
+		]);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st4', 'model4', {
+			model: 'model4',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: { Read: 'read_file' }
+		});
+
+		const output = await readStream(stream);
+		expect(output).toContain('"name":"read_file"');
+		expect(output).toContain('\\"path\\":\\"a.ts\\"');
+		expect(output).toContain('"finish_reason":"tool_calls"');
+		expect(output.match(/"finish_reason":"tool_calls"/g)).toHaveLength(1);
+		expect(output.match(/data: \[DONE\]/g)).toHaveLength(1);
+		expect(recordMock).toHaveBeenCalledTimes(1);
+	});
+
+	it('salvages complete arguments on tool_use message_stop without a block stop', async () => {
+		const response = createResponseWithSse([
+			'data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}',
+			'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu2","name":"CreatePlan"}}',
+			'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"name\\":\\"Plan\\"}"}}',
+			'data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":3}}',
+			'data: {"type":"message_stop"}'
+		]);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st5', 'model5', {
+			model: 'model5',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: {}
+		});
+
+		const output = await readStream(stream);
+		expect(output).toContain('"name":"CreatePlan"');
+		expect(output).toContain('\\"name\\":\\"Plan\\"');
+		expect(output).toContain('"finish_reason":"tool_calls"');
+	});
+
+	it('does not emit truncated JSON and finishes as length on max_tokens', async () => {
+		const response = createResponseWithSse([
+			'data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}',
+			'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu3","name":"Write"}}',
+			'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":\\"a.ts\\""}}',
+			'data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":9}}',
+			'data: {"type":"message_stop"}'
+		]);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st6', 'model6', {
+			model: 'model6',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: {}
+		});
+
+		const output = await readStream(stream);
+		expect(output).toContain('"name":"Write"');
+		expect(output).not.toContain('"path":"a.ts"');
+		expect(output).toContain('"finish_reason":"length"');
+		expect(output).not.toContain('"finish_reason":"tool_calls"');
+	});
+
+	it('does not execute a dangling tool on unexpected EOF even if JSON parses', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const response = createResponseWithSse([
+			'data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}',
+			'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu4","name":"Shell"}}',
+			'data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\\"command\\":\\"rm -rf /\\"}"}}'
+		]);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st7', 'model7', {
+			model: 'model7',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: {}
+		});
+
+		const output = await readStream(stream);
+		errorSpy.mockRestore();
+
+		expect(output).toContain('"name":"Shell"');
+		expect(output).not.toContain('rm -rf /');
+		expect(output).toContain('"finish_reason":"length"');
+		expect(output).not.toContain('"finish_reason":"tool_calls"');
+		expect(output).toContain('data: [DONE]');
+	});
+
+	it('ignores content_block_stop for a different index while a tool is open', async () => {
+		const response = createResponseWithSse([
+			'data: {"type":"message_start","message":{"usage":{"input_tokens":1,"output_tokens":0}}}',
+			'data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tu5","name":"Read"}}',
+			'data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\\"path\\":\\"a.ts\\"}"}}',
+			'data: {"type":"content_block_stop","index":0}',
+			'data: {"type":"message_delta","delta":{"stop_reason":"max_tokens"},"usage":{"output_tokens":2}}',
+			'data: {"type":"message_stop"}'
+		]);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st8', 'model8', {
+			model: 'model8',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: {}
+		});
+
+		const output = await readStream(stream);
+		expect(output).toContain('"name":"Read"');
+		expect(output).not.toContain('"path":"a.ts"');
+		expect(output).toContain('"finish_reason":"length"');
+	});
+
+	it('logs downstream cancellation without flushing an open tool', async () => {
+		const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const encoder = new TextEncoder();
+		const response = new Response(
+			new ReadableStream<Uint8Array>({
+				start(controller) {
+					controller.enqueue(
+						encoder.encode(
+							'data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu6","name":"Write"}}\n'
+						)
+					);
+				}
+			})
+		);
+
+		const { stream } = OpenAIStreamHandler.createStreamResponse(response, 'st9', 'model9', {
+			model: 'model9',
+			source: 'claude',
+			startTime: Date.now(),
+			reverseToolMapping: {}
+		});
+
+		const reader = stream.getReader();
+		const decoder = new TextDecoder();
+		let out = '';
+
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) {
+				break;
+			}
+
+			out += decoder.decode(value, { stream: true });
+			if (out.includes('"name":"Write"')) {
+				await reader.cancel('client abort');
+				break;
+			}
+		}
+
+		const errors = errorSpy.mock.calls.map((call) => call.map(String).join(' ')).join('\n');
+		errorSpy.mockRestore();
+
+		expect(out).toContain('"name":"Write"');
+		expect(out).not.toContain('"finish_reason":"tool_calls"');
+		expect(out).not.toContain('"finish_reason":"length"');
+		expect(out).not.toContain('"finish_reason":"stop"');
+		expect(errors).toContain('Downstream cancelled');
+		expect(errors).toContain('Write');
+		expect(errors).toContain('tu6');
+		expect(recordMock).not.toHaveBeenCalled();
+	});
 });

--- a/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
+++ b/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
@@ -207,4 +207,34 @@ describe('openai-to-anthropic', () => {
 
 		expect(result.max_tokens).toBe(777);
 	});
+
+	it('uses a 32000-token fallback for adaptive-thinking requests without a client limit', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-4.6-opus-high',
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(result.reasoning_budget).toBe('high');
+		expect(result.max_tokens).toBe(32_000);
+	});
+
+	it('keeps the 4096-token fallback when there is no reasoning budget', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-opus-4-6',
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(result.reasoning_budget).toBeUndefined();
+		expect(result.max_tokens).toBe(4096);
+	});
+
+	it('preserves an explicit max_tokens over the thinking fallback', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-4.6-opus-high',
+			max_tokens: 1024,
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(result.max_tokens).toBe(1024);
+	});
 });

--- a/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
+++ b/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { normalizeModelName, openaiToAnthropic } from 'src/adapter/openai-to-anthropic';
+import { logger } from 'src/utils/logger';
 
 import type { AnthropicRequest, ContentBlock } from 'src/types';
 import type { OpenAIChatRequest } from 'src/types/openai';
@@ -12,7 +13,24 @@ function findBlock(request: AnthropicRequest, role: 'user' | 'assistant', type: 
 		.find((block) => block.type === type);
 }
 
+function conversionLog(): string {
+	return (
+		vi
+			.mocked(logger.log)
+			.mock.calls.map((call) => String(call[0]))
+			.find((line) => line.includes('[OpenAI→Anthropic]')) ?? ''
+	);
+}
+
 describe('openai-to-anthropic', () => {
+	beforeEach(() => {
+		vi.spyOn(logger, 'log').mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it('normalizes legacy model names with reasoning budget', () => {
 		expect(normalizeModelName('claude-4.6-opus-high')).toEqual({
 			model: 'claude-opus-4-6',
@@ -206,6 +224,7 @@ describe('openai-to-anthropic', () => {
 		});
 
 		expect(result.max_tokens).toBe(777);
+		expect(conversionLog()).toContain('max_tokens_source=max_completion_tokens');
 	});
 
 	it('uses a 32000-token fallback for adaptive-thinking requests without a client limit', () => {
@@ -216,6 +235,7 @@ describe('openai-to-anthropic', () => {
 
 		expect(result.reasoning_budget).toBe('high');
 		expect(result.max_tokens).toBe(32_000);
+		expect(conversionLog()).toContain('max_tokens_source=thinking-default');
 	});
 
 	it('keeps the 4096-token fallback when there is no reasoning budget', () => {
@@ -226,15 +246,42 @@ describe('openai-to-anthropic', () => {
 
 		expect(result.reasoning_budget).toBeUndefined();
 		expect(result.max_tokens).toBe(4096);
+		expect(conversionLog()).toContain('max_tokens_source=default');
 	});
 
-	it('preserves an explicit max_tokens over the thinking fallback', () => {
+	it('preserves an explicit 4096 max_tokens over the thinking fallback', () => {
 		const result = openaiToAnthropic({
 			model: 'claude-4.6-opus-high',
-			max_tokens: 1024,
+			max_tokens: 4096,
 			messages: [{ role: 'user', content: 'hello' }]
 		});
 
-		expect(result.max_tokens).toBe(1024);
+		expect(result.max_tokens).toBe(4096);
+		expect(conversionLog()).toContain('max_tokens_source=max_tokens');
+	});
+
+	it('preserves an explicit high max_tokens over the thinking fallback', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-4.6-opus-high',
+			max_tokens: 64_000,
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(result.max_tokens).toBe(64_000);
+		expect(conversionLog()).toContain('max_tokens_source=max_tokens');
+	});
+
+	it('treats a none reasoning budget as no adaptive thinking', () => {
+		const result = openaiToAnthropic(
+			{
+				model: 'mapped-opus',
+				messages: [{ role: 'user', content: 'hello' }]
+			},
+			{ model: 'claude-opus-4-6', reasoningBudget: 'none' }
+		);
+
+		expect(result.reasoning_budget).toBeUndefined();
+		expect(result.max_tokens).toBe(4096);
+		expect(conversionLog()).toContain('max_tokens_source=default');
 	});
 });

--- a/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
+++ b/apps/api/tests/unit/adapter/adapter-openai-to-anthropic.test.ts
@@ -238,6 +238,29 @@ describe('openai-to-anthropic', () => {
 		expect(conversionLog()).toContain('max_tokens_source=thinking-default');
 	});
 
+	it('treats a null max_tokens as absent for adaptive thinking', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-4.6-opus-high',
+			max_tokens: null,
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(result.max_tokens).toBe(32_000);
+		expect(conversionLog()).toContain('max_tokens_source=thinking-default');
+	});
+
+	it('uses max_completion_tokens when max_tokens is null', () => {
+		const result = openaiToAnthropic({
+			model: 'claude-opus-4-6',
+			max_tokens: null,
+			max_completion_tokens: 8000,
+			messages: [{ role: 'user', content: 'hello' }]
+		});
+
+		expect(result.max_tokens).toBe(8000);
+		expect(conversionLog()).toContain('max_tokens_source=max_completion_tokens');
+	});
+
 	it('keeps the 4096-token fallback when there is no reasoning budget', () => {
 		const result = openaiToAnthropic({
 			model: 'claude-opus-4-6',


### PR DESCRIPTION
Opus/Fable over Ungate sometimes call CreatePlan (and Write) again and again with no plan and no error. The log shows the same shape twice: a name chunk, then nothing, then Cursor opens a new request.

The Claude stream handler only flushed buffered tool JSON on `content_block_stop`. If the upstream stream ended first, those arguments were dropped and the call was reported as `finish_reason: stop`. Cursor was left holding a tool with a name and empty input.

This PR finalizes the stream once:

- Salvage complete JSON only after Anthropic's `stop_reason: tool_use`. Truncation (`max_tokens`, context window) maps to `length` so Cursor does not execute a partial call. Unexpected EOF never executes a dangling tool, even if the buffer happens to parse — this path can include Shell.
- Log `stop_reason`, unexpected EOF, incomplete JSON, and downstream cancellation (name/id/arg length, never argument contents). That is what tells us whether the next fix is incremental argument streaming.

1.7.9's 4096 fallback also causes high-thinking replies to stop mid-sentence when Cursor omits a limit. Thinking counts toward the cap.

- Adaptive-thinking omissions get 32,000; explicit client values remain authoritative.
- The log now records the value's source (`max_tokens`, `max_completion_tokens`, `thinking-default`, or `default`).
- `'none'` is not adaptive thinking.

Not in this PR: forwarding `input_json_delta` incrementally. That cannot coexist with `ToolNormalizer` without a redesign, and the new logs will show whether Cursor or Anthropic hangs up first.