### PR TITLE
fix: constrain Codex call IDs

### DIFF
--- a/apps/api/src/proxy/codex-call-id.ts
+++ b/apps/api/src/proxy/codex-call-id.ts
@@ -1,0 +1,38 @@
+import { createHash } from 'node:crypto';
+
+const CALL_ITEM_TYPES = new Set(['function_call', 'function_call_output', 'custom_tool_call', 'custom_tool_call_output']);
+
+export function normalizeCodexCallId(id: string): string {
+	if (id.length <= 64) {
+		return id;
+	}
+
+	return `${id.slice(0, 47)}_${createHash('sha256').update(id).digest('hex').slice(0, 16)}`;
+}
+
+// Upstream constrains call_id to 1-64 characters with no character-set rule. An empty id is
+// dropped rather than synthesized: every empty id would hash to the same value and cross-pair
+// unrelated calls, and an unpaired output is already discarded downstream.
+export function remapCodexCallIds(items: Record<string, unknown>[]): Record<string, unknown>[] {
+	const remapped: Record<string, unknown>[] = [];
+
+	for (const item of items) {
+		if (typeof item.type !== 'string' || !CALL_ITEM_TYPES.has(item.type)) {
+			remapped.push(item);
+			continue;
+		}
+
+		if (typeof item.call_id !== 'string') {
+			remapped.push(item);
+			continue;
+		}
+
+		if (item.call_id === '') {
+			continue;
+		}
+
+		remapped.push({ ...item, call_id: normalizeCodexCallId(item.call_id) });
+	}
+
+	return remapped;
+}

--- a/apps/api/src/proxy/codex-input-utils.ts
+++ b/apps/api/src/proxy/codex-input-utils.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import { remapCodexCallIds } from 'src/proxy/codex-call-id';
 
 import type { OpenAIContentPart, OpenAIMessage, OpenAIToolCall } from 'src/types/openai';
 
@@ -19,7 +19,7 @@ export class CodexInputUtils {
 			}
 		}
 
