### PR TITLE
fix: recover orphaned tunnel state

### DIFF
--- a/apps/extension/src/extension-controller.ts
+++ b/apps/extension/src/extension-controller.ts
@@ -451,6 +451,8 @@ export class ExtensionController {
 			runtimeState = await RuntimeStateStore.touchClient(this.windowId);
 		}
 
+		runtimeState = await RuntimeStateStore.reconcileOrphanedTunnel(runtimeState);
+
 		await this.keyFix.applySharedState(runtimeState.keyFix.enabled);
 		this.applyRuntimeState(runtimeState);
 		this.apiServer.syncLeaderHealthMonitor(this.isLeaderWindow(runtimeState));
@@ -502,8 +504,8 @@ export class ExtensionController {
 		}
 
 		const tunnelOwner = runtimeState.tunnel.ownerWindowId;
-		const shouldHandleTunnelCommand =
-			!tunnelOwner || tunnelOwner === this.windowId || !RuntimeStateStore.getLiveClientIds(runtimeState).includes(tunnelOwner);
+		const ownerIsLive = tunnelOwner !== null && RuntimeStateStore.getLiveClientIds(runtimeState).includes(tunnelOwner);
+		const shouldHandleTunnelCommand = ownerIsLive ? tunnelOwner === this.windowId : this.isLeaderWindow(runtimeState);
 
 		if (command.action === 'restart-api') {
 			if (!this.isLeaderWindow(runtimeState)) {

--- a/apps/extension/src/runtime-state/runtime-state-store.ts
+++ b/apps/extension/src/runtime-state/runtime-state-store.ts
@@ -63,6 +63,28 @@ export class RuntimeStateStore {
 		return live[0];
 	}
 
+	public static async reconcileOrphanedTunnel(state: RuntimeState = this.read()): Promise<RuntimeState> {
+		if (!this.isOrphanedTunnel(state)) {
+			return state;
+		}
+
+		return await this.mutate((current) => {
+			if (!this.isOrphanedTunnel(current)) {
+				return current;
+			}
+
+			const now = Date.now();
+
+			current.tunnel.status = 'stopped';
+			current.tunnel.url = null;
+			current.tunnel.lastError = null;
+			current.tunnel.ownerWindowId = null;
+			current.tunnel.lastSeenAt = now;
+
+			return current;
+		});
+	}
+
 	public static getFilePath(): string {
 		return RuntimeStateFileStore.getFilePath();
 	}
@@ -152,6 +174,22 @@ export class RuntimeStateStore {
 
 			return current;
 		});
+	}
+
+	private static isActiveTunnel(state: RuntimeState): boolean {
+		const status = state.tunnel.status;
+
+		return status === 'running' || status === 'starting' || status === 'installing';
+	}
+
+	private static isOrphanedTunnel(state: RuntimeState, now = Date.now()): boolean {
+		if (!this.isActiveTunnel(state)) {
+			return false;
+		}
+
+		const ownerId = state.tunnel.ownerWindowId;
+
+		return ownerId === null || !this.getLiveClientIds(state, now).includes(ownerId);
 	}
 
 	private static async isApiPortHealthy(port: number): Promise<boolean> {

--- a/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
+++ b/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_KEY_FIX_ENABLED, type RuntimeState, type TunnelState } from '@ungate/shared/frontend';
+import { DEFAULT_KEY_FIX_ENABLED, type RuntimeCommand, type RuntimeState, type TunnelState } from '@ungate/shared/frontend';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { TestHelper } from './helpers/test-helper';
@@ -15,7 +15,9 @@ interface MockApiServer {
 }
 
 interface MockTunnelManager {
+	start: ReturnType<typeof vi.fn>;
 	stop: ReturnType<typeof vi.fn>;
+	restart: ReturnType<typeof vi.fn>;
 }
 
 interface MockDashboard {
@@ -60,7 +62,9 @@ const runtimeGetLiveClientIdsMock = vi.fn<(state: RuntimeState) => string[]>();
 const runtimeTouchClientMock = vi.fn<(windowId: string) => Promise<RuntimeState>>();
 const runtimeRemoveClientMock = vi.fn<(windowId: string) => Promise<RuntimeState>>();
 const runtimeGetLeaderWindowIdMock = vi.fn<(state: RuntimeState) => string | null>();
-const runtimePeekCommandMock = vi.fn<() => null>();
+const runtimePeekCommandMock = vi.fn<() => RuntimeCommand | null>();
+const runtimeReconcileOrphanedTunnelMock = vi.fn<(state?: RuntimeState) => Promise<RuntimeState>>();
+const runtimeRemoveCommandMock = vi.fn<(commandId: string) => Promise<RuntimeState>>();
 const prepareApiForBootstrapMock = vi.fn(() => Promise.resolve(runtimeReadMock()));
 
 const apiServerStartMock = vi.fn().mockResolvedValue(undefined);
@@ -112,6 +116,8 @@ vi.mock('../../src/runtime-state', () => {
 			removeClient: runtimeRemoveClientMock,
 			getLeaderWindowId: runtimeGetLeaderWindowIdMock,
 			peekCommand: runtimePeekCommandMock,
+			reconcileOrphanedTunnel: runtimeReconcileOrphanedTunnelMock,
+			removeCommand: runtimeRemoveCommandMock,
 			isApiStartSuppressed: (state?: RuntimeState) => {
 				const runtimeState = state ?? runtimeReadMock();
 
@@ -157,7 +163,9 @@ vi.mock('../../src/openai-key-fix', () => {
 vi.mock('../../src/tunnel-manager', () => {
 	return {
 		TunnelManager: class {
+			start = vi.fn();
 			stop = vi.fn();
+			restart = vi.fn();
 		}
 	};
 });
@@ -207,7 +215,9 @@ function createController(windowId: string): {
 		syncLeaderHealthMonitor: vi.fn()
 	};
 	const tunnelManager: MockTunnelManager = {
-		stop: vi.fn()
+		start: vi.fn().mockResolvedValue(undefined),
+		stop: vi.fn(),
+		restart: vi.fn().mockResolvedValue(undefined)
 	};
 	const dashboard: MockDashboard = {
 		setPort: vi.fn(),
@@ -278,6 +288,12 @@ describe('ExtensionController', () => {
 		runtimeGetLeaderWindowIdMock.mockReset();
 		runtimePeekCommandMock.mockReset();
 		runtimePeekCommandMock.mockReturnValue(null);
+		runtimeReconcileOrphanedTunnelMock.mockReset();
+		runtimeReconcileOrphanedTunnelMock.mockImplementation((state) => {
+			return Promise.resolve(state ?? runtimeReadMock());
+		});
+		runtimeRemoveCommandMock.mockReset();
+		runtimeRemoveCommandMock.mockResolvedValue(createRuntimeState([], null));
 		prepareApiForBootstrapMock.mockReset();
 		prepareApiForBootstrapMock.mockImplementation(() => {
 			const runtimeState = runtimeReadMock();
@@ -528,5 +544,59 @@ describe('ExtensionController', () => {
 
 		expect(dashboard.setPort).toHaveBeenCalledWith(4783);
 		expect(internals.currentPort).toBe(4783);
+	});
+
+	it('uses reconciled stopped tunnel state without starting the tunnel', async () => {
+		const { controller, tunnelManager, dashboard } = createController('window-a');
+		const internals = getInternals(controller);
+		const runtimeState = createRuntimeState(['window-a']);
+		runtimeState.tunnel.status = 'running';
+		runtimeState.tunnel.url = 'https://stale.trycloudflare.com';
+		runtimeState.tunnel.ownerWindowId = 'dead-window';
+		const reconciled = createRuntimeState(['window-a']);
+		reconciled.tunnel.status = 'stopped';
+		reconciled.tunnel.url = null;
+		reconciled.tunnel.ownerWindowId = null;
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeGetLiveClientIdsMock.mockReturnValue(['window-a']);
+		runtimeGetLeaderWindowIdMock.mockReturnValue('window-a');
+		runtimeReconcileOrphanedTunnelMock.mockResolvedValue(reconciled);
+
+		await internals.syncFromRuntimeState();
+
+		expect(runtimeReconcileOrphanedTunnelMock).toHaveBeenCalledWith(runtimeState);
+		expect(dashboard.sendTunnelState).toHaveBeenCalledWith({
+			status: 'stopped',
+			url: null,
+			error: null
+		});
+		expect(tunnelManager.start).not.toHaveBeenCalled();
+		expect(tunnelManager.restart).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		{ windowId: 'window-a', isLeader: true },
+		{ windowId: 'window-b', isLeader: false }
+	])('handles a stale-owner tunnel command only as leader ($windowId)', async ({ windowId, isLeader }) => {
+		const { controller, tunnelManager } = createController(windowId);
+		const internals = getInternals(controller);
+		const runtimeState = createRuntimeState(['window-a', 'window-b']);
+		runtimeState.tunnel.status = 'running';
+		runtimeState.tunnel.ownerWindowId = 'dead-window';
+		const command: RuntimeCommand = {
+			id: 'cmd-stop-tunnel',
+			action: 'stop-tunnel',
+			createdAt: Date.now(),
+			originWindowId: 'window-c'
+		};
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeGetLiveClientIdsMock.mockReturnValue(['window-a', 'window-b']);
+		runtimeGetLeaderWindowIdMock.mockReturnValue('window-a');
+		runtimePeekCommandMock.mockReturnValue(command);
+
+		await internals.syncFromRuntimeState();
+
+		expect(tunnelManager.stop).toHaveBeenCalledTimes(isLeader ? 1 : 0);
+		expect(runtimeRemoveCommandMock.mock.calls).toEqual(isLeader ? [[command.id]] : []);
 	});
 });

--- a/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
+++ b/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
@@ -599,4 +599,27 @@ describe('ExtensionController', () => {
 		expect(tunnelManager.stop).toHaveBeenCalledTimes(isLeader ? 1 : 0);
 		expect(runtimeRemoveCommandMock.mock.calls).toEqual(isLeader ? [[command.id]] : []);
 	});
+
+	it('does not handle a tunnel command when a different live window owns the tunnel', async () => {
+		const { controller, tunnelManager } = createController('window-b');
+		const internals = getInternals(controller);
+		const runtimeState = createRuntimeState(['window-a', 'window-b']);
+		runtimeState.tunnel.status = 'running';
+		runtimeState.tunnel.ownerWindowId = 'window-a';
+		const command: RuntimeCommand = {
+			id: 'cmd-stop-tunnel',
+			action: 'stop-tunnel',
+			createdAt: Date.now(),
+			originWindowId: 'window-c'
+		};
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeGetLiveClientIdsMock.mockReturnValue(['window-a', 'window-b']);
+		runtimeGetLeaderWindowIdMock.mockReturnValue('window-a');
+		runtimePeekCommandMock.mockReturnValue(command);
+
+		await internals.syncFromRuntimeState();
+
+		expect(tunnelManager.stop).not.toHaveBeenCalled();
+		expect(runtimeRemoveCommandMock).not.toHaveBeenCalled();
+	});
 });

--- a/apps/extension/tests/unit/runtime-state-store.test.ts
+++ b/apps/extension/tests/unit/runtime-state-store.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RuntimeStateStore } from '../../src/runtime-state/runtime-state-store';
 
-import type { RuntimeState } from '@ungate/shared/frontend';
+import type { RuntimeState, TunnelStatus } from '@ungate/shared/frontend';
 
 const { runtimeMutateMock, runtimeReadMock } = vi.hoisted(() => {
 	return {
@@ -46,6 +46,17 @@ function createState(apiStatus: RuntimeState['api']['status'], lastError: string
 	};
 }
 
+function createOrphanedTunnelState(status: TunnelStatus): RuntimeState {
+	const state = createState('stopped');
+	state.tunnel.status = status;
+	state.tunnel.url = 'https://example.trycloudflare.com';
+	state.tunnel.lastError = 'stale';
+	state.tunnel.ownerWindowId = null;
+	state.tunnel.lastSeenAt = 1;
+
+	return state;
+}
+
 describe('RuntimeStateStore', () => {
 	beforeEach(() => {
 		runtimeMutateMock.mockReset();
@@ -81,5 +92,49 @@ describe('RuntimeStateStore', () => {
 		const next = runtimeMutateMock.mock.calls[0][0](structuredClone(initial));
 		expect(next.api.startSuppressed).toBe(true);
 		expect(next.api.status).toBe('error');
+	});
+
+	it.each(['running', 'starting', 'installing'] as const)('clears an orphaned %s tunnel', async (status: TunnelStatus) => {
+		const initial = createOrphanedTunnelState(status);
+		runtimeReadMock.mockReturnValue(initial);
+		runtimeMutateMock.mockImplementation((mutator) => Promise.resolve(mutator(structuredClone(initial))));
+
+		const next = await RuntimeStateStore.reconcileOrphanedTunnel();
+
+		expect(runtimeMutateMock).toHaveBeenCalledTimes(1);
+		expect(next.tunnel.status).toBe('stopped');
+		expect(next.tunnel.url).toBeNull();
+		expect(next.tunnel.lastError).toBeNull();
+		expect(next.tunnel.ownerWindowId).toBeNull();
+		expect(next.tunnel.lastSeenAt).toBeGreaterThan(initial.tunnel.lastSeenAt);
+	});
+
+	it('returns live-owned tunnel unchanged without mutate', async () => {
+		const state = createOrphanedTunnelState('running');
+		state.tunnel.ownerWindowId = 'window-a';
+		state.clients = { 'window-a': { lastSeenAt: Date.now() } };
+
+		const next = await RuntimeStateStore.reconcileOrphanedTunnel(state);
+
+		expect(next).toBe(state);
+		expect(runtimeMutateMock).not.toHaveBeenCalled();
+	});
+
+	it('preserves tunnel when owner becomes live before locked mutation', async () => {
+		const orphaned = createOrphanedTunnelState('running');
+		orphaned.tunnel.ownerWindowId = 'window-a';
+
+		const claimed = structuredClone(orphaned);
+		claimed.clients = { 'window-a': { lastSeenAt: Date.now() } };
+
+		runtimeReadMock.mockReturnValue(orphaned);
+		runtimeMutateMock.mockImplementation((mutator) => Promise.resolve(mutator(structuredClone(claimed))));
+
+		const next = await RuntimeStateStore.reconcileOrphanedTunnel();
+
+		expect(runtimeMutateMock).toHaveBeenCalledTimes(1);
+		expect(next.tunnel.status).toBe('running');
+		expect(next.tunnel.url).toBe(orphaned.tunnel.url);
+		expect(next.tunnel.ownerWindowId).toBe('window-a');
 	});
 });


### PR DESCRIPTION
## Summary
- clear active tunnel state when its owner window is no longer live
- re-check ownership under the runtime-state lock to avoid racing a new owner
- route stale-owner tunnel commands to only the deterministic leader window

## Test plan
- [x] `pnpm --filter ungate run lint`
- [x] `pnpm --filter ungate test` (70 tests)
- [x] full repository pre-commit checks (extension and API suites)
- [x] confirm one `cloudflared` process and HTTP 200 from local and public `/health`