-		return [...developerItems, ...mainItems];
+		return remapCodexCallIds([...developerItems, ...mainItems]);
 	}
 
 	public static normalizeAssistantText(input: Record<string, unknown>[]): Record<string, unknown>[] {
@@ -86,10 +86,6 @@ export class CodexInputUtils {
 			) {
 				const nextItem = { ...itemRecord };
 
-				if (typeof nextItem.call_id === 'string') {
-					nextItem.call_id = this.normalizeCallId(nextItem.call_id);
-				}
-
 				mainItems.push(nextItem);
 				continue;
 			}
@@ -108,7 +104,7 @@ export class CodexInputUtils {
 			return null;
 		}
 
-		return [...developerItems, ...mainItems];
+		return remapCodexCallIds([...developerItems, ...mainItems]);
 	}
 
 	public static coerceMessages(body: { messages?: OpenAIMessage[]; input?: unknown }): OpenAIMessage[] {
@@ -217,7 +213,7 @@ export class CodexInputUtils {
 			if (callId) {
 				items.push({
 					type: 'function_call_output',
-					call_id: this.normalizeCallId(callId),
+					call_id: callId,
 					output
 				});
 			}
@@ -226,12 +222,12 @@ export class CodexInputUtils {
 		}
 
 		if (normalizedRole === 'function') {
-			const callReference = message.name ?? `func_${Date.now()}`;
+			const callReference = message.name?.length ? message.name : `func_${Date.now()}`;
 			const output = typeof message.content === 'string' ? message.content : JSON.stringify(message.content ?? '');
 
 			items.push({
 				type: 'function_call_output',
-				call_id: this.normalizeCallId(callReference),
+				call_id: callReference,
 				output
 			});
 
@@ -375,19 +371,11 @@ export class CodexInputUtils {
 				type: 'function_call',
 				name: callName,
 				arguments: typeof callArguments === 'string' ? callArguments : JSON.stringify(callArguments),
-				call_id: this.normalizeCallId(callId)
+				call_id: callId
 			});
 		}
 
 		return outputItems;
-	}
-
-	private static normalizeCallId(id: string): string {
-		if (id.length <= 64) {
-			return id;
-		}
-
-		return `${id.slice(0, 47)}_${createHash('sha256').update(id).digest('hex').slice(0, 16)}`;
 	}
 
 	private static toText(value: unknown): string {

--- a/apps/api/src/proxy/codex-input-utils.ts
+++ b/apps/api/src/proxy/codex-input-utils.ts
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 import type { OpenAIContentPart, OpenAIMessage, OpenAIToolCall } from 'src/types/openai';
 
 export class CodexInputUtils {
@@ -82,7 +84,13 @@ export class CodexInputUtils {
 				itemType === 'custom_tool_call' ||
 				itemType === 'custom_tool_call_output'
 			) {
-				mainItems.push({ ...itemRecord });
+				const nextItem = { ...itemRecord };
+
+				if (typeof nextItem.call_id === 'string') {
+					nextItem.call_id = this.normalizeCallId(nextItem.call_id);
+				}
+
+				mainItems.push(nextItem);
 				continue;
 			}
 
@@ -209,7 +217,7 @@ export class CodexInputUtils {
 			if (callId) {
 				items.push({
 					type: 'function_call_output',
-					call_id: callId,
+					call_id: this.normalizeCallId(callId),
 					output
 				});
 			}
@@ -223,7 +231,7 @@ export class CodexInputUtils {
 
 			items.push({
 				type: 'function_call_output',
-				call_id: callReference,
+				call_id: this.normalizeCallId(callReference),
 				output
 			});
 
@@ -367,11 +375,19 @@ export class CodexInputUtils {
 				type: 'function_call',
 				name: callName,
 				arguments: typeof callArguments === 'string' ? callArguments : JSON.stringify(callArguments),
-				call_id: callId
+				call_id: this.normalizeCallId(callId)
 			});
 		}
 
 		return outputItems;
+	}
+
+	private static normalizeCallId(id: string): string {
+		if (id.length <= 64) {
+			return id;
+		}
+
+		return `${id.slice(0, 47)}_${createHash('sha256').update(id).digest('hex').slice(0, 16)}`;
 	}
 
 	private static toText(value: unknown): string {

--- a/apps/api/tests/unit/proxy/proxy-codex-chat-input.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-codex-chat-input.test.ts
@@ -161,6 +161,81 @@ describe('proxy-codex-chat-input', () => {
 		expect(input.find((item) => item.type === 'function_call_output')?.call_id).toBe(normalizedId);
 		expect(expanded?.map((item) => item.call_id)).toEqual([normalizedId, normalizedId]);
 	});
+
+	it('passes through verified-charset call ids byte-for-byte in both shapes', () => {
+		const probeIds = ['call.probe', 'call:probe', 'call probe', 'call_žluť', '_call_probe', 'call_probe-'];
+
+		for (const probeId of probeIds) {
+			const input = CodexInputUtils.buildFromMessages([
+				{
+					role: 'assistant',
+					content: null,
+					tool_calls: [{ id: probeId, type: 'function', function: { name: 'Read', arguments: '{}' } }]
+				},
+				{ role: 'tool', tool_call_id: probeId, content: 'result' }
+			]);
+			const expanded = CodexInputUtils.expandInput([
+				{ type: 'function_call', call_id: probeId, name: 'Read', arguments: '{}' },
+				{ type: 'function_call_output', call_id: probeId, output: 'result' }
+			]);
+
+			expect(input.find((item) => item.type === 'function_call')?.call_id).toBe(probeId);
+			expect(input.find((item) => item.type === 'function_call_output')?.call_id).toBe(probeId);
+			expect(expanded?.map((item) => item.call_id)).toEqual([probeId, probeId]);
+			expect(ResponsesInputShape.filterOrphans(input)).toEqual(input);
+			expect(ResponsesInputShape.filterOrphans(expanded ?? [])).toEqual(expanded);
+		}
+	});
+
+	it('passes through a 64-char id and remaps a 65-char id in both shapes', () => {
+		const exactId = 'e'.repeat(64);
+		const overId = 'f'.repeat(65);
+		const remappedId = expectedNormalizedCallId(overId);
+		const input = CodexInputUtils.buildFromMessages([
+			{
+				role: 'assistant',
+				content: null,
+				tool_calls: [
+					{ id: exactId, type: 'function', function: { name: 'Read', arguments: '{}' } },
+					{ id: overId, type: 'function', function: { name: 'Write', arguments: '{}' } }
+				]
+			},
+			{ role: 'tool', tool_call_id: exactId, content: 'exact' },
+			{ role: 'tool', tool_call_id: overId, content: 'over' }
+		]);
+		const expanded = CodexInputUtils.expandInput([
+			{ type: 'function_call', call_id: exactId, name: 'Read', arguments: '{}' },
+			{ type: 'function_call_output', call_id: exactId, output: 'exact' },
+			{ type: 'function_call', call_id: overId, name: 'Write', arguments: '{}' },
+			{ type: 'function_call_output', call_id: overId, output: 'over' }
+		]);
+
+		expect(exactId).toHaveLength(64);
+		expect(overId).toHaveLength(65);
+		expect(remappedId).toHaveLength(64);
+		expect(remappedId).not.toBe(overId);
+		expect(input.find((item) => item.type === 'function_call' && item.name === 'Read')?.call_id).toBe(exactId);
+		expect(input.find((item) => item.type === 'function_call' && item.name === 'Write')?.call_id).toBe(remappedId);
+		expect(input.filter((item) => item.type === 'function_call_output').map((item) => item.call_id)).toEqual([exactId, remappedId]);
+		expect(expanded?.map((item) => item.call_id)).toEqual([exactId, exactId, remappedId, remappedId]);
+	});
+
+	it('drops empty Responses call ids and synthesizes a non-empty id for an empty function name', () => {
+		const expanded = CodexInputUtils.expandInput([
+			{ type: 'function_call', call_id: '', name: 'Read', arguments: '{}' },
+			{ type: 'function_call_output', call_id: '', output: 'ok' }
+		]);
+		const functionOutput = CodexInputUtils.buildFromMessages([{ role: 'function', name: '', content: 'x' }]);
+		const synthesizedId = functionOutput.find((item) => item.type === 'function_call_output')?.call_id;
+
+		expect(expanded).toEqual([]);
+		expect(expanded?.some((item) => item.call_id === '')).toBe(false);
+		expect(functionOutput.some((item) => item.type === 'function_call_output')).toBe(true);
+		expect(typeof synthesizedId).toBe('string');
+		expect(synthesizedId).not.toBe('');
+		expect((synthesizedId as string).length).toBeGreaterThanOrEqual(1);
+		expect((synthesizedId as string).length).toBeLessThanOrEqual(64);
+	});
 });
 
 function expectedNormalizedCallId(id: string): string {

--- a/apps/api/tests/unit/proxy/proxy-codex-chat-input.test.ts
+++ b/apps/api/tests/unit/proxy/proxy-codex-chat-input.test.ts
@@ -1,6 +1,9 @@
+import { createHash } from 'node:crypto';
+
 import { describe, expect, it } from 'vitest';
 
 import { CodexInputUtils } from 'src/proxy/codex-input-utils';
+import { ResponsesInputShape } from 'src/proxy/responses-input-normalizer/input-shape';
 
 describe('proxy-codex-chat-input', () => {
 	it('converts mixed openai messages into codex input preserving order with developer first', () => {
@@ -52,4 +55,118 @@ describe('proxy-codex-chat-input', () => {
 		expect(coerced).toHaveLength(1);
 		expect(coerced[0].role).toBe('user');
 	});
+
+	it('maps a long chat call/output pair to the same 64-char id and keeps it through orphan filtering', () => {
+		const longId = `call_${'a'.repeat(80)}`;
+		const expectedId = expectedNormalizedCallId(longId);
+		const input = CodexInputUtils.buildFromMessages([
+			{
+				role: 'assistant',
+				content: null,
+				tool_calls: [{ id: longId, type: 'function', function: { name: 'Read', arguments: '{}' } }]
+			},
+			{ role: 'tool', tool_call_id: longId, content: 'result' },
+			{ role: 'function', name: longId, content: 'legacy-result' }
+		]);
+		const call = input.find((item) => item.type === 'function_call');
+		const outputs = input.filter((item) => item.type === 'function_call_output');
+
+		expect(expectedId).toHaveLength(64);
+		expect(call?.call_id).toBe(expectedId);
+		expect(outputs.map((item) => item.call_id)).toEqual([expectedId, expectedId]);
+		expect(ResponsesInputShape.filterOrphans(input)).toEqual(input);
+	});
+
+	it('keeps two long ids that share a prefix distinct', () => {
+		const prefix = 'x'.repeat(47);
+		const firstId = `${prefix}first-unique-suffix-aaaaaaaaaaaaaaaa`;
+		const secondId = `${prefix}second-unique-suffix-bbbbbbbbbbbbbbb`;
+		const input = CodexInputUtils.buildFromMessages([
+			{
+				role: 'assistant',
+				content: null,
+				tool_calls: [
+					{ id: firstId, type: 'function', function: { name: 'Read', arguments: '{}' } },
+					{ id: secondId, type: 'function', function: { name: 'Write', arguments: '{}' } }
+				]
+			}
+		]);
+		const callIds = input.filter((item) => item.type === 'function_call').map((item) => item.call_id);
+
+		expect(firstId.slice(0, 47)).toBe(secondId.slice(0, 47));
+		expect(callIds).toEqual([expectedNormalizedCallId(firstId), expectedNormalizedCallId(secondId)]);
+		expect(callIds[0]).not.toBe(callIds[1]);
+		expect(callIds.every((id) => typeof id === 'string' && id.length === 64)).toBe(true);
+	});
+
+	it('maps Responses-shaped call/output pairs to the same 64-char id', () => {
+		const longId = `call_${'b'.repeat(80)}`;
+		const expectedId = expectedNormalizedCallId(longId);
+		const expanded = CodexInputUtils.expandInput([
+			{ type: 'function_call', call_id: longId, name: 'Read', arguments: '{}' },
+			{ type: 'function_call_output', call_id: longId, output: 'ok' },
+			{ type: 'custom_tool_call', call_id: longId, name: 'Custom' },
+			{ type: 'custom_tool_call_output', call_id: longId, output: 'custom-ok' }
+		]);
+
+		expect(expanded?.map((item) => item.call_id)).toEqual([expectedId, expectedId, expectedId, expectedId]);
+		expect(ResponsesInputShape.filterOrphans(expanded ?? [])).toEqual(expanded);
+	});
+
+	it('passes through call ids that are already 64 characters or shorter', () => {
+		const shortId = 'call_short';
+		const exactId = 'c'.repeat(64);
+		const input = CodexInputUtils.buildFromMessages([
+			{
+				role: 'assistant',
+				content: null,
+				tool_calls: [
+					{ id: shortId, type: 'function', function: { name: 'Read', arguments: '{}' } },
+					{ id: exactId, type: 'function', function: { name: 'Write', arguments: '{}' } }
+				]
+			},
+			{ role: 'tool', tool_call_id: shortId, content: 'short' },
+			{ role: 'tool', tool_call_id: exactId, content: 'exact' }
+		]);
+		const expanded = CodexInputUtils.expandInput([
+			{ type: 'function_call', call_id: shortId, name: 'Read', arguments: '{}' },
+			{ type: 'function_call_output', call_id: exactId, output: 'exact' }
+		]);
+
+		expect(input.find((item) => item.type === 'function_call' && item.name === 'Read')?.call_id).toBe(shortId);
+		expect(input.find((item) => item.type === 'function_call' && item.name === 'Write')?.call_id).toBe(exactId);
+		expect(input.filter((item) => item.type === 'function_call_output').map((item) => item.call_id)).toEqual([shortId, exactId]);
+		expect(expanded?.[0].call_id).toBe(shortId);
+		expect(expanded?.[1].call_id).toBe(exactId);
+	});
+
+	it('is idempotent for an already-normalized call id', () => {
+		const longId = `call_${'d'.repeat(80)}`;
+		const normalizedId = expectedNormalizedCallId(longId);
+		const input = CodexInputUtils.buildFromMessages([
+			{
+				role: 'assistant',
+				content: null,
+				tool_calls: [{ id: normalizedId, type: 'function', function: { name: 'Read', arguments: '{}' } }]
+			},
+			{ role: 'tool', tool_call_id: normalizedId, content: 'result' }
+		]);
+		const expanded = CodexInputUtils.expandInput([
+			{ type: 'function_call', call_id: normalizedId, name: 'Read', arguments: '{}' },
+			{ type: 'function_call_output', call_id: normalizedId, output: 'result' }
+		]);
+
+		expect(normalizedId).toHaveLength(64);
+		expect(input.find((item) => item.type === 'function_call')?.call_id).toBe(normalizedId);
+		expect(input.find((item) => item.type === 'function_call_output')?.call_id).toBe(normalizedId);
+		expect(expanded?.map((item) => item.call_id)).toEqual([normalizedId, normalizedId]);
+	});
 });
+
+function expectedNormalizedCallId(id: string): string {
+	if (id.length <= 64) {
+		return id;
+	}
+
+	return `${id.slice(0, 47)}_${createHash('sha256').update(id).digest('hex').slice(0, 16)}`;
+}


### PR DESCRIPTION
## Summary
- deterministically shorten only Codex `call_id` values longer than 64 characters
- apply the same mapping to calls and outputs across chat and Responses-shaped input
- preserve short IDs and collision resistance with a SHA-256 suffix

## Test plan
- [x] `pnpm --filter @ungate/api run lint`
- [x] `pnpm --filter @ungate/api test` (85 unit and 59 integration tests)
- [x] full repository pre-commit checks
- [x] send an 83-character call/output pair; upstream `gpt-5.6-sol` returned `verified` with no 400