### PR TITLE
fix(security): harden local proxy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,17 +27,19 @@ Cursor → Cloudflare Tunnel → Ungate API → Provider API. Cursor cannot call
 Fastify server, spawned by the extension as a child Node.js process.
 
 **Entry points:**
-- `/v1/chat/completions` — OpenAI-compatible endpoint, accepts requests from Cursor
-- `/v1/messages` — Anthropic-compatible endpoint (direct proxy)
-- `/v1/analytics` — request statistics
-- `/v1/auth/*` — OAuth routes (Claude, ChatGPT)
-- `/v1/models` — model list
-- `/v1/settings` — settings
+- `/v1/chat/completions` — OpenAI-compatible endpoint, accepts requests from Cursor (proxy key)
+- `/v1/messages` — Anthropic-compatible endpoint (direct proxy, proxy key)
+- `/v1/models` — model list (proxy key)
+- `/v1/analytics` — request statistics (admin key)
+- `/v1/auth/*` — OAuth routes (Claude, ChatGPT) (admin key)
+- `/v1/settings` — settings (admin key)
+- `/health` — the only unauthenticated route; the extension polls it for liveness
 
 **Architecture:**
-- `src/server.ts` — Fastify initialization, plugin registration
-- `src/config.ts` — static configuration (URLs, OAuth, beta parameters)
-- `src/plugins/auth.ts` — preHandler for API-key authentication
+- `src/server.ts` — Fastify initialization, plugin registration. Binds `127.0.0.1` only (`LISTEN_HOST`); the Cloudflare tunnel is the sole remote path in.
+- `src/config.ts` — static configuration (URLs, OAuth, beta parameters). `getConfig` requires `UNGATE_ADMIN_KEY` in the environment and throws without it, so administrative routes can never come up unprotected.
+- `src/plugins/auth.ts` — `apiKeyAuth` (proxy key, `Authorization: Bearer` or `x-api-key`) and `adminKeyAuth` (admin key, `x-ungate-admin-key`). Both compare hashed digests through `timingSafeEqual`, and both fail closed: an absent or blank configured key rejects every request rather than opening the route. Registered as encapsulated `onRequest` hooks inside each route plugin, so a newly added route inherits its plugin's auth instead of defaulting to open.
+- `src/plugins/cors-origin.ts` — CORS origin policy: webview and loopback origins only, never a wildcard, so no web page can drive the dashboard API.
 
 **Routing (`src/routes/`):**
 - `openai.ts` — main router: determines provider by model (MiniMax → mapped → Claude). Branch order matters and must stay consistent.
@@ -84,7 +86,7 @@ Fastify server, spawned by the extension as a child Node.js process.
 
 **Database (`src/database/`):**
 - SQLite via Drizzle ORM + better-sqlite3
-- Tables: `app_settings` (port, apiKey, quiet, extraInstruction), `provider_settings` (per-provider OAuth tokens, refresh tokens, expiry), `model_mappings` (id, label, provider, upstreamModel, reasoningBudget), `requests` (analytics)
+- Tables: `app_settings` (port, apiKey, quiet, extraInstruction), `provider_settings` (per-provider metadata: expiry, email, accountId, baseUrl — the `access_token`/`refresh_token` columns are legacy and always blank), `model_mappings` (id, label, provider, upstreamModel, reasoningBudget), `requests` (analytics)
 - Migrations: `apps/api/drizzle/` — idempotent (`CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`)
 
 **Types (`src/types/`):**
@@ -100,16 +102,23 @@ Fastify server, spawned by the extension as a child Node.js process.
 
 **Auth (`src/auth/`):**
 - OAuth PKCE flow for Anthropic: `startLogin()` generates verifier/challenge, `completeLogin()` exchanges code for tokens. Manual `CODE#STATE` entry required (Anthropic rejects localhost redirect_uri for claude.ai OAuth).
+- Provider methods are async — credentials come from the extension, not the database.
+
+**Security (`src/security/`):**
+- `provider-secrets.ts` — process-wide credential facade over a pluggable transport. Reads deny when no transport is installed, writes throw `SecretStorageUnavailableError`
+- `ipc-secret-transport.ts` — request/response client over the child process IPC channel
+- `credential-channel.ts` — `requireCredentialChannel()`: installs the transport or throws `CredentialChannelMissingError`, then exits the process if the channel is later lost. Called first from `main.ts`, before the legacy migration and before `startServer()`
 
 ## apps/extension — VS Code extension
 
 User entry point. Manages the API server and tunnel lifecycle.
 
-- `extension.ts` — activate/deactivate
-- `extension-controller.ts` — main controller: manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
-- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex
+- `extension.ts` — activate/deactivate. `activate` is async: secrets must be readable before anything starts
+- `extension-controller.ts` — main controller: creates `SecuritySecrets`, manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
+- `security-secrets.ts` — owner of the administrative API key (`ungate.admin-api-key`) and provider credentials in VS Code SecretStorage. `create(storage)` mints a 256-bit base64url key on first run; `handleApiChildMessage` answers the API child's credential requests
+- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex. Spawned with a fourth `ipc` stdio slot for credential requests and `UNGATE_ADMIN_KEY` in the environment
 - `tunnel-manager.ts` — Cloudflare tunnel (cloudflared) management. Quick tunnel only, no named tunnel config (avoids 404 conflicts). Not auto-started, only on explicit user action. Auto-restarts on port change if already running
-- `dashboard.ts` — WebView dashboard (Svelte UI). Reads `index.html` from `web/dist/`, rewrites `/assets/` to `vscode-resource:` URIs, injects `window.__PORT__`. Handshake: frontend sends `webview-ready` before extension sends initial state
+- `dashboard.ts` — WebView dashboard (Svelte UI). Reads `index.html` from `web/dist/`, rewrites `/assets/` to `vscode-resource:` URIs, injects `window.__PORT__` and `window.__ADMIN_KEY__` via `toInlineScriptJson` (JSON plus `<`/`>`/`&`/U+2028/U+2029 escaping, and a function replacer so `$&` patterns in a value are never expanded). Constructor takes `(context, adminApiKey, onMessage)`. Handshake: frontend sends `webview-ready` before extension sends initial state
 - `extension-status-bar.ts` — status bar (API + tunnel state)
 - `extension-commands.ts` — command registration (openDashboard, copyTunnelUrl, restartTunnel, toggleKeyFix)
 - `openai-key-fix.ts` — auto-enable OpenAI API Key in Cursor settings. Uses `aiSettings.usingOpenAIKey.toggle` command. SQLite writes to `state.vscdb` do not work — Cursor does not re-read reactive storage
@@ -118,6 +127,11 @@ User entry point. Manages the API server and tunnel lifecycle.
 **Native dependencies:**
 - better-sqlite3: prebuilt binary downloaded at first run from GitHub Releases matching host Node ABI (not Electron). VSIX ships only JS wrapper + bindings
 - cloudflared: binary downloaded to `~/.ungate/bin/`, managed by tsup bundling
+- sqlite3 CLI: `sqlite-tools` archive from sqlite.org, used only to read Cursor's `state.vscdb`
+- Every download goes through `utils/verified-artifact.ts`: one pinned upstream URL plus a SHA-256 allowlist per platform/arch (and per Node ABI for better-sqlite3). Bytes are hashed while streaming into a staging directory and compared with `timingSafeEqual`; nothing is extracted, copied, chmod-ed or executed before the digest matches, and staging is deleted on failure. Unknown platform/ABI tuples fail closed with an actionable error instead of falling back to a `latest` release
+- Pinned sets: better-sqlite3 12.11.1 for Node ABI 127/137/141/147 (Node 22/24/25/26) on glibc Linux, macOS and Windows; cloudflared 2026.8.2; sqlite-tools 3470200 (upstream publishes only `win-x64`, `linux-x64`, `osx-x64` — macOS arm64 and Linux arm64 must supply their own `sqlite3` on PATH)
+- Every binary Ungate installs carries a `<binary>.sha256` stamp written after verification: `~/.ungate/bin/` for cloudflared and the sqlite3 CLI, and `better_sqlite3.installed.node` in the API's `node_modules`. A managed binary without a matching stamp is treated as unverified — it is never loaded, executed or handed to the API child, and is replaced by a verified install. This retires binaries left behind by pre-pinning Ungate versions and by the `cloudflared` npm helper's `latest` install. The bundled/dev `better_sqlite3.node` binding shipped in the tree is still load-tested, since it is not a download
+- There is no manual drop-in override: on a platform with no pinned artifact the unsupported error says the feature cannot start, rather than pointing at a directory whose unstamped contents would be rejected anyway
 
 **Logs:**
 - Two ring buffers (500 entries each): API (stdout/stderr) and tunnel (stderr)
@@ -139,7 +153,7 @@ Dashboard for managing providers, tunnel, settings.
 
 Types, constants, Zod schemas, helpers.
 
-- `src/types/` — `settings.ts`, `runtime.ts`, `tunnel.ts`, `analytics.ts`, `log.ts`
+- `src/types/` — `settings.ts`, `runtime.ts`, `tunnel.ts`, `analytics.ts`, `log.ts`, `secrets.ts`
 - `src/constants/` — `routes.ts`
 - `src/enums/` — `common.ts`
 - `src/helpers/` — `model-provider.ts`, `provider-labels.ts`, `utils.ts`
@@ -149,7 +163,9 @@ Types, constants, Zod schemas, helpers.
 
 ## Key mechanisms
 
-**Claude OAuth authentication:** acquires token via Anthropic OAuth PKCE flow, stores in SQLite. Refreshes token on 401. Anthropic requires exact request fingerprint: `?beta=true` URL suffix, `User-Agent: claude-cli/2.1.9`, full `x-stainless-*` headers, `anthropic-dangerous-direct-browser-access: true`, three `anthropic-beta` feature flags (oauth, claude-code, interleaved-thinking). Manual `CODE#STATE` entry required — Anthropic does not accept localhost as redirect_uri for claude.ai OAuth.
+**Claude OAuth authentication:** acquires token via Anthropic OAuth PKCE flow, stores the credential in the extension secret store (never SQLite). Refreshes token on 401. Anthropic requires exact request fingerprint: `?beta=true` URL suffix, `User-Agent: claude-cli/2.1.9`, full `x-stainless-*` headers, `anthropic-dangerous-direct-browser-access: true`, three `anthropic-beta` feature flags (oauth, claude-code, interleaved-thinking). Manual `CODE#STATE` entry required — Anthropic does not accept localhost as redirect_uri for claude.ai OAuth.
+
+**Credential storage:** provider access and refresh tokens live in VS Code SecretStorage under `ungate.provider.<provider>`, owned by the extension (`security-secrets.ts`). The API child process asks for them over its IPC channel (`ungate.provider-secret` messages, protocol in `packages/shared/src/types/secrets.ts`); `ProviderSettings` joins that credential with the SQLite metadata row. Every message is validated and correlated by request id; a missing or closed channel fails closed — reads deny, writes throw. `main.ts` refuses to start at all without the channel (`requireCredentialChannel()`), so the API is never up while unable to serve any provider, and the legacy migration never blanks a column it cannot drain. Then `ProviderSettings.migrateLegacySecrets()` moves credentials left in the legacy SQLite columns into the secret store and blanks them. Losing the channel later is equally fatal: the process exits on `disconnect` and the leader window respawns it.
 
 **System prompt conflict:** Claude Code's system prompt describing tools conflicts with Cursor's actual `input_schema`. The prompt must be minimal (just identity) and delegate tool shape to `input_schema`. The `extraInstruction` field in `app_settings` reinforces this priority. Full removal breaks API contract (empty blocks error), long prompts cause `invalid arguments` on large plans.
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ If Cursor turns `OpenAI API Key` off on its own, Ungate should turn it back on a
 - Tunnel URL and proxy API key are secrets and should be treated like credentials.
 - Anyone with both values can send requests through your proxy.
 - Rotate your proxy key from the dashboard when you suspect leakage.
+- The proxy key only authorizes model routes: completions, messages, and the model list.
+- Settings, provider auth, and analytics require a separate admin key that never leaves your machine — the extension keeps it in Cursor's secret storage and injects it into the dashboard only.
+- The proxy binds `127.0.0.1`, so it is reachable through the tunnel and from your own machine, never from other hosts on your network.
+- Clearing the proxy key does not open the proxy up: model routes reject every request until a new key is set.
 
 ## Local build and install in Cursor
 

--- a/apps/api/src/auth/base-provider.ts
+++ b/apps/api/src/auth/base-provider.ts
@@ -8,9 +8,10 @@ export interface OAuthCredentials {
 	accountId?: string | null;
 }
 
+/** Every member is async: credentials live in the extension secret store, one IPC hop away. */
 export interface AIProvider {
 	readonly name: AIProviderName;
-	getAuthHeader(): string | null | Promise<string | null>;
-	isAuthenticated(): boolean;
-	logout(): void;
+	getAuthHeader(): Promise<string | null>;
+	isAuthenticated(): Promise<boolean>;
+	logout(): Promise<void>;
 }

--- a/apps/api/src/auth/claude-provider.ts
+++ b/apps/api/src/auth/claude-provider.ts
@@ -15,11 +15,13 @@ export class ClaudeProvider implements AIProvider {
 		return `Bearer ${token.accessToken}`;
 	}
 
-	isAuthenticated(): boolean {
-		return OAuth.getAuthStatus().authenticated;
+	async isAuthenticated(): Promise<boolean> {
+		const status = await OAuth.getAuthStatus();
+
+		return status.authenticated;
 	}
 
-	logout(): void {
-		OAuth.logout();
+	async logout(): Promise<void> {
+		await OAuth.logout();
 	}
 }

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -120,7 +120,7 @@ export class OAuth {
 			const expiresAt = Date.now() + data.expires_in * 1000;
 			const email = data.account?.email_address;
 
-			ProviderSettings.upsertOAuth('claude', {
+			await ProviderSettings.upsertOAuth('claude', {
 				accessToken: data.access_token,
 				refreshToken: data.refresh_token,
 				expiresAt,
@@ -167,7 +167,7 @@ export class OAuth {
 			const data: TokenRefreshResponse = await response.json();
 			const expiresAt = Date.now() + data.expires_in * 1000;
 
-			ProviderSettings.upsertOAuth('claude', {
+			await ProviderSettings.upsertOAuth('claude', {
 				accessToken: data.access_token,
 				refreshToken: data.refresh_token,
 				expiresAt
@@ -191,9 +191,9 @@ export class OAuth {
 	}
 
 	static async getValidToken(): Promise<TokenInfo | null> {
-		const row = ProviderSettings.get('claude');
+		const row = await ProviderSettings.get('claude');
 
-		if (!row) {
+		if (!row?.accessToken) {
 			return null;
 		}
 
@@ -208,24 +208,28 @@ export class OAuth {
 			return result;
 		}
 
-		return this.refreshToken(row.refreshToken!);
+		if (!row.refreshToken) {
+			return null;
+		}
+
+		return this.refreshToken(row.refreshToken);
 	}
 
-	// No-op — token state is DB-backed, no in-memory cache to clear
+	// No-op — token state lives in the extension secret store, no in-memory cache to clear
 	static clearCachedToken(): void {}
 
-	static getAuthStatus(): AuthStatus {
-		const row = ProviderSettings.get('claude');
+	static async getAuthStatus(): Promise<AuthStatus> {
+		const row = await ProviderSettings.get('claude');
 
-		if (!row) {
+		if (!row?.accessToken) {
 			return { authenticated: false };
 		}
 
 		return { authenticated: true, email: row.email ?? undefined };
 	}
 
-	static logout(): void {
-		ProviderSettings.remove('claude');
+	static async logout(): Promise<void> {
+		await ProviderSettings.remove('claude');
 		logger.log('✓ Logged out, OAuth tokens deleted');
 	}
 }

--- a/apps/api/src/auth/openai/openai-oauth-service.ts
+++ b/apps/api/src/auth/openai/openai-oauth-service.ts
@@ -83,16 +83,16 @@ export class OpenAIOAuthService {
 			accountId: accountId ?? undefined
 		};
 
-		ProviderSettings.upsertOAuth('openai', credentials);
+		await ProviderSettings.upsertOAuth('openai', credentials);
 		logger.log('✓ OpenAI OAuth login complete', email ? `(${email})` : '');
 
 		return { ok: true, email: email ?? undefined };
 	}
 
 	public static async getValidToken(): Promise<OAuthCredentials | null> {
-		const credentials = ProviderSettings.get('openai');
+		const credentials = await ProviderSettings.get('openai');
 
-		if (!credentials) {
+		if (!credentials?.accessToken) {
 			return null;
 		}
 
@@ -113,7 +113,7 @@ export class OpenAIOAuthService {
 			return null;
 		}
 
-		const existingCredentials = ProviderSettings.get('openai');
+		const existingCredentials = ProviderSettings.getMetadata('openai');
 		const expiresIn = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600;
 		const credentials: OAuthCredentials = {
 			accessToken: tokens.access_token as string,
@@ -123,14 +123,14 @@ export class OpenAIOAuthService {
 			accountId: existingCredentials?.accountId ?? undefined
 		};
 
-		ProviderSettings.upsertOAuth('openai', credentials);
+		await ProviderSettings.upsertOAuth('openai', credentials);
 		logger.log('OpenAI token refreshed successfully');
 
 		return credentials;
 	}
 
-	public static getAuthStatus(): { authenticated: boolean; email?: string } {
-		const credentials = ProviderSettings.get('openai');
+	public static async getAuthStatus(): Promise<{ authenticated: boolean; email?: string }> {
+		const credentials = await ProviderSettings.get('openai');
 
 		return {
 			authenticated: !!credentials?.accessToken,
@@ -138,8 +138,8 @@ export class OpenAIOAuthService {
 		};
 	}
 
-	public static logout(): void {
-		ProviderSettings.remove('openai');
+	public static async logout(): Promise<void> {
+		await ProviderSettings.remove('openai');
 		logger.log('✓ OpenAI OAuth logged out, tokens deleted');
 	}
 

--- a/apps/api/src/auth/static-token-provider.ts
+++ b/apps/api/src/auth/static-token-provider.ts
@@ -9,8 +9,8 @@ export class StaticTokenProvider implements AIProvider {
 		this.name = name;
 	}
 
-	getAuthHeader(): string | null {
-		const creds = ProviderSettings.get(this.name);
+	async getAuthHeader(): Promise<string | null> {
+		const creds = await ProviderSettings.get(this.name);
 
 		if (!creds?.accessToken) {
 			return null;
@@ -19,13 +19,11 @@ export class StaticTokenProvider implements AIProvider {
 		return `Bearer ${creds.accessToken}`;
 	}
 
-	isAuthenticated(): boolean {
-		const creds = ProviderSettings.get(this.name);
-
-		return !!creds?.accessToken;
+	async isAuthenticated(): Promise<boolean> {
+		return ProviderSettings.hasCredentials(this.name);
 	}
 
-	logout(): void {
-		ProviderSettings.remove(this.name);
+	async logout(): Promise<void> {
+		await ProviderSettings.remove(this.name);
 	}
 }

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,4 +1,4 @@
-import { MINIMAX_BASE_URLS, type AppSettings } from '@ungate/shared';
+import { ADMIN_KEY_ENV, ADMIN_KEY_MIN_LENGTH, MINIMAX_BASE_URLS, type AppSettings } from '@ungate/shared';
 
 import type { ProxyConfig } from './types';
 
@@ -59,6 +59,22 @@ export function getConfig(settings: AppSettings): ProxyConfig {
 	return {
 		port: envPort ?? settings.port,
 		apiKey: settings.apiKey ?? undefined,
+		adminApiKey: readAdminApiKey(),
 		quietMode: settings.quiet
 	};
+}
+
+// The admin key lives only in the environment. It is minted by the extension, stored in VS Code
+// SecretStorage and handed to this process at spawn time, so a missing value means the API was
+// launched outside the extension. Failing here keeps administrative routes from ever opening up.
+function readAdminApiKey(): string {
+	const value = process.env[ADMIN_KEY_ENV] ?? '';
+
+	if (value.length < ADMIN_KEY_MIN_LENGTH) {
+		throw new Error(
+			`${ADMIN_KEY_ENV} must hold a 256-bit key (at least ${ADMIN_KEY_MIN_LENGTH} characters). The Ungate extension supplies it when it spawns the API.`
+		);
+	}
+
+	return value;
 }

--- a/apps/api/src/database/provider-settings.ts
+++ b/apps/api/src/database/provider-settings.ts
@@ -1,59 +1,128 @@
 import { eq } from 'drizzle-orm';
 
+import { isModelMappingProvider } from '@ungate/shared';
+import { logger } from 'src/utils/logger';
+
+import { ProviderSecrets } from '../security/provider-secrets';
+
 import { providerSettings } from './schema';
 
 import { getDb } from './index';
 
 import type { AIProviderName, OAuthCredentials } from '../auth/base-provider';
 
+/** Everything about a provider that is safe to keep in SQLite. */
+export interface ProviderMetadata {
+	provider: string;
+	expiresAt: number | null;
+	email: string | null;
+	accountId: string | null;
+	createdAt: number;
+	baseUrl: string | null;
+}
+
+/** Metadata joined with the credentials held by the extension. */
+export interface ProviderCredentials extends ProviderMetadata {
+	/** Empty when no credential is stored for an otherwise known provider. */
+	accessToken: string;
+	refreshToken: string | null;
+}
+
+/**
+ * `access_token` / `refresh_token` are legacy columns. They are never written with a real
+ * value anymore — {@link ProviderSettings.migrateLegacySecrets} moves pre-existing values
+ * into the extension secret store and blanks them.
+ */
+const METADATA_COLUMNS = {
+	provider: providerSettings.provider,
+	expiresAt: providerSettings.expiresAt,
+	email: providerSettings.email,
+	accountId: providerSettings.accountId,
+	createdAt: providerSettings.createdAt,
+	baseUrl: providerSettings.baseUrl
+};
+
+const BLANK_LEGACY_SECRETS = { accessToken: '', refreshToken: null };
+
 export class ProviderSettings {
-	static get(provider: AIProviderName) {
+	/** Non-secret fields only. Cheap: no round trip to the extension. */
+	static getMetadata(provider: AIProviderName): ProviderMetadata | undefined {
 		const db = getDb();
 
-		return db.select().from(providerSettings).where(eq(providerSettings.provider, provider)).get();
+		return db.select(METADATA_COLUMNS).from(providerSettings).where(eq(providerSettings.provider, provider)).get();
 	}
 
-	static upsertApiKey(provider: AIProviderName, accessToken: string, baseUrl?: string): void {
+	static async get(provider: AIProviderName): Promise<ProviderCredentials | undefined> {
+		const metadata = this.getMetadata(provider);
+
+		if (!metadata) {
+			return undefined;
+		}
+
+		const secret = await ProviderSecrets.read(provider);
+
+		return {
+			...metadata,
+			accessToken: secret?.accessToken ?? '',
+			refreshToken: secret?.refreshToken ?? null
+		};
+	}
+
+	static async hasCredentials(provider: AIProviderName): Promise<boolean> {
+		const credentials = await this.get(provider);
+
+		return !!credentials?.accessToken;
+	}
+
+	static async upsertApiKey(provider: AIProviderName, accessToken: string, baseUrl?: string): Promise<void> {
+		// Secret first: a metadata row without a credential is merely unauthenticated, while a
+		// credential without a row is unreachable.
+		await ProviderSecrets.write(provider, { accessToken, refreshToken: null });
+
 		const db = getDb();
 
 		db.insert(providerSettings)
 			.values({
 				provider,
-				accessToken,
+				...BLANK_LEGACY_SECRETS,
 				createdAt: Date.now(),
 				...(baseUrl && { baseUrl })
 			})
 			.onConflictDoUpdate({
 				target: providerSettings.provider,
 				set: {
-					accessToken,
+					...BLANK_LEGACY_SECRETS,
 					...(baseUrl !== undefined && { baseUrl })
 				}
 			})
 			.run();
 	}
 
-	static upsertOAuth(provider: AIProviderName, data: OAuthCredentials): void {
+	static async upsertOAuth(provider: AIProviderName, data: OAuthCredentials): Promise<void> {
+		await ProviderSecrets.write(provider, {
+			accessToken: data.accessToken,
+			refreshToken: data.refreshToken ?? null
+		});
+
 		const db = getDb();
+		const metadata = {
+			expiresAt: data.expiresAt,
+			email: data.email ?? null,
+			accountId: data.accountId ?? null
+		};
 
 		db.insert(providerSettings)
 			.values({
 				provider,
-				accessToken: data.accessToken,
-				refreshToken: data.refreshToken,
-				expiresAt: data.expiresAt,
-				email: data.email ?? null,
-				accountId: data.accountId ?? null,
+				...BLANK_LEGACY_SECRETS,
+				...metadata,
 				createdAt: Date.now()
 			})
 			.onConflictDoUpdate({
 				target: providerSettings.provider,
 				set: {
-					accessToken: data.accessToken,
-					refreshToken: data.refreshToken,
-					expiresAt: data.expiresAt,
-					email: data.email ?? null,
-					accountId: data.accountId ?? null
+					...BLANK_LEGACY_SECRETS,
+					...metadata
 				}
 			})
 			.run();
@@ -61,9 +130,8 @@ export class ProviderSettings {
 
 	static updateBaseUrl(provider: AIProviderName, baseUrl: string): boolean {
 		const db = getDb();
-		const existing = this.get(provider);
 
-		if (!existing) {
+		if (!this.getMetadata(provider)) {
 			return false;
 		}
 
@@ -72,9 +140,52 @@ export class ProviderSettings {
 		return true;
 	}
 
-	static remove(provider: AIProviderName): void {
-		const db = getDb();
+	static async remove(provider: AIProviderName): Promise<void> {
+		try {
+			await ProviderSecrets.erase(provider);
+		} finally {
+			getDb().delete(providerSettings).where(eq(providerSettings.provider, provider)).run();
+		}
+	}
 
-		db.delete(providerSettings).where(eq(providerSettings.provider, provider)).run();
+	/**
+	 * Moves credentials written by older versions out of SQLite and blanks the columns. Runs
+	 * once per database: after the first pass there is nothing left to move. Throws when the
+	 * secret store is unreachable so that plaintext is never dropped without a safe copy.
+	 */
+	static async migrateLegacySecrets(): Promise<void> {
+		const db = getDb();
+		const legacyRows = db
+			.select({
+				provider: providerSettings.provider,
+				accessToken: providerSettings.accessToken,
+				refreshToken: providerSettings.refreshToken
+			})
+			.from(providerSettings)
+			.all();
+
+		for (const row of legacyRows) {
+			const accessToken = row.accessToken ?? '';
+			const refreshToken = row.refreshToken ?? '';
+
+			if (!accessToken && !refreshToken) {
+				continue;
+			}
+
+			if (isModelMappingProvider(row.provider)) {
+				const stored = await ProviderSecrets.read(row.provider);
+
+				// A credential written since the last restart is newer than the legacy column.
+				if (!stored?.accessToken) {
+					await ProviderSecrets.write(row.provider, { accessToken, refreshToken: refreshToken || null });
+				}
+
+				logger.log(`[secrets] moved legacy ${row.provider} credentials into the extension secret store`);
+			} else {
+				logger.error(`[secrets] scrubbed legacy credentials of unknown provider "${row.provider}"`);
+			}
+
+			db.update(providerSettings).set(BLANK_LEGACY_SECRETS).where(eq(providerSettings.provider, row.provider)).run();
+		}
 	}
 }

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -12,6 +12,11 @@ export const appSettings = sqliteTable('app_settings', {
 
 export const providerSettings = sqliteTable('provider_settings', {
 	provider: text().primaryKey(),
+	/**
+	 * Legacy: credentials moved to the extension secret store. Kept so
+	 * `ProviderSettings.migrateLegacySecrets()` can drain and blank pre-existing rows; new
+	 * writes always store an empty string / null here.
+	 */
 	accessToken: text().notNull(),
 	refreshToken: text(),
 	expiresAt: integer(),

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,17 @@
+import { ProviderSettings } from './database/provider-settings';
+import { requireCredentialChannel } from './security/credential-channel';
 import { startServer } from './server';
 
-startServer().catch((err) => {
+async function bootstrap(): Promise<void> {
+	// Nothing may start without the extension credential channel: it is the only source of
+	// provider credentials, and the legacy migration must not blank a column it cannot drain.
+	requireCredentialChannel();
+
+	await ProviderSettings.migrateLegacySecrets();
+	await startServer();
+}
+
+bootstrap().catch((err: unknown) => {
 	console.error(err);
 	process.exit(1);
 });

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -1,15 +1,68 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+
 import type { Config } from '../config';
 import type { onRequestAsyncHookHandler } from 'fastify';
 
+const BEARER_PREFIX = 'Bearer ';
+
+/**
+ * Compares two secrets without leaking their contents or length through timing.
+ * Hashing first equalises the buffer length, which `timingSafeEqual` requires and
+ * which a raw length check would otherwise reveal. An absent or empty `expected`
+ * never matches, so an unconfigured key locks the route instead of opening it.
+ */
+function secretsMatch(provided: string | undefined, expected: string | undefined): boolean {
+	if (provided === undefined || expected === undefined || expected.length === 0) return false;
+
+	const providedDigest = createHash('sha256').update(provided, 'utf8').digest();
+	const expectedDigest = createHash('sha256').update(expected, 'utf8').digest();
+
+	return timingSafeEqual(providedDigest, expectedDigest);
+}
+
+/** Duplicate headers arrive as arrays; treat them as absent rather than guessing which one counts. */
+function singleHeader(raw: string | string[] | undefined): string | undefined {
+	return typeof raw === 'string' ? raw : undefined;
+}
+
+/**
+ * Proxy-key auth for the routes Cursor calls: both completion endpoints and the model list.
+ * Cursor sends the key as `Authorization: Bearer <key>` or `x-api-key`.
+ *
+ * Fails closed when no proxy key is configured. These routes are reachable through the public
+ * tunnel, so an absent key must lock them down rather than open them to anyone holding the URL.
+ * `Settings.get()` mints a key on first run; blanking it in the dashboard therefore disables the
+ * proxy until a new one is set.
+ */
 export function apiKeyAuth(config: Config): onRequestAsyncHookHandler {
 	return async (request, reply) => {
-		if (!config.apiKey) return;
-		const bearer = request.headers.authorization?.slice(7);
-		const key = bearer ?? (request.headers['x-api-key'] as string | undefined);
-		if (key !== config.apiKey) {
+		const authorization = singleHeader(request.headers.authorization);
+		const bearer = authorization?.startsWith(BEARER_PREFIX) ? authorization.slice(BEARER_PREFIX.length) : undefined;
+		const key = bearer ?? singleHeader(request.headers['x-api-key']);
+
+		if (!secretsMatch(key, config.apiKey)) {
 			return reply
 				.code(403)
 				.send({ type: 'error', error: { type: 'authentication_error', message: 'Unauthorized: Invalid API key' } });
+		}
+	};
+}
+
+/**
+ * Admin-key auth for every administrative route (settings, provider auth, analytics).
+ * Distinct from the proxy key so that exposing the tunnel URL to Cursor never grants
+ * control over provider credentials or local settings. Fails closed when unconfigured.
+ */
+export function adminKeyAuth(config: Config): onRequestAsyncHookHandler {
+	return async (request, reply) => {
+		const key = singleHeader(request.headers[ADMIN_KEY_HEADER]);
+
+		if (!secretsMatch(key, config.adminApiKey)) {
+			return reply
+				.code(403)
+				.send({ type: 'error', error: { type: 'authentication_error', message: 'Unauthorized: Invalid admin key' } });
 		}
 	};
 }

--- a/apps/api/src/plugins/cors-origin.ts
+++ b/apps/api/src/plugins/cors-origin.ts
@@ -1,0 +1,28 @@
+// Origins the dashboard can legitimately run under. VS Code and Cursor serve webview content
+// from `vscode-webview://<uuid>`; the workbench shell itself is `vscode-file://vscode-app`.
+// Loopback origins cover `pnpm dev` on apps/web. Anything else is a web page that must not be
+// able to read settings or drive provider auth from a victim's browser, even over the tunnel.
+const ALLOWED_SCHEMES = ['vscode-webview:', 'vscode-file:'];
+const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
+
+export function isAllowedDashboardOrigin(origin: string | undefined): boolean {
+	// Requests without an Origin header are not browser cross-origin requests: Cursor's backend
+	// and any CLI client fall here. CORS has nothing to decide, so they pass through untouched.
+	// A literal `null` origin is different — it comes from a sandboxed or file:// document, so
+	// it is refused rather than trusted.
+	if (origin === undefined || origin === '') return true;
+
+	let parsed: URL;
+
+	try {
+		parsed = new URL(origin);
+	} catch {
+		return false;
+	}
+
+	if (ALLOWED_SCHEMES.includes(parsed.protocol)) return true;
+
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+	return LOOPBACK_HOSTNAMES.includes(parsed.hostname);
+}

--- a/apps/api/src/proxy/anthropic-client.ts
+++ b/apps/api/src/proxy/anthropic-client.ts
@@ -67,7 +67,7 @@ async function makeClaudeCodeRequest(
 			const errorBody = await response.clone().text();
 			logger.error(`Claude Code 401 error: ${errorBody}`);
 
-			const row = ProviderSettings.get('claude');
+			const row = await ProviderSettings.get('claude');
 
 			if (row?.refreshToken) {
 				logger.log('Attempting token refresh after 401...');

--- a/apps/api/src/proxy/minimax-client.ts
+++ b/apps/api/src/proxy/minimax-client.ts
@@ -11,8 +11,8 @@ export async function proxyMiniMaxRequest(body: OpenAIChatRequest): Promise<{
 	response: Response;
 	context: RequestContext;
 }> {
-	const creds = ProviderSettings.get('minimax');
-	const minimaxUrl = creds?.baseUrl ?? config.minimax.baseUrlGlobal;
+	const metadata = ProviderSettings.getMetadata('minimax');
+	const minimaxUrl = metadata?.baseUrl ?? config.minimax.baseUrlGlobal;
 	const provider = getProvider('minimax');
 	const authHeader = await provider.getAuthHeader();
 

--- a/apps/api/src/proxy/openai-client.ts
+++ b/apps/api/src/proxy/openai-client.ts
@@ -28,7 +28,7 @@ export class OpenAiClient {
 		const model = body.model;
 		const resolvedModel = ResponsesModelResolver.resolveModel(model);
 		const normalizedModel = resolvedModel.model;
-		const creds = ProviderSettings.get('openai');
+		const creds = await ProviderSettings.get('openai');
 
 		if (!creds?.accessToken) {
 			return this.authErrorResult(model, startTime, 'Not authenticated with OpenAI');

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,6 +1,7 @@
 import { hoursToMilliseconds } from 'date-fns';
 
 import { Analytics } from '../database/analytics';
+import { adminKeyAuth } from '../plugins/auth';
 
 import type { Period } from '@ungate/shared';
 import type { FastifyPluginCallback } from 'fastify';
@@ -21,6 +22,9 @@ function toPeriod(value: string | undefined): Period {
 }
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Encapsulated hook: covers every route this plugin registers, present and future.
+	app.addHook('onRequest', adminKeyAuth(app.config));
+
 	app.get('/analytics', async (request, reply) => {
 		const period = toPeriod((request.query as Record<string, string>).period);
 		const now = Date.now();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -2,10 +2,15 @@ import { OAuth } from '../auth/oauth';
 import { OpenAIOAuthService } from '../auth/openai/openai-oauth-service';
 import { config } from '../config';
 import { ProviderSettings } from '../database/provider-settings';
+import { adminKeyAuth } from '../plugins/auth';
 
 import type { FastifyPluginCallback } from 'fastify';
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Encapsulated hook: covers every route this plugin registers, including the OAuth callback.
+	// Provider login and logout are the most damaging routes to leave open.
+	app.addHook('onRequest', adminKeyAuth(app.config));
+
 	app.post('/auth/claude/start', async (_request, reply) => {
 		const result = await OAuth.startLogin();
 
@@ -24,18 +29,20 @@ const plugin: FastifyPluginCallback = (app) => {
 		return reply.send(result);
 	});
 
-	app.get('/auth/claude/status', (_request, reply) => {
-		return reply.send(OAuth.getAuthStatus());
+	app.get('/auth/claude/status', async (_request, reply) => {
+		const status = await OAuth.getAuthStatus();
+
+		return reply.send(status);
 	});
 
-	app.post('/auth/claude/logout', (_request, reply) => {
-		OAuth.logout();
+	app.post('/auth/claude/logout', async (_request, reply) => {
+		await OAuth.logout();
 
 		return reply.send({ ok: true });
 	});
 
-	app.get('/auth/minimax/status', (_request, reply) => {
-		const creds = ProviderSettings.get('minimax');
+	app.get('/auth/minimax/status', async (_request, reply) => {
+		const creds = await ProviderSettings.get('minimax');
 
 		return reply.send({
 			authenticated: !!creds?.accessToken,
@@ -50,7 +57,7 @@ const plugin: FastifyPluginCallback = (app) => {
 			return reply.code(400).send({ ok: false, error: 'API key is required' });
 		}
 
-		ProviderSettings.upsertApiKey('minimax', apiKey.trim(), baseUrl?.trim());
+		await ProviderSettings.upsertApiKey('minimax', apiKey.trim(), baseUrl?.trim());
 
 		return reply.send({ ok: true });
 	});
@@ -72,8 +79,8 @@ const plugin: FastifyPluginCallback = (app) => {
 		return reply.send({ ok: true });
 	});
 
-	app.post('/auth/minimax/logout', (_request, reply) => {
-		ProviderSettings.remove('minimax');
+	app.post('/auth/minimax/logout', async (_request, reply) => {
+		await ProviderSettings.remove('minimax');
 
 		return reply.send({ ok: true });
 	});
@@ -101,12 +108,14 @@ const plugin: FastifyPluginCallback = (app) => {
 		return reply.type('text/html').send(`<html><body><h1>Error</h1><p>${result.error ?? 'Unknown error'}</p></body></html>`);
 	});
 
-	app.get('/auth/openai/status', (_request, reply) => {
-		return reply.send(OpenAIOAuthService.getAuthStatus());
+	app.get('/auth/openai/status', async (_request, reply) => {
+		const status = await OpenAIOAuthService.getAuthStatus();
+
+		return reply.send(status);
 	});
 
-	app.post('/auth/openai/logout', (_request, reply) => {
-		OpenAIOAuthService.logout();
+	app.post('/auth/openai/logout', async (_request, reply) => {
+		await OpenAIOAuthService.logout();
 
 		return reply.send({ ok: true });
 	});

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -1,8 +1,13 @@
 import { Settings } from '../database/app-settings';
+import { apiKeyAuth } from '../plugins/auth';
 
 import type { FastifyPluginCallback } from 'fastify';
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Cursor discovers models through this route, so it carries the proxy key rather than
+	// the admin key. Left open it let anyone with the tunnel URL enumerate the model registry.
+	app.addHook('onRequest', apiKeyAuth(app.config));
+
 	app.get('/v1/models', async (_request, reply) => {
 		const settings = Settings.get();
 		const data = settings.models.map((model) => ({

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { isModelMappingProvider, isModelServiceTier, isReasoningBudgetTier, type AppSettings } from '@ungate/shared';
 
 import { Settings } from '../database/app-settings';
+import { adminKeyAuth } from '../plugins/auth';
 import { logger } from '../utils/logger';
 
 import type { FastifyPluginCallback } from 'fastify';
@@ -50,6 +51,9 @@ function validateSettingsUpdate(payload: unknown): { ok: true; value: Partial<Ap
 }
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Encapsulated hook: covers every route this plugin registers, present and future.
+	app.addHook('onRequest', adminKeyAuth(app.config));
+
 	app.get('/settings', async (_request, reply) => {
 		const settings = Settings.get();
 

--- a/apps/api/src/security/credential-channel.ts
+++ b/apps/api/src/security/credential-channel.ts
@@ -1,0 +1,36 @@
+import { IpcSecretTransport, type SecretIpcHost } from './ipc-secret-transport';
+
+/** Process surface the credential channel needs: IPC plus the ability to end the process. */
+export interface CredentialChannelHost extends SecretIpcHost {
+	exit(code?: number): never;
+}
+
+export class CredentialChannelMissingError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'CredentialChannelMissingError';
+	}
+}
+
+/**
+ * Claims the credential channel the extension owns. Provider credentials exist nowhere else,
+ * so a process without the channel can serve no provider at all — start-up fails instead of
+ * coming up half-usable. Losing the channel later is equally fatal: the process exits so the
+ * leader window respawns it with a live channel instead of leaving an orphan on the port.
+ */
+export function requireCredentialChannel(host: CredentialChannelHost = process): IpcSecretTransport {
+	const transport = IpcSecretTransport.install(host);
+
+	if (!transport) {
+		throw new CredentialChannelMissingError(
+			'The API process was started without an IPC credential channel. Start Ungate from the extension.'
+		);
+	}
+
+	// Registered after the transport, so in-flight requests reject before the process ends.
+	host.on('disconnect', () => {
+		host.exit(0);
+	});
+
+	return transport;
+}

--- a/apps/api/src/security/ipc-secret-transport.ts
+++ b/apps/api/src/security/ipc-secret-transport.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+	PROVIDER_SECRET_CHANNEL,
+	parseProviderSecretResponse,
+	readProviderSecretEnvelope,
+	type ProviderSecret,
+	type ProviderSecretAction,
+	type ProviderSecretRequest
+} from '@ungate/shared';
+import { logger } from 'src/utils/logger';
+
+import { SecretStorageUnavailableError, useProviderSecretTransport, type ProviderSecretTransport } from './provider-secrets';
+
+import type { AIProviderName } from '../auth/base-provider';
+
+/** The extension answers from VS Code SecretStorage, which is local; a slow answer means it is gone. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+interface PendingRequest {
+	resolve(secret: ProviderSecret | null): void;
+	reject(error: Error): void;
+	timer: NodeJS.Timeout;
+}
+
+/** Slice of `process` the transport drives. Method syntax keeps `process` assignable. */
+export interface SecretIpcHost {
+	send?(message: unknown): boolean;
+	on(event: string, listener: (payload: unknown) => void): unknown;
+}
+
+/**
+ * Request/response client for the extension-owned credential store, riding the IPC channel
+ * of the child process. Every inbound message is validated and correlated by request id;
+ * unknown ids, malformed payloads and channel loss all fail closed.
+ */
+export class IpcSecretTransport implements ProviderSecretTransport {
+	private readonly pending = new Map<string, PendingRequest>();
+	private connected = true;
+
+	private constructor(private readonly host: SecretIpcHost) {
+		this.host.on('message', (message) => {
+			this.onMessage(message);
+		});
+		this.host.on('disconnect', () => {
+			this.onDisconnect();
+		});
+	}
+
+	/** Installs the transport when the process owns an IPC channel, returns null when it does not. */
+	static install(host: SecretIpcHost = process): IpcSecretTransport | null {
+		if (typeof host.send !== 'function') {
+			return null;
+		}
+
+		const transport = new IpcSecretTransport(host);
+
+		useProviderSecretTransport(transport);
+
+		return transport;
+	}
+
+	async read(provider: AIProviderName): Promise<ProviderSecret | null> {
+		return this.request('get', provider);
+	}
+
+	async write(provider: AIProviderName, secret: ProviderSecret): Promise<void> {
+		await this.request('set', provider, secret);
+	}
+
+	async erase(provider: AIProviderName): Promise<void> {
+		await this.request('delete', provider);
+	}
+
+	private request(
+		action: ProviderSecretAction,
+		provider: AIProviderName,
+		secret?: ProviderSecret
+	): Promise<ProviderSecret | null> {
+		const send = this.host.send?.bind(this.host);
+
+		if (!this.connected || typeof send !== 'function') {
+			return Promise.reject(
+				new SecretStorageUnavailableError('The extension credential channel is closed; restart the API from the dashboard.')
+			);
+		}
+
+		const id = randomUUID();
+		const message: ProviderSecretRequest = {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id,
+			action,
+			provider,
+			...(secret && { secret })
+		};
+
+		return new Promise<ProviderSecret | null>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(
+					new SecretStorageUnavailableError(`The extension did not answer a credential ${action} within ${REQUEST_TIMEOUT_MS}ms.`)
+				);
+			}, REQUEST_TIMEOUT_MS);
+
+			timer.unref?.();
+			this.pending.set(id, { resolve, reject, timer });
+
+			try {
+				// A `false` return only means the channel backlog is full; the message stays queued.
+				send(message);
+			} catch (error) {
+				this.pending.delete(id);
+				clearTimeout(timer);
+				reject(
+					new SecretStorageUnavailableError(
+						`Failed to reach the extension credential store: ${error instanceof Error ? error.message : String(error)}`
+					)
+				);
+			}
+		});
+	}
+
+	private onMessage(message: unknown): void {
+		const envelope = readProviderSecretEnvelope(message);
+
+		if (!envelope) {
+			return;
+		}
+
+		const pending = this.pending.get(envelope.id);
+
+		if (!pending) {
+			logger.error('[secrets] discarded a credential response with an unknown request id');
+
+			return;
+		}
+
+		this.pending.delete(envelope.id);
+		clearTimeout(pending.timer);
+
+		const response = parseProviderSecretResponse(message);
+
+		if (!response) {
+			pending.reject(new SecretStorageUnavailableError('The extension sent a malformed credential response.'));
+
+			return;
+		}
+
+		if (!response.ok) {
+			pending.reject(new Error(`The extension refused the credential request: ${response.error}`));
+
+			return;
+		}
+
+		pending.resolve(response.secret);
+	}
+
+	private onDisconnect(): void {
+		this.connected = false;
+
+		const abandoned = [...this.pending.values()];
+
+		this.pending.clear();
+
+		for (const request of abandoned) {
+			clearTimeout(request.timer);
+			request.reject(new SecretStorageUnavailableError('The extension closed the credential channel.'));
+		}
+
+		if (abandoned.length > 0) {
+			logger.error(`[secrets] credential channel closed with ${abandoned.length} request(s) in flight`);
+		}
+	}
+}

--- a/apps/api/src/security/provider-secrets.ts
+++ b/apps/api/src/security/provider-secrets.ts
@@ -1,0 +1,74 @@
+import { logger } from 'src/utils/logger';
+
+import type { AIProviderName } from '../auth/base-provider';
+import type { ProviderSecret } from '@ungate/shared';
+
+/**
+ * Raised when provider credentials cannot be reached at all — no IPC channel, a closed
+ * channel, or a channel that stopped answering. Writes must fail loudly rather than fall
+ * back to the database, which no longer stores credentials.
+ */
+export class SecretStorageUnavailableError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'SecretStorageUnavailableError';
+	}
+}
+
+/** Credential store owned by the extension host. The API process only ever talks to a transport. */
+export interface ProviderSecretTransport {
+	read(provider: AIProviderName): Promise<ProviderSecret | null>;
+	write(provider: AIProviderName, secret: ProviderSecret): Promise<void>;
+	erase(provider: AIProviderName): Promise<void>;
+}
+
+let activeTransport: ProviderSecretTransport | null = null;
+
+/** Installs (or clears, with `null`) the process-wide credential transport. */
+export function useProviderSecretTransport(transport: ProviderSecretTransport | null): void {
+	activeTransport = transport;
+}
+
+export class ProviderSecrets {
+	/**
+	 * Reads deny by default: without a working channel the provider counts as unauthenticated
+	 * instead of falling back to any other source. Failures are logged by provider name only.
+	 */
+	static async read(provider: AIProviderName): Promise<ProviderSecret | null> {
+		if (!activeTransport) {
+			logger.error(`[secrets] no credential channel available, treating ${provider} as unauthenticated`);
+
+			return null;
+		}
+
+		try {
+			return await activeTransport.read(provider);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+
+			logger.error(`[secrets] failed to read ${provider} credentials: ${message}`);
+
+			return null;
+		}
+	}
+
+	static async write(provider: AIProviderName, secret: ProviderSecret): Promise<void> {
+		if (!activeTransport) {
+			throw new SecretStorageUnavailableError(
+				`Cannot store ${provider} credentials: the extension credential channel is unavailable.`
+			);
+		}
+
+		await activeTransport.write(provider, secret);
+	}
+
+	static async erase(provider: AIProviderName): Promise<void> {
+		if (!activeTransport) {
+			throw new SecretStorageUnavailableError(
+				`Cannot delete ${provider} credentials: the extension credential channel is unavailable.`
+			);
+		}
+
+		await activeTransport.erase(provider);
+	}
+}

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,13 +1,13 @@
 import cors from '@fastify/cors';
 import Fastify from 'fastify';
 
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
 import { logger, setQuietMode } from 'src/utils/logger';
-
-const BODY_LIMIT_BYTES = 256 * 1024 * 1024;
 
 import { getConfig } from './config';
 import { getDb } from './database/index';
 import { Settings } from './database/settings';
+import { isAllowedDashboardOrigin } from './plugins/cors-origin';
 import analyticsPlugin from './routes/analytics';
 import anthropicPlugin from './routes/anthropic';
 import authPlugin from './routes/auth';
@@ -15,6 +15,12 @@ import healthPlugin from './routes/health';
 import modelsPlugin from './routes/models';
 import openaiPlugin from './routes/openai';
 import settingsPlugin from './routes/settings';
+
+const BODY_LIMIT_BYTES = 256 * 1024 * 1024;
+
+// Cursor reaches the API through the Cloudflare tunnel, never by connecting to a LAN
+// interface. Binding loopback keeps every other host on the network out.
+export const LISTEN_HOST = '127.0.0.1';
 
 export async function startServer(): Promise<void> {
 	globalThis.console.log('[startup] getDb...');
@@ -41,7 +47,13 @@ export async function startServer(): Promise<void> {
 	});
 
 	globalThis.console.log('[startup] register cors...');
-	await app.register(cors, { origin: '*' });
+	await app.register(cors, {
+		origin: (origin, callback) => {
+			callback(null, isAllowedDashboardOrigin(origin));
+		},
+		credentials: false,
+		allowedHeaders: ['content-type', 'authorization', 'x-api-key', ADMIN_KEY_HEADER]
+	});
 
 	globalThis.console.log('[startup] register plugins...');
 	await app.register(healthPlugin);
@@ -53,7 +65,7 @@ export async function startServer(): Promise<void> {
 	await app.register(settingsPlugin);
 
 	globalThis.console.log(`[startup] listen ${config.port}...`);
-	await app.listen({ port: config.port, host: '0.0.0.0' });
+	await app.listen({ port: config.port, host: LISTEN_HOST });
 
 	// Always print port to stdout — extension parses this to detect the running port.
 	// Uses globalThis.console to bypass quiet mode.

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -1,6 +1,9 @@
 export interface ProxyConfig {
 	port: number;
+	/** Proxy key Cursor sends on completion and model-listing routes. */
 	apiKey?: string;
+	/** Separate 256-bit key required on every administrative route. Never persisted to SQLite. */
+	adminApiKey: string;
 	quietMode: boolean;
 }
 

--- a/apps/api/src/types/shims/fastify.d.ts
+++ b/apps/api/src/types/shims/fastify.d.ts
@@ -1,4 +1,4 @@
-import type { Config } from '../config';
+import type { Config } from '../../config';
 
 declare module 'fastify' {
 	interface FastifyInstance {

--- a/apps/api/tests/helpers/fake-ipc-host.ts
+++ b/apps/api/tests/helpers/fake-ipc-host.ts
@@ -1,0 +1,59 @@
+import type { CredentialChannelHost } from 'src/security/credential-channel';
+import type { ProviderSecretRequest } from '@ungate/shared';
+
+/** Stands in for the IPC channel the extension host owns. */
+export class FakeIpcHost implements CredentialChannelHost {
+	readonly sent: ProviderSecretRequest[] = [];
+	exitCode: number | null = null;
+	private readonly listeners: Record<string, ((payload: unknown) => void)[]> = {};
+
+	send(message: unknown): boolean {
+		this.sent.push(message as ProviderSecretRequest);
+
+		return true;
+	}
+
+	on(event: string, listener: (payload: unknown) => void): this {
+		this.listeners[event] ??= [];
+		this.listeners[event].push(listener);
+
+		return this;
+	}
+
+	/** Records the exit instead of ending the test worker; execution continues past the call. */
+	exit(code?: number): never {
+		this.exitCode = code ?? 0;
+
+		return undefined as never;
+	}
+
+	emit(event: string, payload?: unknown): void {
+		for (const listener of this.listeners[event] ?? []) {
+			listener(payload);
+		}
+	}
+
+	listenerCount(event: string): number {
+		return this.listeners[event]?.length ?? 0;
+	}
+
+	lastRequest(): ProviderSecretRequest {
+		const request = this.sent.at(-1);
+
+		if (!request) {
+			throw new Error('No credential request was sent.');
+		}
+
+		return request;
+	}
+}
+
+/** A host that was started without an IPC channel: no `send`, so nothing can be installed. */
+export function createHostWithoutIpc(): FakeIpcHost {
+	const host = new FakeIpcHost();
+
+	// `send` is the only signal Node gives that an IPC channel exists.
+	Object.defineProperty(host, 'send', { value: undefined, configurable: true });
+
+	return host;
+}

--- a/apps/api/tests/helpers/memory-secret-transport.ts
+++ b/apps/api/tests/helpers/memory-secret-transport.ts
@@ -1,0 +1,39 @@
+import { useProviderSecretTransport, type ProviderSecretTransport } from 'src/security/provider-secrets';
+
+import type { AIProviderName } from 'src/auth/base-provider';
+import type { ProviderSecret } from '@ungate/shared';
+
+/** Stands in for the extension-owned VS Code SecretStorage during tests. */
+export class MemorySecretTransport implements ProviderSecretTransport {
+	private readonly secrets = new Map<AIProviderName, ProviderSecret>();
+
+	async read(provider: AIProviderName): Promise<ProviderSecret | null> {
+		return this.secrets.get(provider) ?? null;
+	}
+
+	async write(provider: AIProviderName, secret: ProviderSecret): Promise<void> {
+		this.secrets.set(provider, { ...secret });
+	}
+
+	async erase(provider: AIProviderName): Promise<void> {
+		this.secrets.delete(provider);
+	}
+
+	/** Direct view for assertions that must not go through the production read path. */
+	peek(provider: AIProviderName): ProviderSecret | undefined {
+		return this.secrets.get(provider);
+	}
+
+	clear(): void {
+		this.secrets.clear();
+	}
+}
+
+/** Installs a fresh in-memory credential store and returns it. */
+export function useMemorySecretTransport(): MemorySecretTransport {
+	const transport = new MemorySecretTransport();
+
+	useProviderSecretTransport(transport);
+
+	return transport;
+}

--- a/apps/api/tests/integration/auth/auth-oauth-lifecycle.test.ts
+++ b/apps/api/tests/integration/auth/auth-oauth-lifecycle.test.ts
@@ -1,29 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAuth } from 'src/auth/oauth';
 import { ProviderSettings } from 'src/database/provider-settings';
 
+import { useMemorySecretTransport, type MemorySecretTransport } from '../../helpers/memory-secret-transport';
+
 describe('auth-oauth-lifecycle', () => {
-	it('returns unauthenticated status when row missing', () => {
-		expect(OAuth.getAuthStatus()).toEqual({ authenticated: false });
+	let secrets: MemorySecretTransport;
+
+	beforeEach(() => {
+		secrets = useMemorySecretTransport();
 	});
 
-	it('returns authenticated status with email and can logout', () => {
-		ProviderSettings.upsertOAuth('claude', {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns unauthenticated status when row missing', async () => {
+		expect(await OAuth.getAuthStatus()).toEqual({ authenticated: false });
+	});
+
+	it('returns authenticated status with email and can logout', async () => {
+		await ProviderSettings.upsertOAuth('claude', {
 			accessToken: 'access',
 			refreshToken: 'refresh',
 			expiresAt: Date.now() + 10 * 60_000,
 			email: 'user@example.com'
 		});
-		expect(OAuth.getAuthStatus()).toEqual({ authenticated: true, email: 'user@example.com' });
 
-		OAuth.logout();
-		expect(ProviderSettings.get('claude')).toBeUndefined();
+		expect(await OAuth.getAuthStatus()).toEqual({ authenticated: true, email: 'user@example.com' });
+
+		await OAuth.logout();
+		expect(await ProviderSettings.get('claude')).toBeUndefined();
+		expect(secrets.peek('claude')).toBeUndefined();
 	});
 
 	it('returns valid token when not expired and null when no row', async () => {
 		const now = Date.now();
-		ProviderSettings.upsertOAuth('claude', {
+		await ProviderSettings.upsertOAuth('claude', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: now + 10 * 60_000
@@ -32,7 +46,36 @@ describe('auth-oauth-lifecycle', () => {
 		const token = await OAuth.getValidToken();
 		expect(token?.accessToken).toBe('a');
 
-		ProviderSettings.remove('claude');
+		await ProviderSettings.remove('claude');
 		expect(await OAuth.getValidToken()).toBeNull();
+	});
+
+	it('persists refreshed tokens to the credential store and not to sqlite', async () => {
+		await ProviderSettings.upsertOAuth('claude', {
+			accessToken: 'stale',
+			refreshToken: 'old-refresh',
+			// Already inside the five-minute refresh window.
+			expiresAt: Date.now() + 60_000,
+			email: 'user@example.com'
+		});
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => {
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve({ access_token: 'fresh', refresh_token: 'new-refresh', expires_in: 3600 })
+				});
+			})
+		);
+
+		const token = await OAuth.getValidToken();
+
+		expect(token?.accessToken).toBe('fresh');
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'fresh', refreshToken: 'new-refresh' });
+		expect(await ProviderSettings.get('claude')).toMatchObject({ accessToken: 'fresh', refreshToken: 'new-refresh' });
+		// The refreshed row is still usable; only the credential moved.
+		expect(await OAuth.getAuthStatus()).toEqual({ authenticated: true, email: undefined });
 	});
 });

--- a/apps/api/tests/integration/auth/auth-openai-oauth-lifecycle.test.ts
+++ b/apps/api/tests/integration/auth/auth-openai-oauth-lifecycle.test.ts
@@ -1,31 +1,40 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { OpenAIOAuthService } from 'src/auth/openai/openai-oauth-service';
 import { ProviderSettings } from 'src/database/provider-settings';
 
-describe('auth-openai-oauth-lifecycle', () => {
-	it('returns auth status from provider settings', () => {
-		expect(OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: false, email: undefined });
+import { useMemorySecretTransport, type MemorySecretTransport } from '../../helpers/memory-secret-transport';
 
-		ProviderSettings.upsertOAuth('openai', {
+describe('auth-openai-oauth-lifecycle', () => {
+	let secrets: MemorySecretTransport;
+
+	beforeEach(() => {
+		secrets = useMemorySecretTransport();
+	});
+
+	it('returns auth status from provider settings', async () => {
+		expect(await OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: false, email: undefined });
+
+		await ProviderSettings.upsertOAuth('openai', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: Date.now() + 10 * 60_000,
 			email: 'u@example.com'
 		});
-		expect(OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: true, email: 'u@example.com' });
+		expect(await OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: true, email: 'u@example.com' });
 	});
 
 	it('returns null token when no credentials and logout removes tokens', async () => {
 		expect(await OpenAIOAuthService.getValidToken()).toBeNull();
 
-		ProviderSettings.upsertOAuth('openai', {
+		await ProviderSettings.upsertOAuth('openai', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: Date.now() + 10 * 60_000
 		});
-		OpenAIOAuthService.logout();
-		expect(ProviderSettings.get('openai')).toBeUndefined();
+		await OpenAIOAuthService.logout();
+		expect(await ProviderSettings.get('openai')).toBeUndefined();
+		expect(secrets.peek('openai')).toBeUndefined();
 		expect(await OpenAIOAuthService.getValidToken()).toBeNull();
 	});
 
@@ -37,7 +46,7 @@ describe('auth-openai-oauth-lifecycle', () => {
 			email: 'x@example.com',
 			accountId: 'acc'
 		};
-		ProviderSettings.upsertOAuth('openai', creds);
+		await ProviderSettings.upsertOAuth('openai', creds);
 		const token = await OpenAIOAuthService.getValidToken();
 		expect(token).toMatchObject(creds);
 	});

--- a/apps/api/tests/integration/database/database-provider-settings.test.ts
+++ b/apps/api/tests/integration/database/database-provider-settings.test.ts
@@ -1,34 +1,102 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { getSqlite } from 'src/database';
 import { ProviderSettings } from 'src/database/provider-settings';
+import { useProviderSecretTransport } from 'src/security/provider-secrets';
+
+import { useMemorySecretTransport, type MemorySecretTransport } from '../../helpers/memory-secret-transport';
+
+function readLegacyColumns(provider: string): { access_token: string | null; refresh_token: string | null } | undefined {
+	return getSqlite()
+		.prepare('SELECT access_token, refresh_token FROM provider_settings WHERE provider = ?')
+		.get(provider) as { access_token: string | null; refresh_token: string | null } | undefined;
+}
 
 describe('database-provider-settings', () => {
-	it('upsert/get/remove api key lifecycle', () => {
-		ProviderSettings.upsertApiKey('minimax', 'token-1', 'https://x');
-		expect(ProviderSettings.get('minimax')?.accessToken).toBe('token-1');
-		expect(ProviderSettings.get('minimax')?.baseUrl).toBe('https://x');
+	let secrets: MemorySecretTransport;
 
-		ProviderSettings.upsertApiKey('minimax', 'token-2');
-		expect(ProviderSettings.get('minimax')?.accessToken).toBe('token-2');
-
-		ProviderSettings.remove('minimax');
-		expect(ProviderSettings.get('minimax')).toBeUndefined();
+	beforeEach(() => {
+		secrets = useMemorySecretTransport();
 	});
 
-	it('stores oauth fields', () => {
-		ProviderSettings.upsertOAuth('openai', {
+	it('upsert/get/remove api key lifecycle', async () => {
+		await ProviderSettings.upsertApiKey('minimax', 'token-1', 'https://x');
+		expect((await ProviderSettings.get('minimax'))?.accessToken).toBe('token-1');
+		expect((await ProviderSettings.get('minimax'))?.baseUrl).toBe('https://x');
+
+		await ProviderSettings.upsertApiKey('minimax', 'token-2');
+		expect((await ProviderSettings.get('minimax'))?.accessToken).toBe('token-2');
+
+		await ProviderSettings.remove('minimax');
+		expect(await ProviderSettings.get('minimax')).toBeUndefined();
+		expect(secrets.peek('minimax')).toBeUndefined();
+	});
+
+	it('stores oauth fields', async () => {
+		await ProviderSettings.upsertOAuth('openai', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: 1000,
-			email: 'user@example.com',
+			email: 'u@example.com',
 			accountId: 'acc'
 		});
 
-		const row = ProviderSettings.get('openai');
+		const row = await ProviderSettings.get('openai');
 		expect(row?.accessToken).toBe('a');
 		expect(row?.refreshToken).toBe('r');
 		expect(row?.expiresAt).toBe(1000);
-		expect(row?.email).toBe('user@example.com');
+		expect(row?.email).toBe('u@example.com');
 		expect(row?.accountId).toBe('acc');
+	});
+
+	it('keeps credentials out of sqlite', async () => {
+		await ProviderSettings.upsertOAuth('claude', { accessToken: 'access', refreshToken: 'refresh', expiresAt: 5 });
+		await ProviderSettings.upsertApiKey('minimax', 'api-key');
+
+		expect(readLegacyColumns('claude')).toEqual({ access_token: '', refresh_token: null });
+		expect(readLegacyColumns('minimax')).toEqual({ access_token: '', refresh_token: null });
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'access', refreshToken: 'refresh' });
+		expect(secrets.peek('minimax')).toEqual({ accessToken: 'api-key', refreshToken: null });
+	});
+
+	it('reports metadata without touching the credential store', async () => {
+		await ProviderSettings.upsertApiKey('minimax', 'api-key', 'https://china');
+		useProviderSecretTransport(null);
+
+		expect(ProviderSettings.getMetadata('minimax')?.baseUrl).toBe('https://china');
+		// Fail closed: the base URL survives, the credential does not.
+		expect(await ProviderSettings.hasCredentials('minimax')).toBe(false);
+		expect((await ProviderSettings.get('minimax'))?.accessToken).toBe('');
+	});
+
+	it('refuses to persist a credential when the store is unavailable', async () => {
+		useProviderSecretTransport(null);
+
+		await expect(ProviderSettings.upsertApiKey('minimax', 'never-stored')).rejects.toThrow(/unavailable/);
+		expect(ProviderSettings.getMetadata('minimax')).toBeUndefined();
+	});
+
+	it('migrates legacy plaintext credentials once and scrubs the columns', async () => {
+		const sqlite = getSqlite();
+		sqlite
+			.prepare('INSERT INTO provider_settings (provider, access_token, refresh_token, expires_at, created_at) VALUES (?,?,?,?,?)')
+			.run('claude', 'legacy-access', 'legacy-refresh', 9999, Date.now());
+		sqlite
+			.prepare('INSERT INTO provider_settings (provider, access_token, refresh_token, created_at) VALUES (?,?,?,?)')
+			.run('ghost', 'orphan-access', null, Date.now());
+
+		await ProviderSettings.migrateLegacySecrets();
+
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'legacy-access', refreshToken: 'legacy-refresh' });
+		expect(readLegacyColumns('claude')).toEqual({ access_token: '', refresh_token: null });
+		expect((await ProviderSettings.get('claude'))?.expiresAt).toBe(9999);
+
+		// A row for a provider the API cannot serve keeps no plaintext either.
+		expect(readLegacyColumns('ghost')).toEqual({ access_token: '', refresh_token: null });
+
+		// Second pass is a no-op and must not overwrite a credential rotated since.
+		await ProviderSettings.upsertOAuth('claude', { accessToken: 'rotated', refreshToken: 'rotated-refresh', expiresAt: 1 });
+		await ProviderSettings.migrateLegacySecrets();
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'rotated', refreshToken: 'rotated-refresh' });
 	});
 });

--- a/apps/api/tests/integration/plugins/plugins-auth.test.ts
+++ b/apps/api/tests/integration/plugins/plugins-auth.test.ts
@@ -1,24 +1,46 @@
 import { describe, expect, it } from 'vitest';
 
-import { apiKeyAuth } from 'src/plugins/auth';
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+import { adminKeyAuth, apiKeyAuth } from 'src/plugins/auth';
 
-import { createTestApp } from '../test-harness';
+import { createTestApp, TEST_ADMIN_KEY } from '../test-harness';
+
+const ADMIN_CONFIG = { port: 0, adminApiKey: TEST_ADMIN_KEY, quietMode: true };
 
 describe('plugins-auth', () => {
-	it('allows request when api key is not configured', async () => {
+	it('fails closed on proxy routes when no api key is configured', async () => {
+		// These routes are reachable through the public tunnel; an absent key must lock them,
+		// never open them to anyone who knows the URL.
 		const app = createTestApp({});
-		app.get('/x', { onRequest: apiKeyAuth({ port: 0, quietMode: true }) }, async () => ({ ok: true }));
+		app.get('/x', { onRequest: apiKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
 		await app.ready();
 
-		const response = await app.inject({ method: 'GET', url: '/x' });
-		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual({ ok: true });
+		const anonymous = await app.inject({ method: 'GET', url: '/x' });
+		expect(anonymous.statusCode).toBe(403);
+		expect(anonymous.json().error.type).toBe('authentication_error');
+
+		// Nor can a caller authenticate by guessing that the configured key is blank.
+		const blankBearer = await app.inject({ method: 'GET', url: '/x', headers: { authorization: 'Bearer ' } });
+		expect(blankBearer.statusCode).toBe(403);
+
+		const blankHeader = await app.inject({ method: 'GET', url: '/x', headers: { 'x-api-key': '' } });
+		expect(blankHeader.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('fails closed on proxy routes when the configured api key is blank', async () => {
+		const app = createTestApp({ apiKey: '' });
+		app.get('/x', { onRequest: apiKeyAuth({ ...ADMIN_CONFIG, apiKey: '' }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({ method: 'GET', url: '/x', headers: { 'x-api-key': '' } });
+		expect(response.statusCode).toBe(403);
 		await app.close();
 	});
 
 	it('rejects request with invalid key and accepts valid key', async () => {
 		const app = createTestApp({ apiKey: 'secret' });
-		app.get('/x', { onRequest: apiKeyAuth({ port: 0, apiKey: 'secret', quietMode: true }) }, async () => ({ ok: true }));
+		app.get('/x', { onRequest: apiKeyAuth({ ...ADMIN_CONFIG, apiKey: 'secret' }) }, async () => ({ ok: true }));
 		await app.ready();
 
 		const bad = await app.inject({ method: 'GET', url: '/x', headers: { 'x-api-key': 'wrong' } });
@@ -31,6 +53,97 @@ describe('plugins-auth', () => {
 			headers: { authorization: 'Bearer secret' }
 		});
 		expect(good.statusCode).toBe(200);
+		await app.close();
+	});
+
+	it('rejects an authorization header that is not a bearer token', async () => {
+		const app = createTestApp({ apiKey: 'secret' });
+		app.get('/x', { onRequest: apiKeyAuth({ ...ADMIN_CONFIG, apiKey: 'secret' }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({ method: 'GET', url: '/x', headers: { authorization: 'Basic secret' } });
+		expect(response.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('rejects an admin request with no key at all', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({ method: 'GET', url: '/x' });
+		expect(response.statusCode).toBe(403);
+		expect(response.json().error.message).toBe('Unauthorized: Invalid admin key');
+		await app.close();
+	});
+
+	it('rejects an admin request carrying the wrong key', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { [ADMIN_KEY_HEADER]: 'a'.repeat(64) }
+		});
+		expect(response.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('rejects an admin request that presents the proxy key instead', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth({ ...ADMIN_CONFIG, apiKey: 'proxy-key' }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { authorization: 'Bearer proxy-key', 'x-api-key': 'proxy-key' }
+		});
+		expect(response.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('accepts an admin request carrying the correct key', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { [ADMIN_KEY_HEADER]: TEST_ADMIN_KEY }
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ ok: true });
+		await app.close();
+	});
+
+	it('fails closed when the admin key is missing from config', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth({ port: 0, adminApiKey: '', quietMode: true }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const empty = await app.inject({ method: 'GET', url: '/x' });
+		expect(empty.statusCode).toBe(403);
+
+		const alsoEmpty = await app.inject({ method: 'GET', url: '/x', headers: { [ADMIN_KEY_HEADER]: '' } });
+		expect(alsoEmpty.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('rejects a request that sends the admin key header twice', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { [ADMIN_KEY_HEADER]: ['wrong', TEST_ADMIN_KEY] }
+		});
+		expect(response.statusCode).toBe(403);
 		await app.close();
 	});
 });

--- a/apps/api/tests/integration/routes/routes-auth.test.ts
+++ b/apps/api/tests/integration/routes/routes-auth.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import authPlugin from 'src/routes/auth';
 
-import { withPlugin } from '../test-harness';
+import { ADMIN_HEADERS, withPlugin } from '../test-harness';
 
 const oauthStartLoginMock = vi.fn();
 const oauthCompleteLoginMock = vi.fn();
@@ -56,24 +56,30 @@ describe('routes-auth', () => {
 
 		const app = await withPlugin(authPlugin);
 
-		const start = await app.inject({ method: 'POST', url: '/auth/claude/start' });
+		const start = await app.inject({ method: 'POST', url: '/auth/claude/start', headers: ADMIN_HEADERS });
 		expect(start.statusCode).toBe(200);
 		expect(start.json()).toEqual({ authUrl: 'u', sessionId: 's' });
 
-		const bad = await app.inject({ method: 'POST', url: '/auth/claude/complete', payload: { code: 'x' } });
+		const bad = await app.inject({
+			method: 'POST',
+			url: '/auth/claude/complete',
+			headers: ADMIN_HEADERS,
+			payload: { code: 'x' }
+		});
 		expect(bad.statusCode).toBe(400);
 
 		const complete = await app.inject({
 			method: 'POST',
 			url: '/auth/claude/complete',
+			headers: ADMIN_HEADERS,
 			payload: { code: 'x', sessionId: 'sid' }
 		});
 		expect(complete.json()).toEqual({ ok: true, email: 'e@e.com' });
 
-		const status = await app.inject({ method: 'GET', url: '/auth/claude/status' });
+		const status = await app.inject({ method: 'GET', url: '/auth/claude/status', headers: ADMIN_HEADERS });
 		expect(status.json()).toEqual({ authenticated: true });
 
-		const logout = await app.inject({ method: 'POST', url: '/auth/claude/logout' });
+		const logout = await app.inject({ method: 'POST', url: '/auth/claude/logout', headers: ADMIN_HEADERS });
 		expect(logout.json()).toEqual({ ok: true });
 		expect(oauthLogoutMock).toHaveBeenCalled();
 		await app.close();
@@ -83,12 +89,13 @@ describe('routes-auth', () => {
 		providerGetMock.mockReturnValueOnce({ accessToken: 'k', baseUrl: 'https://x' });
 		const app = await withPlugin(authPlugin);
 
-		const status = await app.inject({ method: 'GET', url: '/auth/minimax/status' });
+		const status = await app.inject({ method: 'GET', url: '/auth/minimax/status', headers: ADMIN_HEADERS });
 		expect(status.json()).toEqual({ authenticated: true, baseUrl: 'https://x' });
 
 		const badLogin = await app.inject({
 			method: 'POST',
 			url: '/auth/minimax/login',
+			headers: ADMIN_HEADERS,
 			payload: { apiKey: '   ' }
 		});
 		expect(badLogin.statusCode).toBe(400);
@@ -96,12 +103,13 @@ describe('routes-auth', () => {
 		const login = await app.inject({
 			method: 'POST',
 			url: '/auth/minimax/login',
+			headers: ADMIN_HEADERS,
 			payload: { apiKey: ' key ', baseUrl: ' https://m ' }
 		});
 		expect(login.json()).toEqual({ ok: true });
 		expect(providerUpsertApiKeyMock).toHaveBeenCalledWith('minimax', 'key', 'https://m');
 
-		const logout = await app.inject({ method: 'POST', url: '/auth/minimax/logout' });
+		const logout = await app.inject({ method: 'POST', url: '/auth/minimax/logout', headers: ADMIN_HEADERS });
 		expect(logout.json()).toEqual({ ok: true });
 		expect(providerRemoveMock).toHaveBeenCalledWith('minimax');
 		await app.close();
@@ -113,26 +121,60 @@ describe('routes-auth', () => {
 		openaiCompleteLoginMock.mockResolvedValueOnce({ ok: true });
 		const app = await withPlugin(authPlugin);
 
-		const start = await app.inject({ method: 'GET', url: '/auth/openai/start' });
+		const start = await app.inject({ method: 'GET', url: '/auth/openai/start', headers: ADMIN_HEADERS });
 		expect(start.json().authUrl).toBe('openai-url');
 
-		const missing = await app.inject({ method: 'GET', url: '/auth/openai/callback' });
+		const missing = await app.inject({ method: 'GET', url: '/auth/openai/callback', headers: ADMIN_HEADERS });
 		expect(missing.statusCode).toBe(200);
 		expect(missing.body).toContain('Missing code or session');
 
-		const success = await app.inject({ method: 'GET', url: '/auth/openai/callback?code=abc&state=state1' });
+		const success = await app.inject({
+			method: 'GET',
+			url: '/auth/openai/callback?code=abc&state=state1',
+			headers: ADMIN_HEADERS
+		});
 		expect(success.body).toContain('Connected!');
 
 		openaiCompleteLoginMock.mockResolvedValueOnce({ ok: false, error: 'boom' });
-		const failure = await app.inject({ method: 'GET', url: '/auth/openai/callback?code=abc&state=state2' });
+		const failure = await app.inject({
+			method: 'GET',
+			url: '/auth/openai/callback?code=abc&state=state2',
+			headers: ADMIN_HEADERS
+		});
 		expect(failure.body).toContain('Error');
 		expect(failure.body).toContain('boom');
 
-		const status = await app.inject({ method: 'GET', url: '/auth/openai/status' });
+		const status = await app.inject({ method: 'GET', url: '/auth/openai/status', headers: ADMIN_HEADERS });
 		expect(status.json()).toEqual({ authenticated: false });
 
-		await app.inject({ method: 'POST', url: '/auth/openai/logout' });
+		await app.inject({ method: 'POST', url: '/auth/openai/logout', headers: ADMIN_HEADERS });
 		expect(openaiLogoutMock).toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses provider auth routes without the admin key', async () => {
+		const app = await withPlugin(authPlugin);
+
+		const start = await app.inject({ method: 'POST', url: '/auth/claude/start' });
+		expect(start.statusCode).toBe(403);
+
+		const login = await app.inject({
+			method: 'POST',
+			url: '/auth/minimax/login',
+			payload: { apiKey: 'stolen', baseUrl: 'https://m' }
+		});
+		expect(login.statusCode).toBe(403);
+
+		const callback = await app.inject({ method: 'GET', url: '/auth/openai/callback?code=abc&state=s' });
+		expect(callback.statusCode).toBe(403);
+
+		const logout = await app.inject({ method: 'POST', url: '/auth/claude/logout' });
+		expect(logout.statusCode).toBe(403);
+
+		expect(oauthStartLoginMock).not.toHaveBeenCalled();
+		expect(providerUpsertApiKeyMock).not.toHaveBeenCalled();
+		expect(openaiCompleteLoginMock).not.toHaveBeenCalled();
+		expect(oauthLogoutMock).not.toHaveBeenCalled();
 		await app.close();
 	});
 });

--- a/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
+++ b/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+
 import analyticsPlugin from 'src/routes/analytics';
 import healthPlugin from 'src/routes/health';
 import modelsPlugin from 'src/routes/models';
 import settingsPlugin from 'src/routes/settings';
 
-import { withPlugin } from '../test-harness';
+import { ADMIN_HEADERS, withPlugin } from '../test-harness';
 
 const settingsGetMock = vi.fn();
 const settingsUpdateMock = vi.fn();
@@ -48,6 +50,7 @@ describe('routes: health/settings/models/analytics', () => {
 		const res = await app.inject({
 			method: 'POST',
 			url: '/settings',
+			headers: ADMIN_HEADERS,
 			payload: {
 				models: [
 					{
@@ -90,13 +93,14 @@ describe('routes: health/settings/models/analytics', () => {
 		});
 
 		const app = await withPlugin(settingsPlugin);
-		const getRes = await app.inject({ method: 'GET', url: '/settings' });
+		const getRes = await app.inject({ method: 'GET', url: '/settings', headers: ADMIN_HEADERS });
 		expect(getRes.statusCode).toBe(200);
 		expect(getRes.json().port).toBe(4783);
 
 		const postRes = await app.inject({
 			method: 'POST',
 			url: '/settings',
+			headers: ADMIN_HEADERS,
 			payload: { quiet: true }
 		});
 		expect(postRes.statusCode).toBe(200);
@@ -113,8 +117,12 @@ describe('routes: health/settings/models/analytics', () => {
 			]
 		});
 
-		const app = await withPlugin(modelsPlugin);
-		const response = await app.inject({ method: 'GET', url: '/v1/models' });
+		const app = await withPlugin(modelsPlugin, { apiKey: 'proxy-key' });
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/models',
+			headers: { authorization: 'Bearer proxy-key' }
+		});
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual({
 			object: 'list',
@@ -143,16 +151,90 @@ describe('routes: health/settings/models/analytics', () => {
 
 		const app = await withPlugin(analyticsPlugin);
 
-		const summary = await app.inject({ method: 'GET', url: '/analytics?period=all' });
+		const summary = await app.inject({ method: 'GET', url: '/analytics?period=all', headers: ADMIN_HEADERS });
 		expect(summary.statusCode).toBe(200);
 		expect(summary.json().period).toBe('all');
 		expect(summary.json().note).toContain('Costs are estimates');
 
-		await app.inject({ method: 'GET', url: '/analytics/requests?limit=9999' });
+		await app.inject({ method: 'GET', url: '/analytics/requests?limit=9999', headers: ADMIN_HEADERS });
 		expect(analyticsRecentMock).toHaveBeenCalledWith(1000);
 
-		const reset = await app.inject({ method: 'POST', url: '/analytics/reset' });
+		const reset = await app.inject({ method: 'POST', url: '/analytics/reset', headers: ADMIN_HEADERS });
 		expect(reset.json()).toEqual({ success: true, deletedCount: 4 });
+		await app.close();
+	});
+
+	it('refuses settings reads and writes without the admin key', async () => {
+		const app = await withPlugin(settingsPlugin);
+
+		const read = await app.inject({ method: 'GET', url: '/settings' });
+		expect(read.statusCode).toBe(403);
+
+		const write = await app.inject({ method: 'POST', url: '/settings', payload: { quiet: true } });
+		expect(write.statusCode).toBe(403);
+
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		expect(settingsUpdateMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses settings requests carrying a wrong admin key', async () => {
+		const app = await withPlugin(settingsPlugin);
+
+		const read = await app.inject({
+			method: 'GET',
+			url: '/settings',
+			headers: { [ADMIN_KEY_HEADER]: 'not-the-key' }
+		});
+		expect(read.statusCode).toBe(403);
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses every analytics route without the admin key', async () => {
+		const app = await withPlugin(analyticsPlugin);
+
+		for (const url of ['/analytics', '/analytics/requests', '/analytics/tokens']) {
+			const response = await app.inject({ method: 'GET', url });
+			expect(response.statusCode).toBe(403);
+		}
+
+		const reset = await app.inject({ method: 'POST', url: '/analytics/reset' });
+		expect(reset.statusCode).toBe(403);
+
+		expect(analyticsSummaryMock).not.toHaveBeenCalled();
+		expect(analyticsResetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses the model list without the proxy key', async () => {
+		const app = await withPlugin(modelsPlugin, { apiKey: 'proxy-key' });
+
+		const anonymous = await app.inject({ method: 'GET', url: '/v1/models' });
+		expect(anonymous.statusCode).toBe(403);
+
+		const wrong = await app.inject({ method: 'GET', url: '/v1/models', headers: { 'x-api-key': 'nope' } });
+		expect(wrong.statusCode).toBe(403);
+
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses the model list when no proxy key is configured at all', async () => {
+		const app = await withPlugin(modelsPlugin);
+
+		const response = await app.inject({ method: 'GET', url: '/v1/models' });
+		expect(response.statusCode).toBe(403);
+
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('keeps health reachable without any key', async () => {
+		const app = await withPlugin(healthPlugin);
+
+		const response = await app.inject({ method: 'GET', url: '/health' });
+		expect(response.statusCode).toBe(200);
 		await app.close();
 	});
 });

--- a/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
+++ b/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import settingsPlugin from 'src/routes/settings';
 
-import { withPlugin } from '../test-harness';
+import { ADMIN_HEADERS, TEST_ADMIN_KEY, withPlugin } from '../test-harness';
 
 describe('routes: settings (real database)', () => {
 	it('strips unknown fields and saves model to database', async () => {
@@ -11,6 +11,7 @@ describe('routes: settings (real database)', () => {
 		const postRes = await app.inject({
 			method: 'POST',
 			url: '/settings',
+			headers: ADMIN_HEADERS,
 			payload: {
 				quiet: false,
 				models: [
@@ -29,7 +30,7 @@ describe('routes: settings (real database)', () => {
 		});
 		expect(postRes.statusCode).toBe(200);
 
-		const getRes = await app.inject({ method: 'GET', url: '/settings' });
+		const getRes = await app.inject({ method: 'GET', url: '/settings', headers: ADMIN_HEADERS });
 		expect(getRes.statusCode).toBe(200);
 
 		const body = getRes.json();
@@ -37,6 +38,10 @@ describe('routes: settings (real database)', () => {
 
 		expect(saved).toBeDefined();
 		expect(saved).not.toHaveProperty('enabled');
+
+		// The admin key lives in the environment only; it must never travel back through settings.
+		expect(body).not.toHaveProperty('adminApiKey');
+		expect(getRes.body).not.toContain(TEST_ADMIN_KEY);
 
 		await app.close();
 	});

--- a/apps/api/tests/integration/test-harness.ts
+++ b/apps/api/tests/integration/test-harness.ts
@@ -1,7 +1,15 @@
 import Fastify, { type FastifyInstance, type FastifyPluginCallback } from 'fastify';
 
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+
+/** Stand-in for the 256-bit key the extension mints; length matches a hex-encoded key. */
+export const TEST_ADMIN_KEY = 'f'.repeat(64);
+
+export const ADMIN_HEADERS = { [ADMIN_KEY_HEADER]: TEST_ADMIN_KEY };
+
 export interface HarnessConfig {
 	apiKey?: string;
+	adminApiKey?: string;
 }
 
 export function createTestApp(config: HarnessConfig = {}): FastifyInstance {
@@ -9,6 +17,7 @@ export function createTestApp(config: HarnessConfig = {}): FastifyInstance {
 	app.decorate('config', {
 		port: 0,
 		apiKey: config.apiKey,
+		adminApiKey: config.adminApiKey ?? TEST_ADMIN_KEY,
 		quietMode: true
 	});
 

--- a/apps/api/tests/unit/auth/auth-providers-and-index.test.ts
+++ b/apps/api/tests/unit/auth/auth-providers-and-index.test.ts
@@ -4,6 +4,7 @@ const oauthGetValidTokenMock = vi.fn();
 const oauthGetAuthStatusMock = vi.fn();
 const oauthLogoutMock = vi.fn();
 const providerGetMock = vi.fn();
+const providerHasCredentialsMock = vi.fn();
 const providerRemoveMock = vi.fn();
 
 vi.mock('src/auth/oauth', () => ({
@@ -17,6 +18,7 @@ vi.mock('src/auth/oauth', () => ({
 vi.mock('src/database/provider-settings', () => ({
 	ProviderSettings: {
 		get: (...args: unknown[]) => providerGetMock(...args),
+		hasCredentials: (...args: unknown[]) => providerHasCredentialsMock(...args),
 		remove: (...args: unknown[]) => providerRemoveMock(...args)
 	}
 }));
@@ -29,47 +31,48 @@ import { OpenAIProvider } from 'src/auth/openai-provider';
 describe('auth providers and index', () => {
 	it('claude provider delegates oauth methods', async () => {
 		oauthGetValidTokenMock.mockResolvedValueOnce({ accessToken: 'tok' });
-		oauthGetAuthStatusMock.mockReturnValueOnce({ authenticated: true });
+		oauthGetAuthStatusMock.mockResolvedValueOnce({ authenticated: true });
 
 		const provider = new ClaudeProvider();
 		expect(await provider.getAuthHeader()).toBe('Bearer tok');
-		expect(provider.isAuthenticated()).toBe(true);
-		provider.logout();
+		expect(await provider.isAuthenticated()).toBe(true);
+		await provider.logout();
 		expect(oauthLogoutMock).toHaveBeenCalled();
 	});
 
 	it('claude provider returns null auth header without token', async () => {
 		oauthGetValidTokenMock.mockResolvedValueOnce(null);
-		oauthGetAuthStatusMock.mockReturnValueOnce({ authenticated: false });
+		oauthGetAuthStatusMock.mockResolvedValueOnce({ authenticated: false });
 
 		const provider = new ClaudeProvider();
 		expect(await provider.getAuthHeader()).toBeNull();
-		expect(provider.isAuthenticated()).toBe(false);
+		expect(await provider.isAuthenticated()).toBe(false);
 	});
 
-	it('openai and minimax providers use provider settings', () => {
-		providerGetMock.mockReturnValueOnce({ accessToken: 'oa' }).mockReturnValueOnce({ accessToken: 'mm' });
+	it('openai and minimax providers use provider settings', async () => {
+		providerGetMock.mockResolvedValueOnce({ accessToken: 'oa' }).mockResolvedValueOnce({ accessToken: 'mm' });
 
 		const openai = new OpenAIProvider();
 		const minimax = new MiniMaxProvider();
-		expect(openai.getAuthHeader()).toBe('Bearer oa');
-		expect(minimax.getAuthHeader()).toBe('Bearer mm');
+		expect(await openai.getAuthHeader()).toBe('Bearer oa');
+		expect(await minimax.getAuthHeader()).toBe('Bearer mm');
 
-		openai.logout();
-		minimax.logout();
+		await openai.logout();
+		await minimax.logout();
 		expect(providerRemoveMock).toHaveBeenCalledWith('openai');
 		expect(providerRemoveMock).toHaveBeenCalledWith('minimax');
 	});
 
-	it('openai and minimax providers return null auth headers without tokens', () => {
-		providerGetMock.mockReturnValueOnce(null).mockReturnValueOnce({}).mockReturnValueOnce(null).mockReturnValueOnce({});
+	it('openai and minimax providers return null auth headers without tokens', async () => {
+		providerGetMock.mockResolvedValueOnce(null).mockResolvedValueOnce({ accessToken: '' });
+		providerHasCredentialsMock.mockResolvedValue(false);
 
 		const openai = new OpenAIProvider();
 		const minimax = new MiniMaxProvider();
-		expect(openai.getAuthHeader()).toBeNull();
-		expect(openai.isAuthenticated()).toBe(false);
-		expect(minimax.getAuthHeader()).toBeNull();
-		expect(minimax.isAuthenticated()).toBe(false);
+		expect(await openai.getAuthHeader()).toBeNull();
+		expect(await openai.isAuthenticated()).toBe(false);
+		expect(await minimax.getAuthHeader()).toBeNull();
+		expect(await minimax.isAuthenticated()).toBe(false);
 	});
 
 	it('getProvider returns undefined for unknown provider names at runtime', () => {

--- a/apps/api/tests/unit/config/config.test.ts
+++ b/apps/api/tests/unit/config/config.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ADMIN_KEY_ENV } from '@ungate/shared';
 import { getConfig } from 'src/config';
 
+const ADMIN_KEY = 'f'.repeat(64);
+
 describe('config', () => {
+	beforeEach(() => {
+		vi.stubEnv(ADMIN_KEY_ENV, ADMIN_KEY);
+	});
+
 	afterEach(() => {
 		vi.unstubAllEnvs();
 	});
@@ -18,7 +25,7 @@ describe('config', () => {
 			models: []
 		});
 
-		expect(cfg).toEqual({ port: 7777, apiKey: 'abc', quietMode: true });
+		expect(cfg).toEqual({ port: 7777, apiKey: 'abc', adminApiKey: ADMIN_KEY, quietMode: true });
 	});
 
 	it('falls back to settings when env is absent', () => {
@@ -32,7 +39,7 @@ describe('config', () => {
 			models: []
 		});
 
-		expect(cfg).toEqual({ port: 3000, apiKey: undefined, quietMode: false });
+		expect(cfg).toEqual({ port: 3000, apiKey: undefined, adminApiKey: ADMIN_KEY, quietMode: false });
 	});
 
 	it('falls back to settings when env port is invalid number', () => {
@@ -46,6 +53,32 @@ describe('config', () => {
 			models: []
 		});
 
-		expect(cfg).toEqual({ port: 4123, apiKey: undefined, quietMode: false });
+		expect(cfg).toEqual({ port: 4123, apiKey: undefined, adminApiKey: ADMIN_KEY, quietMode: false });
+	});
+
+	it('refuses to build a config when the admin key is absent', () => {
+		vi.stubEnv(ADMIN_KEY_ENV, '');
+
+		expect(() =>
+			getConfig({ port: 4123, apiKey: null, quiet: false, extraInstruction: null, models: [] })
+		).toThrowError(ADMIN_KEY_ENV);
+	});
+
+	it('refuses an admin key too short to carry 256 bits', () => {
+		vi.stubEnv(ADMIN_KEY_ENV, 'short-key');
+
+		expect(() =>
+			getConfig({ port: 4123, apiKey: null, quiet: false, extraInstruction: null, models: [] })
+		).toThrowError(ADMIN_KEY_ENV);
+	});
+
+	it('accepts a base64url-encoded 256-bit key', () => {
+		const base64UrlKey = 'A'.repeat(43);
+		vi.stubEnv(ADMIN_KEY_ENV, base64UrlKey);
+		vi.stubEnv('PORT', '');
+
+		const cfg = getConfig({ port: 4123, apiKey: null, quiet: false, extraInstruction: null, models: [] });
+
+		expect(cfg.adminApiKey).toBe(base64UrlKey);
 	});
 });

--- a/apps/api/tests/unit/plugins/cors-origin.test.ts
+++ b/apps/api/tests/unit/plugins/cors-origin.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAllowedDashboardOrigin } from 'src/plugins/cors-origin';
+
+describe('cors-origin', () => {
+	it('allows requests that carry no Origin header', () => {
+		// Cursor's backend and CLI clients reach the proxy without an Origin; CORS is not involved.
+		expect(isAllowedDashboardOrigin(undefined)).toBe(true);
+		expect(isAllowedDashboardOrigin('')).toBe(true);
+	});
+
+	it('allows the VS Code and Cursor webview origins', () => {
+		expect(isAllowedDashboardOrigin('vscode-webview://1a2b3c4d-5e6f-7788-99aa-bbccddeeff00')).toBe(true);
+		expect(isAllowedDashboardOrigin('vscode-file://vscode-app')).toBe(true);
+	});
+
+	it('allows loopback origins for local web development', () => {
+		expect(isAllowedDashboardOrigin('http://localhost:5173')).toBe(true);
+		expect(isAllowedDashboardOrigin('http://127.0.0.1:4783')).toBe(true);
+		expect(isAllowedDashboardOrigin('http://[::1]:5173')).toBe(true);
+	});
+
+	it('refuses arbitrary web origins', () => {
+		expect(isAllowedDashboardOrigin('https://evil.example')).toBe(false);
+		expect(isAllowedDashboardOrigin('http://attacker.test:8080')).toBe(false);
+		expect(isAllowedDashboardOrigin('https://ungate.dev')).toBe(false);
+	});
+
+	it('refuses hostnames that merely embed a loopback name', () => {
+		expect(isAllowedDashboardOrigin('https://localhost.evil.example')).toBe(false);
+		expect(isAllowedDashboardOrigin('https://127.0.0.1.evil.example')).toBe(false);
+		expect(isAllowedDashboardOrigin('https://notlocalhost')).toBe(false);
+	});
+
+	it('refuses opaque and unparseable origins', () => {
+		expect(isAllowedDashboardOrigin('null')).toBe(false);
+		expect(isAllowedDashboardOrigin('not an origin')).toBe(false);
+		expect(isAllowedDashboardOrigin('file:///etc/passwd')).toBe(false);
+	});
+
+	it('refuses a tunnel hostname, which is where remote traffic arrives', () => {
+		expect(isAllowedDashboardOrigin('https://random-words-1234.trycloudflare.com')).toBe(false);
+	});
+});

--- a/apps/api/tests/unit/security/credential-channel.test.ts
+++ b/apps/api/tests/unit/security/credential-channel.test.ts
@@ -1,0 +1,64 @@
+import { PROVIDER_SECRET_CHANNEL } from '@ungate/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CredentialChannelMissingError, requireCredentialChannel } from 'src/security/credential-channel';
+import { ProviderSecrets, useProviderSecretTransport } from 'src/security/provider-secrets';
+
+import { createHostWithoutIpc, FakeIpcHost } from '../../helpers/fake-ipc-host';
+
+describe('requireCredentialChannel', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		useProviderSecretTransport(null);
+	});
+
+	afterEach(() => {
+		useProviderSecretTransport(null);
+		vi.restoreAllMocks();
+	});
+
+	it('refuses to start without an ipc credential channel', async () => {
+		const host = createHostWithoutIpc();
+
+		expect(() => requireCredentialChannel(host)).toThrow(CredentialChannelMissingError);
+
+		// No transport was installed and no lifecycle handler was registered.
+		await expect(ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null })).rejects.toThrow(/unavailable/);
+		expect(host.listenerCount('disconnect')).toBe(0);
+		expect(host.exitCode).toBeNull();
+	});
+
+	it('installs the transport so credential requests reach the extension', async () => {
+		const host = new FakeIpcHost();
+
+		requireCredentialChannel(host);
+
+		const pending = ProviderSecrets.read('claude');
+		const request = host.lastRequest();
+
+		expect(request).toMatchObject({ channel: PROVIDER_SECRET_CHANNEL, action: 'get', provider: 'claude' });
+
+		host.emit('message', {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: request.id,
+			ok: true,
+			secret: { accessToken: 'access', refreshToken: null }
+		});
+
+		await expect(pending).resolves.toEqual({ accessToken: 'access', refreshToken: null });
+		expect(host.exitCode).toBeNull();
+	});
+
+	it('ends the process when the channel is lost, after rejecting in-flight requests', async () => {
+		const host = new FakeIpcHost();
+
+		requireCredentialChannel(host);
+
+		const inFlight = ProviderSecrets.write('minimax', { accessToken: 'key', refreshToken: null });
+
+		host.emit('disconnect');
+
+		await expect(inFlight).rejects.toThrow(/closed the credential channel/);
+		expect(host.exitCode).toBe(0);
+	});
+});

--- a/apps/api/tests/unit/security/ipc-secret-transport.test.ts
+++ b/apps/api/tests/unit/security/ipc-secret-transport.test.ts
@@ -1,0 +1,130 @@
+import { PROVIDER_SECRET_CHANNEL } from '@ungate/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IpcSecretTransport } from 'src/security/ipc-secret-transport';
+import { ProviderSecrets, SecretStorageUnavailableError, useProviderSecretTransport } from 'src/security/provider-secrets';
+
+import { createHostWithoutIpc, FakeIpcHost } from '../../helpers/fake-ipc-host';
+
+describe('IpcSecretTransport', () => {
+	let host: FakeIpcHost;
+
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		host = new FakeIpcHost();
+		IpcSecretTransport.install(host);
+	});
+
+	afterEach(() => {
+		useProviderSecretTransport(null);
+		vi.restoreAllMocks();
+	});
+
+	it('sends a validated request and resolves with the returned credential', async () => {
+		const pending = ProviderSecrets.read('claude');
+		const request = host.lastRequest();
+
+		expect(request).toMatchObject({ channel: PROVIDER_SECRET_CHANNEL, action: 'get', provider: 'claude' });
+		expect(request.id).toBeTypeOf('string');
+		expect(request.secret).toBeUndefined();
+
+		host.emit('message', {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: request.id,
+			ok: true,
+			secret: { accessToken: 'access', refreshToken: 'refresh' }
+		});
+
+		await expect(pending).resolves.toEqual({ accessToken: 'access', refreshToken: 'refresh' });
+	});
+
+	it('carries the credential on a set request and resolves once acknowledged', async () => {
+		const pending = ProviderSecrets.write('minimax', { accessToken: 'key', refreshToken: null });
+		const request = host.lastRequest();
+
+		expect(request).toMatchObject({
+			action: 'set',
+			provider: 'minimax',
+			secret: { accessToken: 'key', refreshToken: null }
+		});
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: true, secret: null });
+
+		await expect(pending).resolves.toBeUndefined();
+	});
+
+	it('rejects a malformed response instead of trusting it', async () => {
+		const pending = ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null });
+		const request = host.lastRequest();
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: 'yes' });
+
+		await expect(pending).rejects.toThrow(SecretStorageUnavailableError);
+	});
+
+	it('surfaces a refusal reported by the extension', async () => {
+		const pending = ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null });
+		const request = host.lastRequest();
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: false, error: 'keychain locked' });
+
+		await expect(pending).rejects.toThrow(/keychain locked/);
+	});
+
+	it('ignores responses that do not correlate with a pending request', async () => {
+		const pending = ProviderSecrets.read('openai');
+		const request = host.lastRequest();
+		let settled = false;
+
+		void pending.then(() => {
+			settled = true;
+		});
+
+		host.emit('message', { channel: 'some-other-channel', id: request.id, ok: true, secret: null });
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: 'not-a-pending-id', ok: true, secret: null });
+		host.emit('message', 'garbage');
+		await Promise.resolve();
+
+		expect(settled).toBe(false);
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: true, secret: null });
+
+		await expect(pending).resolves.toBeNull();
+	});
+
+	it('rejects in-flight and later requests once the channel disconnects', async () => {
+		const inFlight = ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null });
+
+		host.emit('disconnect');
+
+		await expect(inFlight).rejects.toThrow(SecretStorageUnavailableError);
+		await expect(ProviderSecrets.write('claude', { accessToken: 'b', refreshToken: null })).rejects.toThrow(
+			SecretStorageUnavailableError
+		);
+		// Reads deny instead of throwing so provider calls answer 401.
+		await expect(ProviderSecrets.read('claude')).resolves.toBeNull();
+	});
+});
+
+describe('ProviderSecrets without a transport', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		useProviderSecretTransport(null);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('installs nothing when the process has no ipc channel', () => {
+		expect(IpcSecretTransport.install(createHostWithoutIpc())).toBeNull();
+	});
+
+	it('denies reads and refuses writes', async () => {
+		await expect(ProviderSecrets.read('claude')).resolves.toBeNull();
+		await expect(ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null })).rejects.toThrow(
+			SecretStorageUnavailableError
+		);
+		await expect(ProviderSecrets.erase('claude')).rejects.toThrow(SecretStorageUnavailableError);
+	});
+});

--- a/apps/api/tests/unit/server/server-boundary.test.ts
+++ b/apps/api/tests/unit/server/server-boundary.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ADMIN_KEY_ENV, ADMIN_KEY_HEADER } from '@ungate/shared';
+import { LISTEN_HOST, startServer } from 'src/server';
+
+import type { FastifyCorsOptions, OriginFunction } from '@fastify/cors';
+
+const ADMIN_KEY = 'f'.repeat(64);
+
+const fastifyFactoryMock = vi.fn();
+const decorateMock = vi.fn();
+const addHookMock = vi.fn();
+const registerMock = vi.fn();
+const listenMock = vi.fn();
+const settingsGetMock = vi.fn();
+const getDbMock = vi.fn();
+
+vi.mock('fastify', () => ({
+	default: (...args: unknown[]) => fastifyFactoryMock(...args)
+}));
+
+vi.mock('@fastify/cors', () => ({
+	default: 'cors-plugin'
+}));
+
+vi.mock('src/database/index', () => ({
+	getDb: (...args: unknown[]) => getDbMock(...args),
+	getSqlite: vi.fn(),
+	getCurrentDbPath: vi.fn(),
+	schema: {}
+}));
+
+vi.mock('src/database/settings', () => ({
+	Settings: { get: (...args: unknown[]) => settingsGetMock(...args) }
+}));
+
+function corsOptions(): FastifyCorsOptions {
+	const registration = registerMock.mock.calls.find(([plugin]) => plugin === 'cors-plugin');
+
+	if (!registration) {
+		throw new Error('CORS plugin was never registered');
+	}
+
+	return registration[1] as FastifyCorsOptions;
+}
+
+function resolveOrigin(origin: string | undefined): boolean {
+	// The server registers the callback form of `origin`; the FastifyCorsOptions union also covers
+	// static values and async delegates, so it cannot narrow to that form structurally.
+	const policy = corsOptions().origin as OriginFunction;
+
+	if (typeof policy !== 'function') {
+		throw new Error('CORS origin must be decided by a policy function, not a static value');
+	}
+
+	let allowed: unknown;
+
+	policy(origin, (error, allow) => {
+		if (error) throw error;
+		allowed = allow;
+	});
+
+	if (typeof allowed !== 'boolean') {
+		throw new Error(`CORS origin policy answered with ${String(allowed)} instead of a boolean`);
+	}
+
+	return allowed;
+}
+
+describe('server boundary', () => {
+	beforeEach(() => {
+		vi.stubEnv(ADMIN_KEY_ENV, ADMIN_KEY);
+		vi.stubEnv('PORT', '');
+		vi.spyOn(globalThis.console, 'log').mockImplementation(() => {});
+
+		fastifyFactoryMock.mockReturnValue({
+			decorate: decorateMock,
+			addHook: addHookMock,
+			register: registerMock,
+			listen: listenMock
+		});
+		registerMock.mockResolvedValue(undefined);
+		listenMock.mockResolvedValue(undefined);
+		settingsGetMock.mockReturnValue({
+			port: 4783,
+			apiKey: 'proxy-key',
+			quiet: true,
+			extraInstruction: null,
+			models: []
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it('listens on loopback only, never a LAN interface', async () => {
+		await startServer();
+
+		expect(LISTEN_HOST).toBe('127.0.0.1');
+		expect(listenMock).toHaveBeenCalledWith({ port: 4783, host: '127.0.0.1' });
+	});
+
+	it('hands the environment admin key to the request pipeline', async () => {
+		await startServer();
+
+		expect(decorateMock).toHaveBeenCalledWith(
+			'config',
+			expect.objectContaining({ adminApiKey: ADMIN_KEY, apiKey: 'proxy-key' })
+		);
+	});
+
+	it('refuses to start without an admin key', async () => {
+		vi.stubEnv(ADMIN_KEY_ENV, '');
+
+		await expect(startServer()).rejects.toThrow(ADMIN_KEY_ENV);
+		expect(listenMock).not.toHaveBeenCalled();
+	});
+
+	it('replaces wildcard CORS with an origin policy', async () => {
+		await startServer();
+
+		expect(corsOptions().origin).not.toBe('*');
+		expect(resolveOrigin('vscode-webview://1a2b3c4d-5e6f-7788-99aa-bbccddeeff00')).toBe(true);
+		expect(resolveOrigin(undefined)).toBe(true);
+		expect(resolveOrigin('https://evil.example')).toBe(false);
+		expect(resolveOrigin('https://random-words-1234.trycloudflare.com')).toBe(false);
+	});
+
+	it('permits the admin key header through CORS preflight', async () => {
+		await startServer();
+
+		expect(corsOptions().allowedHeaders).toContain(ADMIN_KEY_HEADER);
+		expect(corsOptions().credentials).toBe(false);
+	});
+});

--- a/apps/extension/src/api-server.ts
+++ b/apps/extension/src/api-server.ts
@@ -2,13 +2,15 @@ import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { sleep, type ApiStatus as ServerStatus, type LogEntry } from '@ungate/shared';
+import { ADMIN_KEY_ENV, sleep, type ApiStatus as ServerStatus, type LogEntry, type ProviderSecretResponse } from '@ungate/shared';
 import * as vscode from 'vscode';
 
 import { RuntimeStateStore } from './runtime-state';
 import { config } from './runtime-state/config';
 import { BetterSqlite3Installer } from './utils/better-sqlite3-installer';
 import { NodeResolver } from './utils/node-resolver';
+
+import type { SecuritySecrets } from './security-secrets';
 
 const HEALTH_CHECK_URL = (port: number) => `http://localhost:${port}/health`;
 const STARTING_STATE_TIMEOUT_MS = 10000;
@@ -38,6 +40,7 @@ export class ApiServer {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
+		private readonly secrets: SecuritySecrets,
 		private readonly callbacks: ApiServerCallbacks
 	) {}
 
@@ -196,6 +199,8 @@ export class ApiServer {
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
 			UNGATE_BETTER_SQLITE3_NATIVE_BINDING: BetterSqlite3Installer.resolveBindingPath(cwd),
+			// Administrative routes are gated by this key; it never reaches SQLite or the log.
+			[ADMIN_KEY_ENV]: this.secrets.adminApiKey,
 			...(isDev ? { DB_PATH: path.join(os.homedir(), '.ungate', 'data-dev.db') } : { DRIZZLE_PATH: path.join(cwd, 'drizzle') })
 		};
 
@@ -203,18 +208,60 @@ export class ApiServer {
 
 		this.callbacks.onLog('info', `[process] starting api via ${runtime}`);
 
-		this.process = cp.spawn(runtime, nodeArgs, { cwd, env, stdio: 'pipe', detached: true });
+		// The fourth stdio slot is the credential channel: the child asks for provider secrets
+		// instead of reading them from the database.
+		this.process = cp.spawn(runtime, nodeArgs, { cwd, env, stdio: ['pipe', 'pipe', 'pipe', 'ipc'], detached: true });
 		this.process.unref();
 		void this.writeRuntimeState('starting', null).catch(() => {});
 
 		this.process.stdout?.on('data', (data: Buffer) => this.onStdout(data));
 		this.process.stderr?.on('data', (data: Buffer) => this.onStderr(data));
 		this.process.on('exit', (code, signal) => this.onExit(code, signal));
+		this.process.on('message', (message: unknown) => {
+			void this.onChildMessage(message);
+		});
 		this.process.on('error', (err) => {
 			void this.onSpawnProcessError(err).catch(() => {});
 		});
 
 		this.startHealthCheck();
+	}
+
+	/**
+	 * Serves credential requests from the API child. Only the outcome is logged: request and
+	 * response payloads carry access and refresh tokens.
+	 */
+	private async onChildMessage(message: unknown): Promise<void> {
+		const child = this.process;
+		let response: ProviderSecretResponse | null;
+
+		try {
+			response = await this.secrets.handleApiChildMessage(message);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+
+			this.callbacks.onLog('error', `[secrets] credential request failed: ${reason}`);
+
+			return;
+		}
+
+		if (!response) {
+			return;
+		}
+
+		if (!child?.connected) {
+			this.callbacks.onLog('error', '[secrets] dropped a credential response: the api channel closed');
+
+			return;
+		}
+
+		try {
+			child.send(response);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+
+			this.callbacks.onLog('error', `[secrets] failed to answer a credential request: ${reason}`);
+		}
 	}
 
 	private onStdout(data: Buffer): void {

--- a/apps/extension/src/dashboard.ts
+++ b/apps/extension/src/dashboard.ts
@@ -19,6 +19,21 @@ export type Msg =
 	| { type: 'clear-logs'; source: 'api' | 'tunnel' }
 	| Extract<WebviewToExtension, { type: (typeof MSGS_SIMPLE)[number] }>;
 
+/**
+ * Serialises a value for embedding inside an inline `<script>` element. JSON alone is not enough:
+ * a literal `</script` inside a string would close the element, and U+2028/U+2029 are line
+ * terminators in JavaScript source but legal inside JSON strings. Escaping the three HTML-special
+ * characters and both separators keeps the payload inert no matter what the value contains.
+ */
+export function toInlineScriptJson(value: unknown): string {
+	return JSON.stringify(value ?? null)
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/&/g, '\\u0026')
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029');
+}
+
 export class Dashboard {
 	private panel: vscode.WebviewPanel | null = null;
 	private readonly apiLogBuffer = new LogRingBuffer(LOG_BUFFER_SIZE);
@@ -30,6 +45,7 @@ export class Dashboard {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
+		private readonly adminApiKey: string,
 		private readonly onMessage: (message: Msg) => void
 	) {}
 
@@ -247,10 +263,15 @@ export class Dashboard {
 		html = html.replace(/src="\/assets\//g, `src="${assetsUri.toString()}/`);
 		html = html.replace(/href="\/assets\//g, `href="${assetsUri.toString()}/`);
 		html = html.replace('href="/favicon.png"', `href="${faviconUri.toString()}"`);
-		html = html.replace(
-			'</head>',
-			`<script>window.__PORT__ = ${this.currentPort}; window.__TS__ = ${Date.now()};</script>\n\t</head>`
-		);
+
+		const bootstrap =
+			`<script>window.__PORT__ = ${toInlineScriptJson(this.currentPort)}; ` +
+			`window.__ADMIN_KEY__ = ${toInlineScriptJson(this.adminApiKey)}; ` +
+			`window.__TS__ = ${Date.now()};</script>`;
+
+		// The replacement is a function so that `$&`-style patterns inside the injected values
+		// are never interpreted by String.replace.
+		html = html.replace('</head>', () => `${bootstrap}\n\t</head>`);
 
 		return html;
 	}

--- a/apps/extension/src/extension-controller.ts
+++ b/apps/extension/src/extension-controller.ts
@@ -17,6 +17,7 @@ import { ExtensionStatusBar } from './extension-status-bar';
 import { OpenAiKeyFix } from './openai-key-fix';
 import { RuntimeStateStore } from './runtime-state';
 import { config } from './runtime-state/config';
+import { SecuritySecrets } from './security-secrets';
 import { TunnelManager } from './tunnel-manager';
 
 import type { LogEntry } from './utils/log-ring-buffer';
@@ -41,7 +42,7 @@ export class ExtensionController {
 
 	constructor(private readonly context: vscode.ExtensionContext) {}
 
-	public activate(): void {
+	public async activate(): Promise<void> {
 		this.extensionHostActive = true;
 		this.outputChannel = vscode.window.createOutputChannel('Ungate');
 		this.context.subscriptions.push(this.outputChannel);
@@ -50,7 +51,11 @@ export class ExtensionController {
 		this.statusBar.command = extensionCommands.openDashboard;
 		this.context.subscriptions.push(this.statusBar);
 
-		this.dashboard = new Dashboard(this.context, (message) => {
+		// Nothing may start before the secrets are readable: the administrative API key gates the
+		// dashboard and the API child, and provider credentials live in the same store.
+		const secrets = await this.createSecuritySecrets();
+
+		this.dashboard = new Dashboard(this.context, secrets.adminApiKey, (message) => {
 			this.handleDashboardMessage(message);
 		});
 		this.keyFix = new OpenAiKeyFix(
@@ -81,7 +86,7 @@ export class ExtensionController {
 			}
 		);
 
-		this.apiServer = new ApiServer(this.context, {
+		this.apiServer = new ApiServer(this.context, secrets, {
 			onLog: (level: LogEntry['level'], message: string) => {
 				this.log(message);
 				this.dashboard.pushLog('api', { timestamp: Date.now(), level, message });
@@ -142,7 +147,7 @@ export class ExtensionController {
 
 		const disposeState = RuntimeStateStore.read();
 		if (this.isLeaderWindow(disposeState)) {
-			void this.apiServer.stop().catch(() => {});
+			void this.apiServer?.stop().catch(() => {});
 		}
 
 		if (this.heartbeatTimer) {
@@ -171,6 +176,23 @@ export class ExtensionController {
 
 		if (!hasLiveClients) {
 			this.tunnelManager?.stop();
+		}
+	}
+
+	/**
+	 * Fails closed: when VS Code SecretStorage cannot be reached there is no administrative key
+	 * and no provider credential source, so activation must not continue with an open API.
+	 */
+	private async createSecuritySecrets(): Promise<SecuritySecrets> {
+		try {
+			return await SecuritySecrets.create(this.context.secrets);
+		} catch (error: unknown) {
+			const message = this.formatError(error);
+
+			this.log(`[secrets] secret storage unavailable: ${message}`);
+			void vscode.window.showErrorMessage(`Ungate cannot start: secret storage is unavailable (${message}).`);
+
+			throw error;
 		}
 	}
 

--- a/apps/extension/src/extension.ts
+++ b/apps/extension/src/extension.ts
@@ -5,11 +5,13 @@ import { ExtensionController } from './extension-controller';
 // Keep a single controller instance between activate/deactivate hooks.
 let active: ExtensionController | undefined;
 
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	const app = new ExtensionController(context);
 
-	app.activate();
+	// Registered before awaiting so deactivate can tear down a half-started controller.
 	active = app;
+
+	await app.activate();
 }
 
 export function deactivate(): void {

--- a/apps/extension/src/security-secrets.ts
+++ b/apps/extension/src/security-secrets.ts
@@ -1,0 +1,120 @@
+import { randomBytes } from 'node:crypto';
+
+import {
+	ADMIN_KEY_MIN_LENGTH,
+	ADMIN_KEY_SECRET_KEY,
+	PROVIDER_SECRET_CHANNEL,
+	isProviderSecret,
+	parseProviderSecretRequest,
+	providerSecretKey,
+	readProviderSecretEnvelope,
+	type ModelMappingProvider,
+	type ProviderSecret,
+	type ProviderSecretResponse
+} from '@ungate/shared';
+
+/**
+ * The slice of `vscode.SecretStorage` this module needs. Narrowing it keeps the credential
+ * logic independent of the `vscode` module so it can be driven directly.
+ */
+export interface SecretStore {
+	get(key: string): Thenable<string | undefined>;
+	store(key: string, value: string): Thenable<void>;
+	delete(key: string): Thenable<void>;
+}
+
+/**
+ * Owner of every Ungate secret: the administrative API key that gates administrative HTTP
+ * routes, and the provider credentials the API child process asks for over IPC. Nothing here
+ * is written to SQLite, the runtime state file, or the log.
+ */
+export class SecuritySecrets {
+	private constructor(
+		private readonly storage: SecretStore,
+		public readonly adminApiKey: string
+	) {}
+
+	/** Loads the administrative key, minting a 256-bit one on first run or if the stored key is unusable. */
+	static async create(storage: SecretStore): Promise<SecuritySecrets> {
+		const stored = await storage.get(ADMIN_KEY_SECRET_KEY);
+
+		if (stored && stored.length >= ADMIN_KEY_MIN_LENGTH) {
+			return new SecuritySecrets(storage, stored);
+		}
+
+		const minted = randomBytes(32).toString('base64url');
+
+		await storage.store(ADMIN_KEY_SECRET_KEY, minted);
+
+		return new SecuritySecrets(storage, minted);
+	}
+
+	/**
+	 * Answers one IPC message from the API child. Returns the response to send back, or null
+	 * when the message does not belong to the credential channel. Errors are reported by
+	 * provider and action only — never with a credential value.
+	 */
+	async handleApiChildMessage(message: unknown): Promise<ProviderSecretResponse | null> {
+		const envelope = readProviderSecretEnvelope(message);
+
+		if (!envelope) {
+			return null;
+		}
+
+		const request = parseProviderSecretRequest(message);
+
+		if (!request) {
+			return { channel: PROVIDER_SECRET_CHANNEL, id: envelope.id, ok: false, error: 'Malformed credential request' };
+		}
+
+		try {
+			if (request.action === 'get') {
+				return {
+					channel: PROVIDER_SECRET_CHANNEL,
+					id: request.id,
+					ok: true,
+					secret: await this.readProviderSecret(request.provider)
+				};
+			}
+
+			if (request.action === 'set') {
+				await this.storage.store(providerSecretKey(request.provider), JSON.stringify(request.secret));
+			} else {
+				await this.storage.delete(providerSecretKey(request.provider));
+			}
+
+			return { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: true, secret: null };
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+
+			return {
+				channel: PROVIDER_SECRET_CHANNEL,
+				id: request.id,
+				ok: false,
+				error: `Secret storage rejected ${request.action} for ${request.provider}: ${reason}`
+			};
+		}
+	}
+
+	private async readProviderSecret(provider: ModelMappingProvider): Promise<ProviderSecret | null> {
+		const raw = await this.storage.get(providerSecretKey(provider));
+
+		if (!raw) {
+			return null;
+		}
+
+		let parsed: unknown;
+
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			return null;
+		}
+
+		if (!isProviderSecret(parsed)) {
+			return null;
+		}
+
+		return { accessToken: parsed.accessToken, refreshToken: parsed.refreshToken };
+	}
+}

--- a/apps/extension/src/tunnel-manager.ts
+++ b/apps/extension/src/tunnel-manager.ts
@@ -2,10 +2,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { bin, install, use, Tunnel } from 'cloudflared';
+import { bin, use, Tunnel } from 'cloudflared';
 
 import { RuntimeStateStore } from './runtime-state';
 import { config } from './runtime-state/config';
+import { CLOUDFLARED_VERSION, CloudflaredInstaller } from './utils/cloudflared-installer';
 
 import type { LogEntry, TunnelState } from '@ungate/shared/frontend';
 
@@ -84,12 +85,11 @@ export class TunnelManager {
 	}
 
 	private async ensureBinary(): Promise<void> {
-		const devBinExists = fs.existsSync(bin);
-		const userBinPath = this.resolveUserBinaryPath();
-
-		if (devBinExists) {
+		if (fs.existsSync(bin)) {
 			return;
 		}
+
+		const userBinPath = this.resolveUserBinaryPath();
 
 		if (userBinPath) {
 			use(userBinPath);
@@ -98,15 +98,17 @@ export class TunnelManager {
 		}
 
 		this.setState({ status: 'installing', url: null, error: null });
-		this.onLog({ timestamp: Date.now(), level: 'info', message: 'Downloading cloudflared binary...' });
+		this.onLog({ timestamp: Date.now(), level: 'info', message: `Downloading cloudflared ${CLOUDFLARED_VERSION}...` });
 
 		try {
-			fs.mkdirSync(CLOUDFLARED_BIN_DIR, { recursive: true });
-			const installPath = getCloudflaredBinPath();
-			const installedPath = await install(installPath);
+			const installedPath = await CloudflaredInstaller.install(getCloudflaredBinPath());
 
 			use(installedPath);
-			this.onLog({ timestamp: Date.now(), level: 'info', message: 'cloudflared installed successfully' });
+			this.onLog({
+				timestamp: Date.now(),
+				level: 'info',
+				message: `cloudflared ${CLOUDFLARED_VERSION} installed and checksum-verified`
+			});
 			this.setState({ status: 'starting', url: null, error: null });
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
@@ -115,18 +117,20 @@ export class TunnelManager {
 		}
 	}
 
+	/**
+	 * Returns a managed `~/.ungate/bin` binary only when it came from the pinned
+	 * release. Binaries from an earlier unverified `latest` install are ignored so
+	 * they get replaced by a checksum-verified one instead of being executed.
+	 */
 	private resolveUserBinaryPath(): string | null {
 		const binPath = getCloudflaredBinPath();
-
-		if (fs.existsSync(binPath)) {
-			return binPath;
-		}
-
 		const legacyPath = getCloudflaredLegacyBinPath();
 
-		if (process.platform === 'win32' && fs.existsSync(legacyPath)) {
+		if (process.platform === 'win32' && !fs.existsSync(binPath) && fs.existsSync(legacyPath)) {
 			fs.renameSync(legacyPath, binPath);
+		}
 
+		if (CloudflaredInstaller.isPinnedInstall(binPath)) {
 			return binPath;
 		}
 

--- a/apps/extension/src/utils/better-sqlite3-installer.ts
+++ b/apps/extension/src/utils/better-sqlite3-installer.ts
@@ -2,7 +2,6 @@ import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { promisify } from 'node:util';
 import { createGunzip } from 'node:zlib';
@@ -12,11 +11,50 @@ import * as tar from 'tar';
 import { RuntimeStateStore } from '../runtime-state';
 
 import { CrossProcessLock } from './cross-process-lock';
-import { NodeResolver } from './node-resolver';
+import { NodeResolver, type RuntimeInfo } from './node-resolver';
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from './verified-artifact';
 
 const NATIVE_INSTALL_LOCK = 'native-install.lock';
 const INSTALLED_BINARY_NAME = 'better_sqlite3.installed.node';
 const execFile = promisify(cp.execFile);
+
+const PINNED_VERSION = '12.11.1';
+const RELEASE_BASE = `https://github.com/WiseLibs/better-sqlite3/releases/download/v${PINNED_VERSION}`;
+
+/**
+ * SHA-256 of every WiseLibs prebuild this extension is allowed to install, taken
+ * from the immutable v12.11.1 release assets. Node ABI 127 = Node 22,
+ * 137 = Node 24, 141 = Node 25, 147 = Node 26 (nodejs/node abi_version_registry).
+ * Tuples missing from this table fail closed instead of being fetched:
+ * musl Linux, 32-bit and Electron ABIs are deliberately absent because
+ * `process.platform` cannot distinguish them from the entries below.
+ */
+const PREBUILT_SHA256: Record<string, string> = {
+	'node-v127-darwin-arm64': '8855551fa9a93d7141c5ff2156dd418bde42f63c23255b309a5b29c7c77925e2',
+	'node-v127-darwin-x64': '9c76d0dd927ad83941d29ba9cd3a4f507a88c14057afa0a3e0dbe93b5e251f4d',
+	'node-v127-linux-arm64': '00f8035f4322c14ab4dbb3ee6f4b6c9ca25209fe2a77ac2759cd09dd42587d48',
+	'node-v127-linux-x64': '94ce113ea2d9347fcd1cf8e46445cc271d1dbd02d05a64aa460442222f023b11',
+	'node-v127-win32-arm64': '895af65f470351e6252b03249dbea123f3246175471c3f59801b87a22e6ed5bf',
+	'node-v127-win32-x64': '927b34496e946dc7c9a45636a03a039df72f10191ccc4960b8616d1a9319e45b',
+	'node-v137-darwin-arm64': '6eaefc8a9c088fea873365f7db2c0f89be6ea021ede62f6a71832f5130826a93',
+	'node-v137-darwin-x64': 'f9fe570a2ef7d6069196dd595f49bc8592574963dd1f249dcaa8878626773fc9',
+	'node-v137-linux-arm64': '60da4cbe1b1714c8db62f2ee71a9928cde5303dab57bde14c02debd12a784439',
+	'node-v137-linux-x64': '99c43785639d5d3690c396ba245ee680ac8b469a46b19233a3546f0eb7f8e312',
+	'node-v137-win32-arm64': 'a6d712a918ece580882f83aee8c02d37c8841036eef68d208d71eb255d041e80',
+	'node-v137-win32-x64': '4ee5e653174d6ddd301605d351798cdae2613da06c4f37ecdce263021fcf1255',
+	'node-v141-darwin-arm64': 'e5a528210e820667d0c00d72db88c54f49b651e0b2861c349efba1d7d35b5cd5',
+	'node-v141-darwin-x64': '27e8e4f4ccbd476271f607866cdbf1555fb75d7b35bc997520eb93da7c40ce50',
+	'node-v141-linux-arm64': 'a5c37512a904e88bda3ffa1d28c8fbbfa79eb786e95c2e0a6309d55377fa0135',
+	'node-v141-linux-x64': '6c9e172375f9fb73b6adcc59057e257a36cbea77a8ea337f41561f73949339a1',
+	'node-v141-win32-arm64': 'd472ea8b36ecf195e47bbcb70185bf3c3798ff0dde6ba211f8e884eb4768f3f5',
+	'node-v141-win32-x64': 'c3a1e9556bca6a517cc0b524a51585e648f2982fdff78c6bcb0b267f778238aa',
+	'node-v147-darwin-arm64': '449dc1a8d6faf652fd449a19af125746f45c0f0abb1a5d17ec9fd44e8f5e7e69',
+	'node-v147-darwin-x64': 'a2ecaf018ac3648dc752efa4a97de098d4d24b2425731c897de94ca1e8ae0b0e',
+	'node-v147-linux-arm64': 'e277fc5bae5847d54351b12f907e9b6929c8f2c5c0660520ae4632b4806ee6f8',
+	'node-v147-linux-x64': 'a90711eae785b646d6799b31cf8dd79a5d750b1af72d310472c3b996c5cee92d',
+	'node-v147-win32-arm64': '65f177370ca2b4917501686b295f977585977a1276cc69898a50744dadb282d2',
+	'node-v147-win32-x64': 'ff6d04d52e1625d4fbf4b7a62e4f282366953be40016ded4815a651b2160bff8'
+};
 
 interface InstallCallbacks {
 	onLog(level: 'info' | 'warn' | 'error', message: string): void;
@@ -47,11 +85,35 @@ export class BetterSqlite3Installer {
 		return installedBinaryPath;
 	}
 
+	/**
+	 * The binding path handed to the API child. The managed binary is only offered
+	 * once it carries a pinned checksum stamp, so a legacy `better_sqlite3.installed.node`
+	 * left by a pre-pinning Ungate is never loaded.
+	 */
 	static resolveBindingPath(apiDir: string): string {
 		const installed = this.getInstalledBinaryPath(apiDir);
-		if (fs.existsSync(installed)) return installed;
+
+		if (this.isVerifiedManagedBinary(installed)) {
+			return installed;
+		}
 
 		return this.getBinaryPath(apiDir);
+	}
+
+	/**
+	 * True when the file was written by a verified install of one of the pinned
+	 * prebuilds. Absent or foreign stamps mean the bytes were never checked, so the
+	 * binary must be replaced rather than executed. ABI correctness is enforced
+	 * separately by the load probe in {@link canLoad}.
+	 */
+	static isVerifiedManagedBinary(installedBinaryPath: string): boolean {
+		if (!fs.existsSync(installedBinaryPath)) {
+			return false;
+		}
+
+		const digest = InstallStamp.read(installedBinaryPath);
+
+		return digest !== null && Object.values(PREBUILT_SHA256).includes(digest);
 	}
 
 	static async ensureInstalled(apiDir: string, runtime: string, callbacks: InstallCallbacks): Promise<void> {
@@ -93,20 +155,25 @@ export class BetterSqlite3Installer {
 	private static async install(apiDir: string, runtime: string, callbacks: InstallCallbacks): Promise<void> {
 		const binaryPath = this.getBinaryPath(apiDir);
 		const installedBinaryPath = this.getInstalledBinaryPath(apiDir);
-		const version = this.readBundledVersion(apiDir);
 		const info = NodeResolver.inspect(runtime);
-		const tarName = `better-sqlite3-v${version}-node-v${info.abi}-${info.platform}-${info.arch}.tar.gz`;
-		const url = `https://github.com/WiseLibs/better-sqlite3/releases/download/v${version}/${tarName}`;
+		const artifact = this.getPinnedArtifact(apiDir, info);
+		const tarName = artifact.url.slice(artifact.url.lastIndexOf('/') + 1);
 
 		callbacks.onLog('info', `[native] Using runtime: ${runtime}`);
 		callbacks.onLog('info', `[native] Downloading ${tarName}...`);
 
 		const stagingRoot = path.join(os.tmpdir(), `ungate-better-sqlite3-${process.pid}-${Date.now()}`);
+		const archivePath = path.join(stagingRoot, tarName);
+		const extractDir = path.join(stagingRoot, 'extracted');
 
 		try {
-			fs.mkdirSync(stagingRoot, { recursive: true });
-			await this.downloadAndExtract(url, stagingRoot);
-			const stagedBinary = path.join(stagingRoot, 'build', 'Release', 'better_sqlite3.node');
+			fs.mkdirSync(extractDir, { recursive: true });
+
+			// Verified before extraction: a tampered archive never reaches tar.
+			await VerifiedArtifact.download(artifact, archivePath);
+			await this.extractArchive(archivePath, extractDir);
+
+			const stagedBinary = path.join(extractDir, 'build', 'Release', 'better_sqlite3.node');
 
 			if (!fs.existsSync(stagedBinary)) {
 				throw new Error('[native] Downloaded archive did not contain better_sqlite3.node');
@@ -118,14 +185,10 @@ export class BetterSqlite3Installer {
 
 			fs.copyFileSync(stagedBinary, tempTarget);
 			fs.renameSync(tempTarget, installedBinaryPath);
-			callbacks.onLog('info', '[native] better-sqlite3 binary installed');
+			InstallStamp.write(installedBinaryPath, artifact);
+			callbacks.onLog('info', `[native] better-sqlite3 binary installed (sha256 ${artifact.sha256})`);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-
-			if (message.includes('HTTP 404')) {
-				callbacks.onLog('error', `[native] No prebuilt binary for ABI ${info.abi}`);
-				throw new Error(`[native] No prebuilt better-sqlite3 binary for Node ABI ${info.abi} (${info.platform}-${info.arch}).`);
-			}
 
 			callbacks.onLog('error', `[native] Prebuilt install failed: ${message}`);
 			throw err;
@@ -134,22 +197,40 @@ export class BetterSqlite3Installer {
 		}
 	}
 
-	private static async downloadAndExtract(url: string, extractDir: string): Promise<void> {
-		const response = await fetch(url, {
-			headers: { 'User-Agent': 'ungate-extension' }
-		});
+	/**
+	 * Resolves the single pinned prebuild for this runtime. Throws — never falls
+	 * back to an unpinned URL — when the bundled version drifts from the pinned
+	 * checksum set or the host ABI/platform/arch tuple has no entry.
+	 */
+	private static getPinnedArtifact(apiDir: string, info: RuntimeInfo): PinnedArtifact {
+		const version = this.readBundledVersion(apiDir);
 
-		if (!response.ok) {
-			throw new Error(`Download failed: HTTP ${response.status}`);
+		if (version !== PINNED_VERSION) {
+			throw new Error(
+				`[native] better-sqlite3 ${version} is bundled but only ${PINNED_VERSION} has pinned checksums. ` +
+					'Refresh PREBUILT_SHA256 from the upstream release assets before bumping the dependency.'
+			);
 		}
 
-		if (!response.body) {
-			throw new Error('Download failed: empty response body');
+		const tuple = `node-v${info.abi}-${info.platform}-${info.arch}`;
+		const sha256 = PREBUILT_SHA256[tuple];
+
+		if (!sha256) {
+			throw VerifiedArtifact.unsupportedError(
+				`[native] better-sqlite3 ${PINNED_VERSION}`,
+				tuple,
+				Object.keys(PREBUILT_SHA256),
+				'Point Ungate at a Node 22, 24, 25 or 26 runtime on glibc Linux, macOS or Windows.'
+			);
 		}
 
+		return { url: `${RELEASE_BASE}/better-sqlite3-v${PINNED_VERSION}-${tuple}.tar.gz`, sha256 };
+	}
+
+	private static async extractArchive(archivePath: string, extractDir: string): Promise<void> {
 		// tar types are loose in CJS; runtime extract is validated by canLoad().
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-		await pipeline(Readable.fromWeb(response.body), createGunzip(), tar.extract({ cwd: extractDir }));
+		await pipeline(fs.createReadStream(archivePath), createGunzip(), tar.extract({ cwd: extractDir }));
 	}
 
 	private static async canLoad(runtime: string, apiDir: string, callbacks: InstallCallbacks): Promise<boolean> {
@@ -157,7 +238,8 @@ export class BetterSqlite3Installer {
 		const installedBinaryPath = this.getInstalledBinaryPath(apiDir);
 		const defaultBinaryPath = this.getBinaryPath(apiDir);
 
-		if (fs.existsSync(installedBinaryPath)) {
+		// A managed binary without a pinned stamp predates checksum verification.
+		if (this.isVerifiedManagedBinary(installedBinaryPath)) {
 			pathsToTry.push(installedBinaryPath);
 		}
 

--- a/apps/extension/src/utils/cloudflared-installer.ts
+++ b/apps/extension/src/utils/cloudflared-installer.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from './verified-artifact';
+
+/**
+ * Exactly one pinned cloudflared release. The npm helper's `install()` resolves
+ * `latest/download/`, which silently changes bytes under us; Ungate must know
+ * up front which binary it is about to execute.
+ */
+export const CLOUDFLARED_VERSION = '2026.8.2';
+
+const RELEASE_BASE = `https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}`;
+
+interface CloudflaredEntry {
+	readonly file: string;
+	readonly sha256: string;
+	/** macOS assets are gzipped tarballs; every other platform ships a bare executable. */
+	readonly archived: boolean;
+}
+
+interface CloudflaredArtifact extends PinnedArtifact {
+	readonly archived: boolean;
+}
+
+/**
+ * SHA-256 of the upstream release assets for {@link CLOUDFLARED_VERSION}.
+ * Cloudflare ships macOS as a `.tgz` containing a single `cloudflared` entry and
+ * every other platform as a bare executable. There is no Windows arm64 build, so
+ * Windows on arm64 runs the amd64 executable under emulation — the same binary,
+ * and therefore the same pinned digest, as Windows x64.
+ */
+const CLOUDFLARED_ARTIFACTS: Record<string, CloudflaredEntry> = {
+	'darwin-arm64': {
+		file: 'cloudflared-darwin-arm64.tgz',
+		sha256: '9042c2c5d8b2de78e60f313d5fb31b6c5c1cebde787a3caf1f2c9588084ac442',
+		archived: true
+	},
+	'darwin-x64': {
+		file: 'cloudflared-darwin-amd64.tgz',
+		sha256: 'f1727723c586500e2092368ae21871b3df7ddfd2cb097f22d81bee4a9c458bb4',
+		archived: true
+	},
+	'linux-arm64': {
+		file: 'cloudflared-linux-arm64',
+		sha256: '7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790',
+		archived: false
+	},
+	'linux-x64': {
+		file: 'cloudflared-linux-amd64',
+		sha256: 'fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2',
+		archived: false
+	},
+	'win32-arm64': {
+		file: 'cloudflared-windows-amd64.exe',
+		sha256: 'c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5',
+		archived: false
+	},
+	'win32-x64': {
+		file: 'cloudflared-windows-amd64.exe',
+		sha256: 'c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5',
+		archived: false
+	}
+};
+
+// Ungate refuses to execute a cloudflared it has not verified, and `resolveUserBinaryPath`
+// ignores unstamped files, so telling the user to drop a binary into ~/.ungate/bin would be
+// a lie. State the real consequence instead.
+const UNSUPPORTED_REMEDY = `Ungate only runs a cloudflared build it can verify against a pinned SHA-256, and Cloudflare publishes no ${CLOUDFLARED_VERSION} build for this platform, so the built-in tunnel cannot start here. Run cloudflared yourself and give Cursor that tunnel URL.`;
+
+export class CloudflaredInstaller {
+	/**
+	 * True when `binaryPath` was installed from the currently pinned artifact.
+	 * Binaries left behind by the npm helper's `latest` install carry no stamp and
+	 * are therefore reported as not current, so they get replaced rather than run.
+	 */
+	static isPinnedInstall(binaryPath: string): boolean {
+		const artifact = this.getPinnedArtifact();
+
+		return artifact !== null && fs.existsSync(binaryPath) && InstallStamp.matches(binaryPath, artifact);
+	}
+
+	/**
+	 * Installs the pinned cloudflared release at `binaryPath` and returns it.
+	 * Downloads into a staging directory, verifies the digest, and only then
+	 * extracts, copies and marks the binary executable.
+	 */
+	static async install(binaryPath: string): Promise<string> {
+		const artifact = this.getPinnedArtifact();
+
+		if (!artifact) {
+			throw VerifiedArtifact.unsupportedError(
+				`cloudflared ${CLOUDFLARED_VERSION}`,
+				`${process.platform}-${process.arch}`,
+				Object.keys(CLOUDFLARED_ARTIFACTS),
+				UNSUPPORTED_REMEDY
+			);
+		}
+
+		const stagingRoot = path.join(os.tmpdir(), `ungate-cloudflared-${process.pid}-${Date.now()}`);
+		const downloadPath = path.join(stagingRoot, artifact.url.slice(artifact.url.lastIndexOf('/') + 1));
+
+		try {
+			fs.mkdirSync(stagingRoot, { recursive: true });
+
+			// Verified before extraction and before any chmod/copy of an executable.
+			await VerifiedArtifact.download(artifact, downloadPath);
+
+			const stagedBinary = artifact.archived ? this.extractTarball(downloadPath, stagingRoot) : downloadPath;
+
+			fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
+			fs.copyFileSync(stagedBinary, binaryPath);
+
+			if (process.platform !== 'win32') {
+				fs.chmodSync(binaryPath, 0o755);
+			}
+
+			InstallStamp.write(binaryPath, artifact);
+
+			return binaryPath;
+		} finally {
+			fs.rmSync(stagingRoot, { recursive: true, force: true });
+		}
+	}
+
+	private static getPinnedArtifact(): CloudflaredArtifact | null {
+		const entry = CLOUDFLARED_ARTIFACTS[`${process.platform}-${process.arch}`];
+
+		if (!entry) {
+			return null;
+		}
+
+		return { url: `${RELEASE_BASE}/${entry.file}`, sha256: entry.sha256, archived: entry.archived };
+	}
+
+	private static extractTarball(tarballPath: string, stagingRoot: string): string {
+		execFileSync('tar', ['-xzf', tarballPath, '-C', stagingRoot]);
+
+		const extracted = path.join(stagingRoot, 'cloudflared');
+
+		if (!fs.existsSync(extracted)) {
+			throw new Error(`cloudflared ${CLOUDFLARED_VERSION} archive did not contain a cloudflared executable`);
+		}
+
+		return extracted;
+	}
+}

--- a/apps/extension/src/utils/node-resolver.ts
+++ b/apps/extension/src/utils/node-resolver.ts
@@ -4,8 +4,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 const DEFAULT_NODE_COMMAND = 'node';
+const SUPPORTED_NODE_ABIS: Record<string, true> = { '127': true, '137': true, '141': true, '147': true };
+const SUPPORTED_NODE_VERSIONS = '22, 24, 25 or 26';
 
-interface RuntimeInfo {
+export interface RuntimeInfo {
 	abi: string;
 	platform: string;
 	arch: string;
@@ -14,18 +16,24 @@ interface RuntimeInfo {
 export class NodeResolver {
 	static resolve(overridePath?: string): string {
 		if (overridePath) {
-			return overridePath;
+			if (this.isSupported(overridePath)) {
+				return overridePath;
+			}
+
+			throw new Error(`[native] UNGATE_NODE_BIN must point to Node ${SUPPORTED_NODE_VERSIONS}: ${overridePath}`);
 		}
 
 		const candidates = this.getCandidates();
 
 		for (const candidate of candidates) {
-			if (this.isUsable(candidate)) {
+			if (this.isSupported(candidate)) {
 				return candidate;
 			}
 		}
 
-		return DEFAULT_NODE_COMMAND;
+		throw new Error(
+			`[native] No supported Node runtime found. Install Node ${SUPPORTED_NODE_VERSIONS}, or set UNGATE_NODE_BIN to one.`
+		);
 	}
 
 	static inspect(runtime: string): RuntimeInfo {
@@ -92,6 +100,7 @@ export class NodeResolver {
 		this.push(candidates, seen, path.join(homeDir, '.volta', 'bin', binaryName));
 		this.push(candidates, seen, path.join(homeDir, '.asdf', 'shims', binaryName));
 		this.pushFromDir(candidates, seen, path.join(homeDir, '.nvm', 'versions', 'node'), binaryName);
+		this.pushFromDir(candidates, seen, path.join(homeDir, '.asdf', 'installs', 'nodejs'), binaryName);
 
 		return candidates;
 	}
@@ -121,9 +130,11 @@ export class NodeResolver {
 		}
 	}
 
-	private static isUsable(candidate: string): boolean {
-		const result = cp.spawnSync(candidate, ['-v'], { encoding: 'utf8' });
-
-		return !result.error && result.status === 0;
+	private static isSupported(candidate: string): boolean {
+		try {
+			return SUPPORTED_NODE_ABIS[this.inspect(candidate).abi] === true;
+		} catch {
+			return false;
+		}
 	}
 }

--- a/apps/extension/src/utils/sqlite3-cli-resolver.ts
+++ b/apps/extension/src/utils/sqlite3-cli-resolver.ts
@@ -4,19 +4,46 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from './verified-artifact';
+
 const execFileAsync = promisify(execFile);
 
 const BIN_DIR = path.join(os.homedir(), '.ungate', 'bin');
 const SQLITE_TOOLS_VERSION = '3470200';
 const SQLITE_YEAR = '2024';
 
+/**
+ * SHA-256 of the exact sqlite.org release archives for {@link SQLITE_TOOLS_VERSION}.
+ * sqlite.org publishes only these three tool bundles for 3.47.2 — there is no
+ * macOS arm64 or Linux arm64 archive, so those hosts must supply their own CLI.
+ * Regenerate by hashing the URLs below after bumping the version and year.
+ */
+const SQLITE_TOOLS_ARTIFACTS: Record<string, { readonly file: string; readonly sha256: string }> = {
+	'darwin-x64': {
+		file: `sqlite-tools-osx-x64-${SQLITE_TOOLS_VERSION}.zip`,
+		sha256: '5f7d782ded38a56377eb34b38a8020e9c2c6f908109c904fe4e032f4a8ea54d0'
+	},
+	'linux-x64': {
+		file: `sqlite-tools-linux-x64-${SQLITE_TOOLS_VERSION}.zip`,
+		sha256: '9043648ac1186308c212c82d32327f0f1351fdf9dfb56a2a58bcf9bc947e3f90'
+	},
+	'win32-x64': {
+		file: `sqlite-tools-win-x64-${SQLITE_TOOLS_VERSION}.zip`,
+		sha256: '8c7fffbf4eec1f43e63153cca6deb018e4360d4d6b0d99bbdd2a541c53b7fa1c'
+	}
+};
+
+const UNSUPPORTED_REMEDY =
+	'Install the sqlite3 command-line tool yourself so it is discoverable on PATH (macOS: `brew install sqlite`, Debian/Ubuntu: `apt install sqlite3`).';
+
 type InstallLogger = (message: string) => void;
 
 export class Sqlite3CliResolver {
 	static async resolve(onLog?: InstallLogger): Promise<string | null> {
+		const artifact = this.getPinnedArtifact();
 		const installedPath = this.getInstalledPath();
 
-		if (fs.existsSync(installedPath)) {
+		if (artifact && fs.existsSync(installedPath) && InstallStamp.matches(installedPath, artifact)) {
 			return installedPath;
 		}
 
@@ -26,7 +53,20 @@ export class Sqlite3CliResolver {
 			return systemPath;
 		}
 
-		return this.downloadAndInstall(onLog);
+		if (!artifact) {
+			onLog?.(
+				VerifiedArtifact.unsupportedError(
+					`SQLite CLI ${SQLITE_TOOLS_VERSION}`,
+					`${process.platform}-${process.arch}`,
+					Object.keys(SQLITE_TOOLS_ARTIFACTS),
+					UNSUPPORTED_REMEDY
+				).message
+			);
+
+			return null;
+		}
+
+		return this.downloadAndInstall(artifact, onLog);
 	}
 
 	static getBinaryName(): string {
@@ -62,59 +102,36 @@ export class Sqlite3CliResolver {
 		return null;
 	}
 
-	private static getDownloadUrl(): string | null {
-		const { platform, arch } = process;
+	/**
+	 * Returns the pinned archive for the current host, or `null` when upstream
+	 * publishes nothing for this platform/arch. A `null` result must never be
+	 * turned into a download attempt.
+	 */
+	private static getPinnedArtifact(): PinnedArtifact | null {
+		const entry = SQLITE_TOOLS_ARTIFACTS[`${process.platform}-${process.arch}`];
 
-		if (platform === 'win32' && arch === 'x64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-win-x64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'darwin' && arch === 'arm64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-osx-aarch64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'darwin' && (arch === 'x64' || arch === 'x86_64')) {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-osx-x86-64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'linux' && arch === 'x64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-linux-x64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'linux' && arch === 'arm64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-linux-aarch64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		return null;
-	}
-
-	private static async downloadAndInstall(onLog?: InstallLogger): Promise<string | null> {
-		const url = this.getDownloadUrl();
-
-		if (!url) {
-			onLog?.(`SQLite CLI is not supported on ${process.platform}-${process.arch}`);
-
+		if (!entry) {
 			return null;
 		}
 
-		const zipPath = path.join(os.tmpdir(), `ungate-sqlite3-${process.pid}-${Date.now()}.zip`);
-		const extractDir = path.join(os.tmpdir(), `ungate-sqlite3-${process.pid}-${Date.now()}`);
+		return {
+			url: `https://www.sqlite.org/${SQLITE_YEAR}/${entry.file}`,
+			sha256: entry.sha256
+		};
+	}
+
+	private static async downloadAndInstall(artifact: PinnedArtifact, onLog?: InstallLogger): Promise<string | null> {
+		const stagingRoot = path.join(os.tmpdir(), `ungate-sqlite3-${process.pid}-${Date.now()}`);
+		const zipPath = path.join(stagingRoot, 'sqlite-tools.zip');
+		const extractDir = path.join(stagingRoot, 'extracted');
+		const installedPath = this.getInstalledPath();
 
 		try {
 			onLog?.('Downloading SQLite CLI...');
-			fs.mkdirSync(BIN_DIR, { recursive: true });
 			fs.mkdirSync(extractDir, { recursive: true });
 
-			const response = await fetch(url);
-
-			if (!response.ok) {
-				throw new Error(`HTTP ${response.status}`);
-			}
-
-			const arrayBuffer = await response.arrayBuffer();
-			const zipBytes = Buffer.from(arrayBuffer);
-
-			fs.writeFileSync(zipPath, zipBytes);
+			// Verified before extraction: a tampered archive never reaches unzip.
+			await VerifiedArtifact.download(artifact, zipPath);
 			await this.extractZip(zipPath, extractDir);
 
 			const extractedBinary = this.findExtractedBinary(extractDir);
@@ -123,22 +140,23 @@ export class Sqlite3CliResolver {
 				throw new Error('sqlite3 binary was not found in the downloaded archive');
 			}
 
-			fs.copyFileSync(extractedBinary, this.getInstalledPath());
+			fs.mkdirSync(BIN_DIR, { recursive: true });
+			fs.copyFileSync(extractedBinary, installedPath);
 
 			if (process.platform !== 'win32') {
-				fs.chmodSync(this.getInstalledPath(), 0o755);
+				fs.chmodSync(installedPath, 0o755);
 			}
 
+			InstallStamp.write(installedPath, artifact);
 			onLog?.('SQLite CLI installed');
 
-			return this.getInstalledPath();
+			return installedPath;
 		} catch (error) {
 			onLog?.(`Failed to install SQLite CLI: ${String(error)}`);
 
 			return null;
 		} finally {
-			fs.rmSync(zipPath, { force: true });
-			fs.rmSync(extractDir, { recursive: true, force: true });
+			fs.rmSync(stagingRoot, { recursive: true, force: true });
 		}
 	}
 

--- a/apps/extension/src/utils/verified-artifact.ts
+++ b/apps/extension/src/utils/verified-artifact.ts
@@ -1,0 +1,114 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import * as fs from 'node:fs';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const USER_AGENT = 'ungate-extension';
+const SHA256_HEX_LENGTH = 64;
+const STAMP_SUFFIX = '.sha256';
+
+export interface PinnedArtifact {
+	/** Absolute upstream release URL. Must point at an immutable, versioned artifact. */
+	readonly url: string;
+	/** Lowercase hex SHA-256 of the exact upstream bytes. */
+	readonly sha256: string;
+}
+
+/**
+ * Downloads pinned upstream artifacts and refuses to hand anything back until the
+ * bytes hash to the expected SHA-256. Nothing is copied, chmod-ed or executed by
+ * this module: callers only ever see a staging path that already passed verification.
+ */
+export class VerifiedArtifact {
+	/**
+	 * Streams `artifact` to `destPath` while hashing, then verifies the digest.
+	 * On any failure the partial file is removed and the error is rethrown, so a
+	 * rejected download can never leave a usable file behind.
+	 */
+	static async download(artifact: PinnedArtifact, destPath: string): Promise<void> {
+		const expected = this.parseDigest(artifact.sha256);
+		const response = await fetch(artifact.url, {
+			headers: { 'User-Agent': USER_AGENT },
+			redirect: 'follow'
+		});
+
+		if (!response.ok) {
+			throw new Error(`Download failed for ${artifact.url}: HTTP ${response.status}`);
+		}
+
+		if (!response.body) {
+			throw new Error(`Download failed for ${artifact.url}: empty response body`);
+		}
+
+		const hash = createHash('sha256');
+
+		try {
+			await pipeline(
+				Readable.fromWeb(response.body),
+				async function* (source: AsyncIterable<Uint8Array>) {
+					for await (const chunk of source) {
+						hash.update(chunk);
+						yield chunk;
+					}
+				},
+				fs.createWriteStream(destPath)
+			);
+
+			const actual = hash.digest();
+
+			if (!timingSafeEqual(actual, expected)) {
+				throw new Error(
+					`Checksum mismatch for ${artifact.url}: expected sha256 ${artifact.sha256}, got ${actual.toString('hex')}. ` +
+						'The artifact was rejected and discarded.'
+				);
+			}
+		} catch (error) {
+			fs.rmSync(destPath, { force: true });
+			throw error;
+		}
+	}
+
+	/**
+	 * Fail-closed error for a host tuple that has no pinned artifact. Unknown
+	 * tuples must never trigger a download, so the message has to tell the user
+	 * what is supported and how to work around the gap.
+	 */
+	static unsupportedError(subject: string, tuple: string, supported: readonly string[], remedy: string): Error {
+		return new Error(
+			`${subject} has no pinned, checksum-verified artifact for ${tuple}. ` +
+				`Supported: ${[...supported].sort().join(', ')}. ${remedy}`
+		);
+	}
+
+	private static parseDigest(sha256: string): Buffer {
+		if (sha256.length !== SHA256_HEX_LENGTH || !/^[0-9a-f]+$/.test(sha256)) {
+			throw new Error(`Malformed pinned SHA-256 digest: ${sha256}`);
+		}
+
+		return Buffer.from(sha256, 'hex');
+	}
+}
+
+/**
+ * Records which pinned artifact produced a managed binary in `~/.ungate/bin`.
+ * Installs made before artifact pinning existed carry no stamp, so they are
+ * treated as unverified and replaced instead of reused.
+ */
+export class InstallStamp {
+	/** The recorded digest, or `null` when the binary carries no stamp at all. */
+	static read(binaryPath: string): string | null {
+		try {
+			return fs.readFileSync(`${binaryPath}${STAMP_SUFFIX}`, 'utf8').trim();
+		} catch {
+			return null;
+		}
+	}
+
+	static matches(binaryPath: string, artifact: PinnedArtifact): boolean {
+		return this.read(binaryPath) === artifact.sha256;
+	}
+
+	static write(binaryPath: string, artifact: PinnedArtifact): void {
+		fs.writeFileSync(`${binaryPath}${STAMP_SUFFIX}`, artifact.sha256, 'utf8');
+	}
+}

--- a/apps/extension/tests/unit/api-server-health-check.test.ts
+++ b/apps/extension/tests/unit/api-server-health-check.test.ts
@@ -6,6 +6,12 @@ import { TestHelper } from './helpers/test-helper';
 
 import type { RuntimeState } from '@ungate/shared/frontend';
 
+interface SpawnedChildMock {
+	emit(event: string, payload?: unknown): void;
+	connected: boolean;
+	send: (message: unknown) => boolean;
+}
+
 const {
 	runtimeReadMock,
 	runtimeHasLiveClientsMock,
@@ -33,6 +39,13 @@ const {
 
 				return child;
 			},
+			emit(event: string, payload?: unknown) {
+				for (const handler of handlers.get(event) ?? []) {
+					handler(payload);
+				}
+			},
+			connected: true,
+			send: vi.fn(() => true),
 			unref: vi.fn(),
 			kill: vi.fn()
 		};
@@ -77,7 +90,9 @@ vi.mock('../../src/utils/better-sqlite3-installer', () => {
 
 vi.mock('@ungate/shared', () => {
 	return {
-		sleep: sleepMock
+		sleep: sleepMock,
+		ADMIN_KEY_ENV: 'UNGATE_ADMIN_KEY',
+		PROVIDER_SECRET_CHANNEL: 'ungate.provider-secret'
 	};
 });
 
@@ -124,6 +139,9 @@ interface ApiServerInternals {
 	shouldRespawn(): boolean;
 }
 
+/** Stand-in for the base64url 256-bit key SecuritySecrets mints. */
+const TEST_ADMIN_KEY = 'a'.repeat(43);
+
 function createRuntimeState(): RuntimeState {
 	const runtimeState = TestHelper.createRuntimeState([], 4783);
 
@@ -144,14 +162,20 @@ function createServer(options?: { isLeaderWindow?: boolean; isExtensionHostActiv
 	onStatusChange: ReturnType<typeof vi.fn>;
 	onPortDetected: ReturnType<typeof vi.fn>;
 	onLog: ReturnType<typeof vi.fn>;
+	handleApiChildMessage: ReturnType<typeof vi.fn>;
 } {
 	const onStatusChange = vi.fn();
 	const onPortDetected = vi.fn();
 	const onLog = vi.fn();
+	const handleApiChildMessage = vi.fn().mockResolvedValue(null);
 	const server = new ApiServer(
 		{
 			extensionMode: 1,
 			extensionPath: '/tmp/ungate-extension'
+		} as never,
+		{
+			adminApiKey: TEST_ADMIN_KEY,
+			handleApiChildMessage
 		} as never,
 		{
 			onLog,
@@ -169,7 +193,7 @@ function createServer(options?: { isLeaderWindow?: boolean; isExtensionHostActiv
 		}
 	);
 
-	return { server, onStatusChange, onPortDetected, onLog };
+	return { server, onStatusChange, onPortDetected, onLog, handleApiChildMessage };
 }
 
 describe('ApiServer.runHealthCheckCycle', () => {
@@ -200,10 +224,10 @@ describe('ApiServer.runHealthCheckCycle', () => {
 			return {
 				error: undefined,
 				status: 0,
-				stdout: 'v24.0.0\n',
+				stdout: '{"abi":"137","platform":"darwin","arch":"arm64"}',
 				stderr: '',
 				pid: 1,
-				output: [null, 'v24.0.0\n', ''],
+				output: [null, '{"abi":"137","platform":"darwin","arch":"arm64"}', ''],
 				signal: null
 			};
 		});
@@ -297,11 +321,81 @@ describe('ApiServer.runHealthCheckCycle', () => {
 			expect.any(String),
 			expect.any(Array),
 			expect.objectContaining({
+				stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 				env: expect.objectContaining({
-					UNGATE_BETTER_SQLITE3_NATIVE_BINDING: expect.stringContaining('better_sqlite3.installed.node')
+					UNGATE_BETTER_SQLITE3_NATIVE_BINDING: expect.stringContaining('better_sqlite3.installed.node'),
+					UNGATE_ADMIN_KEY: TEST_ADMIN_KEY
 				})
 			})
 		);
+	});
+
+	it('answers credential requests from the api child and never logs the payload', async () => {
+		const runtimeState = createRuntimeState([], null);
+		const { server, onLog, handleApiChildMessage } = createServer();
+		const internals = getInternals(server);
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeMutateMock.mockImplementation((mutator) => {
+			const nextState = mutator(structuredClone(runtimeState));
+
+			return Promise.resolve(nextState);
+		});
+		vi.spyOn(internals, 'startHealthCheck').mockImplementation(() => {});
+
+		await server.start();
+
+		const child = spawnMock.mock.results.at(-1)!.value as SpawnedChildMock;
+		const response = {
+			channel: 'ungate.provider-secret',
+			id: 'req-1',
+			ok: true,
+			secret: { accessToken: 'plaintext-access', refreshToken: null }
+		};
+		handleApiChildMessage.mockResolvedValueOnce(response);
+
+		child.emit('message', { channel: 'ungate.provider-secret', id: 'req-1', action: 'get', provider: 'claude' });
+		await flushPromises();
+
+		expect(handleApiChildMessage).toHaveBeenCalledWith({
+			channel: 'ungate.provider-secret',
+			id: 'req-1',
+			action: 'get',
+			provider: 'claude'
+		});
+		expect(child.send).toHaveBeenCalledWith(response);
+
+		const loggedLines = onLog.mock.calls.map((call) => String(call[1])).join('\n');
+		expect(loggedLines).not.toContain('plaintext-access');
+	});
+
+	it('drops credential responses when the api channel is already closed', async () => {
+		const runtimeState = createRuntimeState([], null);
+		const { server, onLog, handleApiChildMessage } = createServer();
+		const internals = getInternals(server);
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeMutateMock.mockImplementation((mutator) => {
+			const nextState = mutator(structuredClone(runtimeState));
+
+			return Promise.resolve(nextState);
+		});
+		vi.spyOn(internals, 'startHealthCheck').mockImplementation(() => {});
+
+		await server.start();
+
+		const child = spawnMock.mock.results.at(-1)!.value as SpawnedChildMock;
+		child.connected = false;
+		handleApiChildMessage.mockResolvedValueOnce({
+			channel: 'ungate.provider-secret',
+			id: 'req-2',
+			ok: true,
+			secret: null
+		});
+
+		child.emit('message', { channel: 'ungate.provider-secret', id: 'req-2', action: 'delete', provider: 'minimax' });
+		await flushPromises();
+
+		expect(child.send).not.toHaveBeenCalled();
+		expect(onLog).toHaveBeenCalledWith('error', expect.stringContaining('the api channel closed'));
 	});
 
 	it('retries startup when shared starting state is stale', async () => {

--- a/apps/extension/tests/unit/better-sqlite3-installer.test.ts
+++ b/apps/extension/tests/unit/better-sqlite3-installer.test.ts
@@ -1,5 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const PINNED_VERSION = '12.11.1';
+const WIN32_X64_ABI137_SHA256 = '4ee5e653174d6ddd301605d351798cdae2613da06c4f37ecdce263021fcf1255';
+
+/** Staging directory prefix used by BetterSqlite3Installer.install for the extracted archive. */
+const STAGING_PREFIX = 'ungate-better-sqlite3-';
+
+/** Serves the pinned checksum stamp for `<binary>.sha256` and the bundled package.json otherwise. */
+function readStampedFile(target: unknown): string {
+	if (String(target).endsWith('.sha256')) {
+		return WIN32_X64_ABI137_SHA256;
+	}
+
+	return JSON.stringify({ version: PINNED_VERSION });
+}
+
 const execFileMock = vi.fn();
 const existsSyncMock = vi.fn();
 const fetchMock = vi.fn();
@@ -7,6 +22,11 @@ const copyFileSyncMock = vi.fn();
 const renameSyncMock = vi.fn();
 const rmSyncMock = vi.fn();
 const mkdirSyncMock = vi.fn();
+const writeFileSyncMock = vi.fn();
+const readFileSyncMock = vi.fn(readStampedFile);
+const inspectMock = vi.fn(() => {
+	return { abi: '137', platform: 'win32', arch: 'x64' };
+});
 
 vi.mock('node:child_process', () => {
 	return {
@@ -17,12 +37,13 @@ vi.mock('node:child_process', () => {
 vi.mock('node:fs', () => {
 	return {
 		existsSync: (...args: unknown[]) => existsSyncMock(...args),
-		readFileSync: vi.fn(() => JSON.stringify({ version: '11.10.0' })),
+		readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
 		realpathSync: vi.fn((target: string) => target),
 		mkdirSync: (...args: unknown[]) => mkdirSyncMock(...args),
 		copyFileSync: (...args: unknown[]) => copyFileSyncMock(...args),
 		rmSync: (...args: unknown[]) => rmSyncMock(...args),
-		renameSync: (...args: unknown[]) => renameSyncMock(...args)
+		renameSync: (...args: unknown[]) => renameSyncMock(...args),
+		writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args)
 	};
 });
 
@@ -37,9 +58,7 @@ vi.mock('../../src/utils/cross-process-lock', () => {
 vi.mock('../../src/utils/node-resolver', () => {
 	return {
 		NodeResolver: {
-			inspect: vi.fn(() => {
-				return { abi: '137', platform: 'win32', arch: 'x64' };
-			})
+			inspect: (...args: unknown[]) => inspectMock(...args)
 		}
 	};
 });
@@ -65,6 +84,7 @@ vi.mock('../../src/runtime-state', () => {
 });
 
 import { BetterSqlite3Installer } from '../../src/utils/better-sqlite3-installer';
+import { VerifiedArtifact, type PinnedArtifact } from '../../src/utils/verified-artifact';
 
 type ExecFileCallback = (error: Error | null, result: { stdout: string; stderr: string }) => void;
 
@@ -72,6 +92,19 @@ function mockExecFileSuccess(): void {
 	execFileMock.mockImplementation((_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
 		callback(null, { stdout: '', stderr: '' });
 	});
+}
+
+function mockExecFileFailure(): void {
+	execFileMock.mockImplementation((_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+		const error = new Error('load failed') as Error & { stderr?: string };
+		error.stderr = '';
+		callback(error, { stdout: '', stderr: '' });
+	});
+}
+
+/** Archive extraction is a private static; spying on it keeps the test off the filesystem. */
+function privateApi(): { extractArchive(archivePath: string, extractDir: string): Promise<void> } {
+	return BetterSqlite3Installer as unknown as { extractArchive(archivePath: string, extractDir: string): Promise<void> };
 }
 
 describe('BetterSqlite3Installer', () => {
@@ -87,13 +120,19 @@ describe('BetterSqlite3Installer', () => {
 		renameSyncMock.mockReset();
 		rmSyncMock.mockReset();
 		mkdirSyncMock.mockReset();
+		writeFileSyncMock.mockReset();
+		readFileSyncMock.mockReset();
+		readFileSyncMock.mockImplementation(readStampedFile);
+		inspectMock.mockReset();
+		inspectMock.mockReturnValue({ abi: '137', platform: 'win32', arch: 'x64' });
 	});
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
 	});
 
-	it('skips download when the installed native binary already loads', async () => {
+	it('skips download when a pin-stamped installed native binary already loads', async () => {
 		mockExecFileSuccess();
 		existsSyncMock.mockImplementation((target) => String(target).endsWith('better_sqlite3.installed.node'));
 
@@ -107,6 +146,81 @@ describe('BetterSqlite3Installer', () => {
 
 		expect(script).toContain('nativeBinding');
 		expect(script).toContain('better_sqlite3.installed.node');
+	});
+
+	it('ignores an unstamped legacy managed binary and probes the bundled binding instead', async () => {
+		mockExecFileSuccess();
+		existsSyncMock.mockReturnValue(true);
+		readFileSyncMock.mockImplementation((target: unknown) => {
+			if (String(target).endsWith('.sha256')) {
+				throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			}
+
+			return JSON.stringify({ version: PINNED_VERSION });
+		});
+
+		await BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() });
+
+		const probedScripts = execFileMock.mock.calls.map(([, args]) => (Array.isArray(args) ? String(args[1]) : ''));
+
+		expect(probedScripts).toHaveLength(1);
+		expect(probedScripts[0]).not.toContain('better_sqlite3.installed.node');
+		expect(probedScripts[0]).toContain('build/Release/better_sqlite3.node');
+	});
+
+	it('replaces a managed binary whose stamp is not a pinned digest, then stamps the verified one', async () => {
+		let stamp = 'deadbeef'.repeat(8);
+
+		mockExecFileSuccess();
+		existsSyncMock.mockImplementation((target) => {
+			const value = String(target);
+
+			// The managed binary exists (with a foreign stamp) and so does the extracted
+			// staging binary; the bundled default binding does not, so canLoad has nothing
+			// trustworthy to probe and install has to run.
+			return value.endsWith('better_sqlite3.installed.node') || value.includes(STAGING_PREFIX);
+		});
+		readFileSyncMock.mockImplementation((target: unknown) =>
+			String(target).endsWith('.sha256') ? stamp : JSON.stringify({ version: PINNED_VERSION })
+		);
+		writeFileSyncMock.mockImplementation((target: unknown, data: unknown) => {
+			if (String(target).endsWith('.sha256')) {
+				stamp = String(data);
+			}
+		});
+
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download').mockResolvedValue(undefined);
+
+		vi.spyOn(privateApi(), 'extractArchive').mockResolvedValue(undefined);
+
+		await BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() });
+
+		expect(downloadSpy).toHaveBeenCalledTimes(1);
+		expect(writeFileSyncMock).toHaveBeenCalledWith(
+			expect.stringContaining('better_sqlite3.installed.node.sha256'),
+			WIN32_X64_ABI137_SHA256,
+			'utf8'
+		);
+		expect(stamp).toBe(WIN32_X64_ABI137_SHA256);
+	});
+
+	it('hands the API child the managed binding only once it carries a pinned stamp', () => {
+		existsSyncMock.mockReturnValue(true);
+
+		expect(BetterSqlite3Installer.resolveBindingPath('/tmp/ungate-api')).toContain('better_sqlite3.installed.node');
+
+		readFileSyncMock.mockImplementation((target: unknown) => {
+			if (String(target).endsWith('.sha256')) {
+				throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			}
+
+			return JSON.stringify({ version: PINNED_VERSION });
+		});
+
+		const fallback = BetterSqlite3Installer.resolveBindingPath('/tmp/ungate-api');
+
+		expect(fallback).toContain('better_sqlite3.node');
+		expect(fallback).not.toContain('better_sqlite3.installed.node');
 	});
 
 	it('does not call https when a concurrent install already made the binary loadable', async () => {
@@ -141,7 +255,7 @@ describe('BetterSqlite3Installer', () => {
 		expect(execFileMock).not.toHaveBeenCalled();
 	});
 
-	it('stores the downloaded binary in the installed native path', async () => {
+	it('installs the pinned prebuild matching the host ABI tuple', async () => {
 		execFileMock
 			.mockImplementationOnce((_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
 				const error = new Error('load failed') as Error & { stderr?: string };
@@ -167,17 +281,63 @@ describe('BetterSqlite3Installer', () => {
 
 			return false;
 		});
-		const installer = BetterSqlite3Installer as unknown as {
-			downloadAndExtract(url: string, extractDir: string): Promise<void>;
-		};
 
-		installer.downloadAndExtract = vi.fn().mockResolvedValue(undefined);
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download').mockResolvedValue(undefined);
+
+		vi.spyOn(privateApi(), 'extractArchive').mockResolvedValue(undefined);
 
 		await BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() });
 
+		const artifact = downloadSpy.mock.calls[0]?.[0] as PinnedArtifact | undefined;
+
+		expect(artifact?.url).toBe(
+			`https://github.com/WiseLibs/better-sqlite3/releases/download/v${PINNED_VERSION}/better-sqlite3-v${PINNED_VERSION}-node-v137-win32-x64.tar.gz`
+		);
+		expect(artifact?.sha256).toBe(WIN32_X64_ABI137_SHA256);
 		expect(renameSyncMock).toHaveBeenCalledWith(
 			expect.stringContaining('better_sqlite3.installed.node'),
 			expect.stringContaining('better_sqlite3.installed.node')
 		);
+	});
+
+	it('fails closed for an ABI tuple that has no pinned checksum', async () => {
+		mockExecFileFailure();
+		existsSyncMock.mockReturnValue(true);
+		inspectMock.mockReturnValue({ abi: '115', platform: 'linux', arch: 'x64' });
+
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download');
+
+		await expect(BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() })).rejects.toThrow(
+			/no pinned, checksum-verified artifact for node-v115-linux-x64/
+		);
+
+		expect(downloadSpy).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('fails closed for a musl-only tuple that shares process.platform with glibc', async () => {
+		mockExecFileFailure();
+		existsSyncMock.mockReturnValue(true);
+		inspectMock.mockReturnValue({ abi: '137', platform: 'linuxmusl', arch: 'x64' });
+
+		await expect(BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() })).rejects.toThrow(
+			/no pinned, checksum-verified artifact for node-v137-linuxmusl-x64/
+		);
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('refuses to install when the bundled version drifts from the pinned checksums', async () => {
+		mockExecFileFailure();
+		existsSyncMock.mockReturnValue(true);
+		readFileSyncMock.mockReturnValue(JSON.stringify({ version: '12.12.0' }));
+
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download');
+
+		await expect(BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() })).rejects.toThrow(
+			`[native] better-sqlite3 12.12.0 is bundled but only ${PINNED_VERSION} has pinned checksums`
+		);
+
+		expect(downloadSpy).not.toHaveBeenCalled();
 	});
 });

--- a/apps/extension/tests/unit/cloudflared-installer.test.ts
+++ b/apps/extension/tests/unit/cloudflared-installer.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { CLOUDFLARED_VERSION, CloudflaredInstaller } from '../../src/utils/cloudflared-installer';
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from '../../src/utils/verified-artifact';
+
+const LINUX_X64_SHA256 = 'fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2';
+
+function forceHost(platform: string, arch: string): void {
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+	Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+describe('CloudflaredInstaller', () => {
+	const originalPlatform = process.platform;
+	const originalArch = process.arch;
+	let binDir: string;
+	let fetchMock: Mock;
+
+	beforeEach(() => {
+		binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ungate-cloudflared-'));
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		forceHost(originalPlatform, originalArch);
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		fs.rmSync(binDir, { recursive: true, force: true });
+	});
+
+	it('installs, marks executable and stamps the pinned artifact', async () => {
+		forceHost('linux', 'x64');
+
+		const downloadSpy = vi
+			.spyOn(VerifiedArtifact, 'download')
+			.mockImplementation((_artifact: PinnedArtifact, destPath: string) => {
+				fs.mkdirSync(path.dirname(destPath), { recursive: true });
+				fs.writeFileSync(destPath, 'verified-cloudflared');
+
+				return Promise.resolve();
+			});
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+		const installed = await CloudflaredInstaller.install(binaryPath);
+
+		expect(installed).toBe(binaryPath);
+		expect(fs.readFileSync(binaryPath, 'utf8')).toBe('verified-cloudflared');
+		expect(fs.statSync(binaryPath).mode & 0o777).toBe(0o755);
+		expect(fs.readFileSync(`${binaryPath}.sha256`, 'utf8')).toBe(LINUX_X64_SHA256);
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(true);
+
+		const artifact = downloadSpy.mock.calls[0]?.[0];
+
+		expect(artifact?.url).toBe(
+			`https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64`
+		);
+		expect(artifact?.sha256).toBe(LINUX_X64_SHA256);
+	});
+
+	it('rejects a tampered download without leaving an executable behind', async () => {
+		forceHost('linux', 'x64');
+		fetchMock.mockResolvedValue(new Response('tampered-cloudflared'));
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+
+		await expect(CloudflaredInstaller.install(binaryPath)).rejects.toThrow(/Checksum mismatch/);
+
+		expect(fs.existsSync(binaryPath)).toBe(false);
+		expect(fs.existsSync(`${binaryPath}.sha256`)).toBe(false);
+	});
+
+	it('fails closed on an unsupported platform without downloading anything', async () => {
+		forceHost('sunos', 'x64');
+
+		let message = '';
+
+		try {
+			await CloudflaredInstaller.install(path.join(binDir, 'cloudflared'));
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toContain('no pinned, checksum-verified artifact for sunos-x64');
+		expect(message).toContain('the built-in tunnel cannot start here');
+		// The remedy must not promise a manual drop-in: resolveUserBinaryPath rejects unstamped files.
+		expect(message).not.toContain('place it in ~/.ungate/bin');
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('ignores a binary left behind by an unverified latest install', () => {
+		forceHost('linux', 'x64');
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+
+		fs.writeFileSync(binaryPath, 'binary from an unpinned latest download');
+
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(false);
+
+		InstallStamp.write(binaryPath, { url: 'https://example.invalid/cloudflared', sha256: LINUX_X64_SHA256 });
+
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(true);
+	});
+
+	it('reports no pinned install on platforms with no pinned artifact', () => {
+		forceHost('sunos', 'x64');
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+
+		fs.writeFileSync(binaryPath, 'anything');
+
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(false);
+	});
+});

--- a/apps/extension/tests/unit/dashboard-admin-key.test.ts
+++ b/apps/extension/tests/unit/dashboard-admin-key.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestHelper } from './helpers/test-helper';
+
+const createWebviewPanelMock = vi.fn();
+const fileUriMock = vi.fn((value: string) => {
+	return { fsPath: value, toString: () => value };
+});
+
+let indexHtml = '<html><head></head><body></body></html>';
+
+vi.mock('node:fs', () => {
+	return {
+		readFileSync: vi.fn(() => indexHtml)
+	};
+});
+
+vi.mock('../../src/runtime-state/shared-log-store', () => {
+	return {
+		SharedLogStore: {
+			append() {},
+			readAll() {
+				return [];
+			},
+			readSince() {
+				return { entries: [], nextOffset: 0 };
+			},
+			getFileSize() {
+				return 0;
+			},
+			clear() {}
+		}
+	};
+});
+
+vi.mock('vscode', () => {
+	class Disposable {
+		dispose(): void {}
+	}
+
+	return {
+		window: {
+			createWebviewPanel: createWebviewPanelMock
+		},
+		ViewColumn: {
+			One: 1
+		},
+		Uri: {
+			file: fileUriMock
+		},
+		ExtensionMode: {
+			Development: 1,
+			Production: 2
+		},
+		MarkdownString: TestHelper.createMarkdownStringClass(),
+		Disposable
+	};
+});
+
+let Dashboard: typeof import('../../src/dashboard').Dashboard;
+let toInlineScriptJson: typeof import('../../src/dashboard').toInlineScriptJson;
+
+function createPanel() {
+	return {
+		webview: {
+			html: '',
+			postMessage: vi.fn(),
+			asWebviewUri: vi.fn((value) => value),
+			onDidReceiveMessage: vi.fn()
+		},
+		onDidChangeViewState: vi.fn(),
+		onDidDispose: vi.fn(),
+		reveal: vi.fn(),
+		visible: true,
+		iconPath: null
+	};
+}
+
+function showDashboard(adminApiKey: string) {
+	const panel = createPanel();
+	createWebviewPanelMock.mockReturnValue(panel);
+
+	const dashboard = new Dashboard(
+		{
+			extensionMode: 1,
+			extensionPath: '/tmp/ungate-extension'
+		} as never,
+		adminApiKey,
+		() => {}
+	);
+	dashboard.show();
+
+	return { dashboard, panel };
+}
+
+describe('Dashboard admin key injection', () => {
+	beforeAll(async () => {
+		const module = await import('../../src/dashboard');
+		Dashboard = module.Dashboard;
+		toInlineScriptJson = module.toInlineScriptJson;
+	});
+
+	beforeEach(() => {
+		createWebviewPanelMock.mockReset();
+		fileUriMock.mockClear();
+		indexHtml = '<html><head></head><body></body></html>';
+	});
+
+	it('injects the admin key and port into the webview bootstrap', () => {
+		const { panel } = showDashboard('f'.repeat(64));
+
+		expect(panel.webview.html).toContain(`window.__ADMIN_KEY__ = "${'f'.repeat(64)}"`);
+		expect(panel.webview.html).toContain('window.__PORT__ = null');
+	});
+
+	it('keeps the injected key inside the script element when it contains HTML', () => {
+		// A key can only be hex or base64url in practice, but the injection must stay inert for any
+		// value: an unescaped `</script>` would end the element and turn the rest into markup.
+		const hostileKey = '</script><img src=x onerror=alert(1)>';
+		const { panel } = showDashboard(hostileKey);
+
+		expect(panel.webview.html).not.toContain('</script><img');
+		expect(panel.webview.html).not.toContain('<img src=x');
+		expect(panel.webview.html).toContain('\\u003c/script\\u003e');
+	});
+
+	it('escapes every character that could break out of an inline script', () => {
+		expect(toInlineScriptJson('</script>')).toBe('"\\u003c/script\\u003e"');
+		expect(toInlineScriptJson('a&b')).toBe('"a\\u0026b"');
+		expect(toInlineScriptJson('line\u2028break')).toBe('"line\\u2028break"');
+		expect(toInlineScriptJson('para\u2029break')).toBe('"para\\u2029break"');
+		expect(toInlineScriptJson(null)).toBe('null');
+		expect(toInlineScriptJson(4783)).toBe('4783');
+	});
+
+	it('does not let a key containing $ patterns corrupt the surrounding html', () => {
+		// A plain replacement string would expand `$&` into the matched `</head>` and `` $` `` into
+		// everything before it. The `&` is separately escaped as \u0026; the `$` runs must survive
+		// verbatim, which is what proves no replacement-pattern expansion happened.
+		const { panel } = showDashboard('$&$`$0');
+
+		expect(panel.webview.html).toContain('window.__ADMIN_KEY__ = "$\\u0026$`$0"');
+		expect(panel.webview.html).toContain('</head>');
+		expect(panel.webview.html).toContain('<body></body>');
+	});
+
+	it('re-injects the current port on rebuild without dropping the admin key', () => {
+		const { dashboard, panel } = showDashboard('f'.repeat(64));
+
+		dashboard.setPort(4783);
+
+		expect(panel.webview.html).toContain('window.__PORT__ = 4783');
+		expect(panel.webview.html).toContain(`window.__ADMIN_KEY__ = "${'f'.repeat(64)}"`);
+	});
+});

--- a/apps/extension/tests/unit/dashboard-set-port.test.ts
+++ b/apps/extension/tests/unit/dashboard-set-port.test.ts
@@ -104,6 +104,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		dashboard.show();
@@ -128,6 +129,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		dashboard.show();
@@ -147,6 +149,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		const dashboardB = new Dashboard(
@@ -154,6 +157,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		dashboardA.pushLog('api', { timestamp: 1, level: 'info', message: 'started elsewhere' });

--- a/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
+++ b/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
@@ -192,9 +192,24 @@ function createRuntimeState(windowIds: string[], apiPort: number | null = 4783):
 }
 
 function createContext() {
+	const stored: Record<string, string> = {};
+
 	return {
 		subscriptions: [],
-		extensionPath: '/tmp/ungate-extension'
+		extensionPath: '/tmp/ungate-extension',
+		secrets: {
+			get: (key: string) => Promise.resolve(stored[key]),
+			store: (key: string, value: string) => {
+				stored[key] = value;
+
+				return Promise.resolve();
+			},
+			delete: (key: string) => {
+				delete stored[key];
+
+				return Promise.resolve();
+			}
+		}
 	};
 }
 
@@ -329,7 +344,7 @@ describe('ExtensionController', () => {
 			startRuntimeSync: vi.fn()
 		});
 
-		controller.activate();
+		await controller.activate();
 
 		await vi.waitFor(() => {
 			expect(apiServerStartMock).toHaveBeenCalledTimes(1);
@@ -376,7 +391,7 @@ describe('ExtensionController', () => {
 			startRuntimeSync: vi.fn()
 		});
 
-		controller.activate();
+		await controller.activate();
 
 		await vi.waitFor(() => {
 			expect(apiServerStartMock).toHaveBeenCalledTimes(1);

--- a/apps/extension/tests/unit/node-resolver.test.ts
+++ b/apps/extension/tests/unit/node-resolver.test.ts
@@ -1,9 +1,11 @@
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const spawnSyncMock = vi.fn();
 const existsSyncMock = vi.fn();
+const readdirSyncMock = vi.fn();
 
 vi.mock('node:child_process', () => {
 	return {
@@ -15,7 +17,7 @@ vi.mock('node:child_process', () => {
 vi.mock('node:fs', () => {
 	return {
 		existsSync: (...args: unknown[]) => existsSyncMock(...args),
-		readdirSync: vi.fn(() => [])
+		readdirSync: (...args: unknown[]) => readdirSyncMock(...args)
 	};
 });
 
@@ -27,13 +29,24 @@ describe('NodeResolver', () => {
 	beforeEach(() => {
 		spawnSyncMock.mockReset();
 		existsSyncMock.mockReset();
+		readdirSyncMock.mockReset();
 	});
 
 	afterEach(() => {
 		Object.defineProperty(process, 'platform', { value: originalPlatform });
 	});
 
-	it('returns override path when UNGATE_NODE_BIN is provided via resolve argument', () => {
+	it('returns a supported override path when UNGATE_NODE_BIN is provided via resolve argument', () => {
+		spawnSyncMock.mockReturnValue({
+			error: undefined,
+			status: 0,
+			stdout: '{"abi":"137","platform":"win32","arch":"x64"}',
+			stderr: '',
+			pid: 1,
+			output: [null, '{"abi":"137","platform":"win32","arch":"x64"}', ''],
+			signal: null
+		});
+
 		expect(NodeResolver.resolve('C:\\Program Files\\nodejs\\node.exe')).toBe('C:\\Program Files\\nodejs\\node.exe');
 	});
 
@@ -53,10 +66,10 @@ describe('NodeResolver', () => {
 				return {
 					error: undefined,
 					status: 0,
-					stdout: 'v24.0.0\n',
+					stdout: '{"abi":"137","platform":"win32","arch":"x64"}',
 					stderr: '',
 					pid: 1,
-					output: [null, 'v24.0.0\n', ''],
+					output: [null, '{"abi":"137","platform":"win32","arch":"x64"}', ''],
 					signal: null
 				};
 			}
@@ -69,6 +82,57 @@ describe('NodeResolver', () => {
 		});
 
 		expect(NodeResolver.resolve()).toBe(programFilesNode);
+	});
+	it('skips an unsupported active Node and finds a supported asdf installation', () => {
+		Object.defineProperty(process, 'platform', { value: 'darwin' });
+		const asdfRoot = path.join(os.homedir(), '.asdf', 'installs', 'nodejs');
+		const supportedNode = path.join(asdfRoot, '24.16.0', 'bin', 'node');
+
+		existsSyncMock.mockImplementation((target) => String(target) === asdfRoot);
+		readdirSyncMock.mockImplementation((target) => (String(target) === asdfRoot ? ['23.9.0', '24.16.0'] : []));
+		spawnSyncMock.mockImplementation((command) => {
+			if (command === 'node') {
+				return {
+					error: undefined,
+					status: 0,
+					stdout: '{"abi":"131","platform":"darwin","arch":"arm64"}',
+					stderr: '',
+					pid: 1,
+					output: [null, '{"abi":"131","platform":"darwin","arch":"arm64"}', ''],
+					signal: null
+				};
+			}
+
+			if (command === supportedNode) {
+				return {
+					error: undefined,
+					status: 0,
+					stdout: '{"abi":"137","platform":"darwin","arch":"arm64"}',
+					stderr: '',
+					pid: 2,
+					output: [null, '{"abi":"137","platform":"darwin","arch":"arm64"}', ''],
+					signal: null
+				};
+			}
+
+			return { error: new Error('ENOENT'), status: 1, stdout: '', stderr: '', pid: 0, output: [null, '', ''], signal: null };
+		});
+
+		expect(NodeResolver.resolve()).toBe(supportedNode);
+	});
+
+	it('rejects an unsupported explicit override', () => {
+		spawnSyncMock.mockReturnValue({
+			error: undefined,
+			status: 0,
+			stdout: '{"abi":"131","platform":"darwin","arch":"arm64"}',
+			stderr: '',
+			pid: 1,
+			output: [null, '{"abi":"131","platform":"darwin","arch":"arm64"}', ''],
+			signal: null
+		});
+
+		expect(() => NodeResolver.resolve('/custom/node')).toThrow('must point to Node 22, 24, 25 or 26');
 	});
 
 	it('inspect returns abi platform and arch from runtime output', () => {

--- a/apps/extension/tests/unit/security-secrets.test.ts
+++ b/apps/extension/tests/unit/security-secrets.test.ts
@@ -1,0 +1,164 @@
+import { ADMIN_KEY_MIN_LENGTH, ADMIN_KEY_SECRET_KEY, PROVIDER_SECRET_CHANNEL } from '@ungate/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { SecuritySecrets, type SecretStore } from '../../src/security-secrets';
+
+/** Stands in for vscode.SecretStorage. */
+class MemorySecretStore implements SecretStore {
+	readonly values: Record<string, string> = {};
+	failOn: string | null = null;
+
+	get(key: string): Promise<string | undefined> {
+		return Promise.resolve(this.values[key]);
+	}
+
+	store(key: string, value: string): Promise<void> {
+		if (this.failOn === key) {
+			return Promise.reject(new Error('keychain is locked'));
+		}
+
+		this.values[key] = value;
+
+		return Promise.resolve();
+	}
+
+	delete(key: string): Promise<void> {
+		delete this.values[key];
+
+		return Promise.resolve();
+	}
+}
+
+const CLAUDE_KEY = 'ungate.provider.claude';
+
+function getRequest(id: string, provider = 'claude'): unknown {
+	return { channel: PROVIDER_SECRET_CHANNEL, id, action: 'get', provider };
+}
+
+describe('SecuritySecrets', () => {
+	let storage: MemorySecretStore;
+
+	beforeEach(() => {
+		storage = new MemorySecretStore();
+	});
+
+	it('mints a 256-bit admin key once and reuses the stored one', async () => {
+		const first = await SecuritySecrets.create(storage);
+
+		expect(first.adminApiKey.length).toBeGreaterThanOrEqual(ADMIN_KEY_MIN_LENGTH);
+		expect(first.adminApiKey).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(storage.values[ADMIN_KEY_SECRET_KEY]).toBe(first.adminApiKey);
+
+		const second = await SecuritySecrets.create(storage);
+
+		expect(second.adminApiKey).toBe(first.adminApiKey);
+	});
+
+	it('replaces a stored admin key that is too short to carry 256 bits', async () => {
+		storage.values[ADMIN_KEY_SECRET_KEY] = 'too-short';
+
+		const secrets = await SecuritySecrets.create(storage);
+
+		expect(secrets.adminApiKey).not.toBe('too-short');
+		expect(secrets.adminApiKey.length).toBeGreaterThanOrEqual(ADMIN_KEY_MIN_LENGTH);
+	});
+
+	it('stores, reads and deletes provider credentials under a constant key', async () => {
+		const secrets = await SecuritySecrets.create(storage);
+
+		const stored = await secrets.handleApiChildMessage({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r1',
+			action: 'set',
+			provider: 'claude',
+			secret: { accessToken: 'access', refreshToken: 'refresh' }
+		});
+
+		expect(stored).toEqual({ channel: PROVIDER_SECRET_CHANNEL, id: 'r1', ok: true, secret: null });
+		expect(storage.values[CLAUDE_KEY]).toBe(JSON.stringify({ accessToken: 'access', refreshToken: 'refresh' }));
+
+		const read = await secrets.handleApiChildMessage(getRequest('r2'));
+
+		expect(read).toEqual({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r2',
+			ok: true,
+			secret: { accessToken: 'access', refreshToken: 'refresh' }
+		});
+
+		const deleted = await secrets.handleApiChildMessage({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r3',
+			action: 'delete',
+			provider: 'claude'
+		});
+
+		expect(deleted).toEqual({ channel: PROVIDER_SECRET_CHANNEL, id: 'r3', ok: true, secret: null });
+		expect(storage.values[CLAUDE_KEY]).toBeUndefined();
+		await expect(secrets.handleApiChildMessage(getRequest('r4'))).resolves.toEqual({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r4',
+			ok: true,
+			secret: null
+		});
+	});
+
+	it('ignores messages that do not belong to the credential channel', async () => {
+		const secrets = await SecuritySecrets.create(storage);
+
+		await expect(secrets.handleApiChildMessage({ type: 'webview-ready' })).resolves.toBeNull();
+		await expect(secrets.handleApiChildMessage('garbage')).resolves.toBeNull();
+		await expect(secrets.handleApiChildMessage(null)).resolves.toBeNull();
+		// Channel matches but the correlation id is missing, so there is nobody to answer.
+		await expect(secrets.handleApiChildMessage({ channel: PROVIDER_SECRET_CHANNEL, action: 'get' })).resolves.toBeNull();
+	});
+
+	it('answers malformed credential requests with an error instead of acting on them', async () => {
+		const secrets = await SecuritySecrets.create(storage);
+		const malformed: unknown[] = [
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm1', action: 'wipe', provider: 'claude' },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm2', action: 'get', provider: 'anthropic' },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm3', action: 'set', provider: 'claude' },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm4', action: 'set', provider: 'claude', secret: { accessToken: 42 } },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm5', action: 'delete', provider: 'claude', secret: { accessToken: 'x' } }
+		];
+
+		for (const message of malformed) {
+			await expect(secrets.handleApiChildMessage(message)).resolves.toMatchObject({ ok: false });
+		}
+
+		expect(storage.values[CLAUDE_KEY]).toBeUndefined();
+	});
+
+	it('treats an unreadable stored credential as absent', async () => {
+		const secrets = await SecuritySecrets.create(storage);
+		storage.values[CLAUDE_KEY] = 'not json';
+
+		await expect(secrets.handleApiChildMessage(getRequest('r5'))).resolves.toMatchObject({ ok: true, secret: null });
+
+		storage.values[CLAUDE_KEY] = JSON.stringify({ accessToken: 7 });
+
+		await expect(secrets.handleApiChildMessage(getRequest('r6'))).resolves.toMatchObject({ ok: true, secret: null });
+	});
+
+	it('reports storage failures without echoing the credential', async () => {
+		const secrets = await SecuritySecrets.create(storage);
+		storage.failOn = CLAUDE_KEY;
+
+		const response = await secrets.handleApiChildMessage({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r7',
+			action: 'set',
+			provider: 'claude',
+			secret: { accessToken: 'super-secret-token', refreshToken: null }
+		});
+
+		expect(response).toEqual({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r7',
+			ok: false,
+			error: 'Secret storage rejected set for claude: keychain is locked'
+		});
+		expect(JSON.stringify(response)).not.toContain('super-secret-token');
+	});
+});

--- a/apps/extension/tests/unit/sqlite3-cli-resolver.test.ts
+++ b/apps/extension/tests/unit/sqlite3-cli-resolver.test.ts
@@ -28,8 +28,27 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 import { Sqlite3CliResolver } from '../../src/utils/sqlite3-cli-resolver';
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from '../../src/utils/verified-artifact';
+
+const LINUX_X64_SHA256 = '9043648ac1186308c212c82d32327f0f1351fdf9dfb56a2a58bcf9bc947e3f90';
+const LINUX_X64_URL = 'https://www.sqlite.org/2024/sqlite-tools-linux-x64-3470200.zip';
+
+function forceHost(platform: string, arch: string): void {
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+	Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+/** `which sqlite3` misses, so the resolver has to decide between a pinned download and failing closed. */
+function mockEmptyPath(): void {
+	mocks.execFileMock.mockImplementation((command: string, _args: string[], callback: (error: Error | null) => void) => {
+		callback(new Error(`not found: ${command}`));
+	});
+}
 
 describe('Sqlite3CliResolver', () => {
+	const originalPlatform = process.platform;
+	const originalArch = process.arch;
+
 	beforeEach(() => {
 		mocks.execFileMock.mockReset();
 		mocks.existsSyncMock.mockReset();
@@ -38,18 +57,45 @@ describe('Sqlite3CliResolver', () => {
 	});
 
 	afterEach(() => {
+		forceHost(originalPlatform, originalArch);
 		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
 	});
 
-	it('returns the bundled install path when it already exists', async () => {
-		mocks.existsSyncMock.mockImplementation(
-			(target) => String(target).endsWith('sqlite3.exe') || String(target).endsWith('/sqlite3')
-		);
+	it('returns the bundled install path when it was installed from the pinned archive', async () => {
+		forceHost('linux', 'x64');
+		mocks.existsSyncMock.mockImplementation((target) => String(target) === Sqlite3CliResolver.getInstalledPath());
+		vi.spyOn(InstallStamp, 'matches').mockReturnValue(true);
 
 		const resolved = await Sqlite3CliResolver.resolve();
 
 		expect(resolved).toBe(Sqlite3CliResolver.getInstalledPath());
 		expect(mocks.execFileMock).not.toHaveBeenCalled();
+	});
+
+	it('ignores an existing binary that carries no pinned checksum stamp', async () => {
+		forceHost('linux', 'x64');
+		mocks.existsSyncMock.mockImplementation((target) => {
+			const value = String(target);
+
+			return value === Sqlite3CliResolver.getInstalledPath() || value === '/usr/bin/sqlite3';
+		});
+		mocks.execFileMock.mockImplementation(
+			(command: string, args: string[], callback: (error: Error | null, result?: { stdout: string }) => void) => {
+				if (command === 'which' && args[0] === 'sqlite3') {
+					callback(null, { stdout: '/usr/bin/sqlite3\n' });
+
+					return;
+				}
+
+				callback(new Error('not found'));
+			}
+		);
+
+		const resolved = await Sqlite3CliResolver.resolve();
+
+		expect(resolved).toBe('/usr/bin/sqlite3');
+		expect(mocks.fetchMock).not.toHaveBeenCalled();
 	});
 
 	it('falls back to sqlite3 from PATH before downloading', async () => {
@@ -73,9 +119,7 @@ describe('Sqlite3CliResolver', () => {
 	});
 
 	it('uses where.exe on win32 when searching PATH', async () => {
-		const originalPlatform = process.platform;
-
-		Object.defineProperty(process, 'platform', { value: 'win32' });
+		forceHost('win32', 'x64');
 		mocks.existsSyncMock.mockImplementation((target) => String(target) === 'C:\\Tools\\sqlite3.exe');
 		mocks.execFileMock.mockImplementation(
 			(command: string, args: string[], callback: (error: Error | null, result: { stdout: string }) => void) => {
@@ -91,12 +135,12 @@ describe('Sqlite3CliResolver', () => {
 
 		const resolved = await Sqlite3CliResolver.resolve();
 
-		Object.defineProperty(process, 'platform', { value: originalPlatform });
-
 		expect(resolved).toBe('C:\\Tools\\sqlite3.exe');
 	});
 
-	it('downloads sqlite3 into ~/.ungate/bin when nothing is available locally', async () => {
+	it('downloads the pinned archive into ~/.ungate/bin when nothing is available locally', async () => {
+		forceHost('linux', 'x64');
+
 		const installedPath = Sqlite3CliResolver.getInstalledPath();
 
 		mocks.existsSyncMock.mockImplementation((target) => {
@@ -106,35 +150,67 @@ describe('Sqlite3CliResolver', () => {
 		});
 		mocks.execFileMock.mockImplementation(
 			(command: string, args: string[], callback: (error: Error | null, result?: { stdout: string }) => void) => {
-				if (command === 'which') {
-					callback(new Error('not found'));
-
-					return;
-				}
-
 				if (command === 'unzip') {
 					const destDir = args[args.indexOf('-d') + 1];
 
 					fs.mkdirSync(destDir, { recursive: true });
-					fs.writeFileSync(path.join(destDir, Sqlite3CliResolver.getBinaryName()), '');
+					fs.writeFileSync(path.join(destDir, 'sqlite3'), '');
 					callback(null);
 
 					return;
 				}
 
-				callback(new Error(`unexpected command: ${command}`));
+				callback(new Error(`not found: ${command}`));
 			}
 		);
-		mocks.fetchMock.mockResolvedValue({
-			ok: true,
-			arrayBuffer: () => Promise.resolve(new Uint8Array([0x50, 0x4b, 0x03, 0x04]).buffer)
-		});
+
+		const downloadSpy = vi
+			.spyOn(VerifiedArtifact, 'download')
+			.mockImplementation((_artifact: PinnedArtifact, destPath: string) => {
+				fs.mkdirSync(path.dirname(destPath), { recursive: true });
+				fs.writeFileSync(destPath, 'verified-zip');
+
+				return Promise.resolve();
+			});
 
 		const resolved = await Sqlite3CliResolver.resolve();
+		const artifact = downloadSpy.mock.calls[0]?.[0];
 
 		fs.rmSync(installedPath, { force: true });
+		fs.rmSync(`${installedPath}.sha256`, { force: true });
 
 		expect(resolved).toBe(installedPath);
-		expect(mocks.fetchMock).toHaveBeenCalledWith(expect.stringMatching(/^https:\/\/www\.sqlite\.org\/\d{4}\/sqlite-tools-/));
+		expect(artifact?.url).toBe(LINUX_X64_URL);
+		expect(artifact?.sha256).toBe(LINUX_X64_SHA256);
+	});
+
+	it('rejects a tampered archive before extraction and installs nothing', async () => {
+		forceHost('linux', 'x64');
+		mocks.existsSyncMock.mockReturnValue(false);
+		mockEmptyPath();
+		mocks.fetchMock.mockResolvedValue(new Response('tampered-sqlite-tools-zip'));
+
+		const logs: string[] = [];
+		const resolved = await Sqlite3CliResolver.resolve((message) => logs.push(message));
+
+		expect(resolved).toBeNull();
+		expect(logs.join('\n')).toMatch(/Checksum mismatch/);
+		expect(mocks.execFileMock.mock.calls.some(([command]) => command === 'unzip')).toBe(false);
+	});
+
+	it('fails closed with an actionable message where upstream publishes no archive', async () => {
+		forceHost('darwin', 'arm64');
+		mocks.existsSyncMock.mockReturnValue(false);
+		mockEmptyPath();
+
+		const logs: string[] = [];
+		const resolved = await Sqlite3CliResolver.resolve((message) => logs.push(message));
+		const log = logs.join('\n');
+
+		expect(resolved).toBeNull();
+		expect(log).toContain('no pinned, checksum-verified artifact for darwin-arm64');
+		expect(log).toContain('darwin-x64, linux-x64, win32-x64');
+		expect(log).toContain('brew install sqlite');
+		expect(mocks.fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/extension/tests/unit/tunnel-manager-binary-path.test.ts
+++ b/apps/extension/tests/unit/tunnel-manager-binary-path.test.ts
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => {
 	return {
 		existsSyncMock: vi.fn(),
 		renameSyncMock: vi.fn(),
-		installMock: vi.fn(),
 		useMock: vi.fn(),
 		binExport: '/dev/cloudflared-package/bin/cloudflared'
 	};
@@ -16,7 +15,6 @@ const mocks = vi.hoisted(() => {
 vi.mock('cloudflared', () => {
 	return {
 		bin: mocks.binExport,
-		install: mocks.installMock,
 		use: mocks.useMock,
 		Tunnel: {
 			quick: vi.fn(() => ({
@@ -48,66 +46,93 @@ vi.mock('../../src/runtime-state', () => {
 });
 
 import { TunnelManager } from '../../src/tunnel-manager';
+import { CloudflaredInstaller } from '../../src/utils/cloudflared-installer';
+
+function createManager(): TunnelManager {
+	return new TunnelManager(
+		'window-a',
+		() => true,
+		() => {},
+		() => {}
+	);
+}
 
 describe('TunnelManager cloudflared binary path', () => {
 	const binDir = path.join(os.homedir(), '.ungate', 'bin');
+	const originalPlatform = process.platform;
 
 	afterEach(() => {
+		Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
 		vi.clearAllMocks();
+		vi.restoreAllMocks();
 	});
 
-	it('installs cloudflared.exe on win32', async () => {
-		const originalPlatform = process.platform;
-
-		Object.defineProperty(process, 'platform', { value: 'win32' });
+	it('installs cloudflared.exe from the pinned artifact on win32', async () => {
+		Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
 		const expectedPath = path.join(binDir, 'cloudflared.exe');
 
 		mocks.existsSyncMock.mockReturnValue(false);
-		mocks.installMock.mockResolvedValue(expectedPath);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(false);
 
-		const manager = new TunnelManager(
-			'window-a',
-			() => true,
-			() => {},
-			() => {}
-		);
+		const installSpy = vi.spyOn(CloudflaredInstaller, 'install').mockResolvedValue(expectedPath);
 
-		await manager.start(47821);
+		await createManager().start(47821);
 
-		Object.defineProperty(process, 'platform', { value: originalPlatform });
-
-		expect(mocks.installMock).toHaveBeenCalledWith(expectedPath);
+		expect(installSpy).toHaveBeenCalledWith(expectedPath);
 		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
 	});
 
-	it('renames a legacy Windows install without .exe extension', async () => {
-		const originalPlatform = process.platform;
+	it('reuses a managed binary that carries the pinned checksum stamp', async () => {
+		Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-		Object.defineProperty(process, 'platform', { value: 'win32' });
+		const expectedPath = path.join(binDir, 'cloudflared.exe');
+
+		mocks.existsSyncMock.mockReturnValue(false);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(true);
+
+		const installSpy = vi.spyOn(CloudflaredInstaller, 'install');
+
+		await createManager().start(47821);
+
+		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
+		expect(installSpy).not.toHaveBeenCalled();
+	});
+
+	it('renames a legacy Windows install without .exe extension, then replaces it because it is unverified', async () => {
+		Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
 		const legacyPath = path.join(binDir, 'cloudflared');
 		const expectedPath = path.join(binDir, 'cloudflared.exe');
 
-		mocks.existsSyncMock.mockImplementation((target) => {
-			const value = String(target);
+		mocks.existsSyncMock.mockImplementation((target) => String(target) === legacyPath);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(false);
 
-			return value === legacyPath;
-		});
+		const installSpy = vi.spyOn(CloudflaredInstaller, 'install').mockResolvedValue(expectedPath);
 
-		const manager = new TunnelManager(
-			'window-a',
-			() => true,
-			() => {},
-			() => {}
-		);
+		await createManager().start(47821);
+
+		expect(mocks.renameSyncMock).toHaveBeenCalledWith(legacyPath, expectedPath);
+		expect(installSpy).toHaveBeenCalledWith(expectedPath);
+		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
+	});
+
+	it('surfaces a failed verification as a tunnel error instead of starting cloudflared', async () => {
+		Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+		mocks.existsSyncMock.mockReturnValue(false);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(false);
+		vi.spyOn(CloudflaredInstaller, 'install').mockRejectedValue(new Error('Checksum mismatch for cloudflared-linux-amd64'));
+
+		const manager = createManager();
 
 		await manager.start(47821);
 
-		Object.defineProperty(process, 'platform', { value: originalPlatform });
-
-		expect(mocks.renameSyncMock).toHaveBeenCalledWith(legacyPath, expectedPath);
-		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
-		expect(mocks.installMock).not.toHaveBeenCalled();
+		expect(manager.getState()).toEqual({
+			status: 'error',
+			url: null,
+			error: 'Install failed: Checksum mismatch for cloudflared-linux-amd64'
+		});
+		expect(mocks.useMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/extension/tests/unit/verified-artifact.test.ts
+++ b/apps/extension/tests/unit/verified-artifact.test.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InstallStamp, VerifiedArtifact } from '../../src/utils/verified-artifact';
+
+const PAYLOAD = Buffer.from('ungate pinned artifact payload');
+const PAYLOAD_SHA256 = createHash('sha256').update(PAYLOAD).digest('hex');
+const OTHER_SHA256 = createHash('sha256').update('a different artifact').digest('hex');
+
+function respondWith(body: Buffer): void {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(() => Promise.resolve(new Response(new Uint8Array(body))))
+	);
+}
+
+describe('VerifiedArtifact', () => {
+	let stagingRoot: string;
+
+	beforeEach(() => {
+		stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ungate-verified-artifact-'));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		fs.rmSync(stagingRoot, { recursive: true, force: true });
+	});
+
+	it('writes the artifact when the streamed bytes match the pinned digest', async () => {
+		respondWith(PAYLOAD);
+
+		const destPath = path.join(stagingRoot, 'artifact.bin');
+
+		await VerifiedArtifact.download({ url: 'https://example.invalid/artifact.bin', sha256: PAYLOAD_SHA256 }, destPath);
+
+		expect(fs.readFileSync(destPath)).toEqual(PAYLOAD);
+	});
+
+	it('rejects a one-byte modification and discards the staged file', async () => {
+		const tampered = Buffer.from(PAYLOAD);
+
+		tampered[0] ^= 0x01;
+		respondWith(tampered);
+
+		const destPath = path.join(stagingRoot, 'artifact.bin');
+
+		await expect(
+			VerifiedArtifact.download({ url: 'https://example.invalid/artifact.bin', sha256: PAYLOAD_SHA256 }, destPath)
+		).rejects.toThrow(/Checksum mismatch/);
+
+		expect(fs.existsSync(destPath)).toBe(false);
+	});
+
+	it('discards the staged file when the response is not ok', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('nope', { status: 404 })))
+		);
+
+		const destPath = path.join(stagingRoot, 'artifact.bin');
+
+		await expect(
+			VerifiedArtifact.download({ url: 'https://example.invalid/artifact.bin', sha256: PAYLOAD_SHA256 }, destPath)
+		).rejects.toThrow('HTTP 404');
+
+		expect(fs.existsSync(destPath)).toBe(false);
+	});
+
+	it('refuses a malformed pinned digest before making a request', async () => {
+		const fetchMock = vi.fn();
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			VerifiedArtifact.download(
+				{ url: 'https://example.invalid/artifact.bin', sha256: 'not-a-digest' },
+				path.join(stagingRoot, 'artifact.bin')
+			)
+		).rejects.toThrow(/Malformed pinned SHA-256 digest/);
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('names the host tuple, the supported tuples and a remedy when nothing is pinned', () => {
+		const error = VerifiedArtifact.unsupportedError('cloudflared 1.2.3', 'sunos-mips', ['linux-x64', 'darwin-arm64'], 'Do X.');
+
+		expect(error.message).toContain('sunos-mips');
+		expect(error.message).toContain('darwin-arm64, linux-x64');
+		expect(error.message).toContain('Do X.');
+	});
+});
+
+describe('InstallStamp', () => {
+	let stagingRoot: string;
+
+	beforeEach(() => {
+		stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ungate-install-stamp-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(stagingRoot, { recursive: true, force: true });
+	});
+
+	it('treats an unstamped binary as unverified and a stamped one as current', () => {
+		const artifact = { url: 'https://example.invalid/tool', sha256: PAYLOAD_SHA256 };
+		const binaryPath = path.join(stagingRoot, 'tool');
+
+		fs.writeFileSync(binaryPath, PAYLOAD);
+
+		expect(InstallStamp.matches(binaryPath, artifact)).toBe(false);
+
+		InstallStamp.write(binaryPath, artifact);
+
+		expect(InstallStamp.matches(binaryPath, artifact)).toBe(true);
+		expect(InstallStamp.matches(binaryPath, { ...artifact, sha256: OTHER_SHA256 })).toBe(false);
+	});
+});

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -1,4 +1,5 @@
 import {
+	ADMIN_KEY_HEADER,
 	sleep,
 	type AnalyticsSummary,
 	type AppSettings,
@@ -8,7 +9,7 @@ import {
 } from '@ungate/shared/frontend';
 
 export class Api {
-	private static port: number | null = (window as unknown as { __PORT__?: number | null }).__PORT__ ?? null;
+	private static port: number | null = window.__PORT__ ?? null;
 	private static readonly portWaiters = new Set<(port: number) => void>();
 
 	static {
@@ -30,7 +31,7 @@ export class Api {
 	}
 
 	private static async getPort(): Promise<number> {
-		const injected = (window as unknown as { __PORT__?: number | null }).__PORT__;
+		const injected = window.__PORT__;
 
 		if (injected) {
 			return injected;
@@ -65,9 +66,25 @@ export class Api {
 		return `http://localhost:${port}`;
 	}
 
+	/**
+	 * Administrative routes (settings, provider auth, analytics) require the admin key that the
+	 * extension injects into this webview. It is read per request rather than cached, so a webview
+	 * HTML rebuild always wins. Proxy routes are never called from here.
+	 */
+	private static adminHeaders(base?: Record<string, string>): Record<string, string> {
+		const key = window.__ADMIN_KEY__;
+		const headers: Record<string, string> = { ...base };
+
+		if (key) {
+			headers[ADMIN_KEY_HEADER] = key;
+		}
+
+		return headers;
+	}
+
 	private static async get<T>(path: string): Promise<T> {
 		const baseUrl = await this.baseUrl();
-		const response = await fetch(`${baseUrl}${path}`);
+		const response = await fetch(`${baseUrl}${path}`, { headers: this.adminHeaders() });
 
 		if (!response.ok) {
 			throw new Error(`GET ${path} failed: ${response.status}`);
@@ -80,7 +97,7 @@ export class Api {
 		const baseUrl = await this.baseUrl();
 		const response = await fetch(`${baseUrl}${path}`, {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: this.adminHeaders({ 'Content-Type': 'application/json' }),
 			body: JSON.stringify(body ?? {})
 		});
 

--- a/apps/web/src/types/shims/webview-globals.d.ts
+++ b/apps/web/src/types/shims/webview-globals.d.ts
@@ -1,0 +1,8 @@
+// Globals the extension injects into the dashboard webview HTML before any module runs.
+// `__PORT__` is the port the local API listens on; `__ADMIN_KEY__` is the key required by
+// administrative routes and is deliberately never persisted anywhere the webview can write.
+interface Window {
+	__PORT__?: number | null;
+	__ADMIN_KEY__?: string | null;
+	__TS__?: number;
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,14 @@
+// Administrative routes (settings, provider auth, analytics) are gated by a key that is
+// separate from the proxy API key Cursor uses. The extension mints it per install and
+// keeps it in VS Code SecretStorage, so it never reaches the SQLite settings table.
+export const ADMIN_KEY_HEADER = 'x-ungate-admin-key';
+
+export const ADMIN_KEY_ENV = 'UNGATE_ADMIN_KEY';
+
+// A 256-bit key is 43 characters base64url-encoded and 64 characters hex-encoded.
+// Anything shorter than the base64url length cannot carry 256 bits of entropy.
+export const ADMIN_KEY_MIN_LENGTH = 43;
+
 export const DEFAULT_KEY_FIX_ENABLED = false;
 
 export const MINIMAX_BASE_URLS = {

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './runtime';
 export * from './settings';
 export * from './log';
 export * from './tunnel';
+export * from './secrets';

--- a/packages/shared/src/types/secrets.ts
+++ b/packages/shared/src/types/secrets.ts
@@ -1,0 +1,151 @@
+import { isModelMappingProvider } from '../guards/settings';
+
+import type { ModelMappingProvider } from './settings';
+
+/** VS Code SecretStorage key holding the administrative API key the extension mints per install. */
+export const ADMIN_KEY_SECRET_KEY = 'ungate.admin-api-key';
+
+/** Prefix of the VS Code SecretStorage keys holding per-provider credentials. */
+export const PROVIDER_SECRET_KEY_PREFIX = 'ungate.provider.';
+
+/**
+ * Discriminator carried by every message on the API child IPC channel. Both sides drop
+ * messages without it, so the channel can be shared with unrelated traffic.
+ */
+export const PROVIDER_SECRET_CHANNEL = 'ungate.provider-secret';
+
+export const PROVIDER_SECRET_ACTIONS = ['get', 'set', 'delete'] as const;
+
+export type ProviderSecretAction = (typeof PROVIDER_SECRET_ACTIONS)[number];
+
+/** The only credential fields that must never be written to SQLite. */
+export interface ProviderSecret {
+	accessToken: string;
+	refreshToken: string | null;
+}
+
+export interface ProviderSecretRequest {
+	channel: typeof PROVIDER_SECRET_CHANNEL;
+	id: string;
+	action: ProviderSecretAction;
+	provider: ModelMappingProvider;
+	/** Present exactly for `set`. */
+	secret?: ProviderSecret;
+}
+
+export type ProviderSecretResponse =
+	| { channel: typeof PROVIDER_SECRET_CHANNEL; id: string; ok: true; secret: ProviderSecret | null }
+	| { channel: typeof PROVIDER_SECRET_CHANNEL; id: string; ok: false; error: string };
+
+export function providerSecretKey(provider: ModelMappingProvider): string {
+	return `${PROVIDER_SECRET_KEY_PREFIX}${provider}`;
+}
+
+export function isProviderSecretAction(value: unknown): value is ProviderSecretAction {
+	return typeof value === 'string' && PROVIDER_SECRET_ACTIONS.includes(value as ProviderSecretAction);
+}
+
+export function isProviderSecret(value: unknown): value is ProviderSecret {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const candidate = value as { accessToken?: unknown; refreshToken?: unknown };
+
+	if (typeof candidate.accessToken !== 'string') {
+		return false;
+	}
+
+	return candidate.refreshToken === null || typeof candidate.refreshToken === 'string';
+}
+
+/**
+ * Recognizes a message as belonging to the secret channel without trusting its payload.
+ * The correlation id is needed to answer malformed requests instead of leaving the
+ * sender waiting for a reply that never comes.
+ */
+export function readProviderSecretEnvelope(value: unknown): { id: string } | null {
+	if (typeof value !== 'object' || value === null) {
+		return null;
+	}
+
+	const candidate = value as { channel?: unknown; id?: unknown };
+
+	if (candidate.channel !== PROVIDER_SECRET_CHANNEL) {
+		return null;
+	}
+
+	if (typeof candidate.id !== 'string' || candidate.id.length === 0) {
+		return null;
+	}
+
+	return { id: candidate.id };
+}
+
+export function parseProviderSecretRequest(value: unknown): ProviderSecretRequest | null {
+	const envelope = readProviderSecretEnvelope(value);
+
+	if (!envelope) {
+		return null;
+	}
+
+	const candidate = value as { action?: unknown; provider?: unknown; secret?: unknown };
+
+	if (!isProviderSecretAction(candidate.action) || !isModelMappingProvider(candidate.provider)) {
+		return null;
+	}
+
+	if (candidate.action === 'set') {
+		if (!isProviderSecret(candidate.secret)) {
+			return null;
+		}
+
+		return {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: envelope.id,
+			action: 'set',
+			provider: candidate.provider,
+			secret: { accessToken: candidate.secret.accessToken, refreshToken: candidate.secret.refreshToken }
+		};
+	}
+
+	if (candidate.secret !== undefined) {
+		return null;
+	}
+
+	return {
+		channel: PROVIDER_SECRET_CHANNEL,
+		id: envelope.id,
+		action: candidate.action,
+		provider: candidate.provider
+	};
+}
+
+export function parseProviderSecretResponse(value: unknown): ProviderSecretResponse | null {
+	const envelope = readProviderSecretEnvelope(value);
+
+	if (!envelope) {
+		return null;
+	}
+
+	const candidate = value as { ok?: unknown; secret?: unknown; error?: unknown };
+
+	if (candidate.ok === true) {
+		if (candidate.secret !== null && !isProviderSecret(candidate.secret)) {
+			return null;
+		}
+
+		return {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: envelope.id,
+			ok: true,
+			secret: candidate.secret ?? null
+		};
+	}
+
+	if (candidate.ok === false && typeof candidate.error === 'string') {
+		return { channel: PROVIDER_SECRET_CHANNEL, id: envelope.id, ok: false, error: candidate.error };
+	}
+
+	return null;
+}

--- a/scripts/reset-sqlite-binary/run.sh
+++ b/scripts/reset-sqlite-binary/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
-# Removes the runtime-installed better-sqlite3 binary so the extension
-# re-downloads it on the next API start (reproduces prebuild failures).
+# Removes the runtime-installed better-sqlite3 binary and its pinned-checksum
+# stamp so the extension re-downloads and re-verifies it on the next API start
+# (reproduces prebuild failures).
 
 rm -f apps/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node
-echo "removed better_sqlite3.installed.node"
+rm -f apps/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node.sha256
+echo "removed better_sqlite3.installed.node and its checksum stamp"


### PR DESCRIPTION
## Summary

This PR closes several security gaps in the local API, public tunnel, credential storage, and
native binary installation.

The changes span the extension, API, dashboard, shared types, tests, and packaging because the
security boundary crosses all of those components.

## What changed

### Protect administrative routes

- Bind the local API to `127.0.0.1` instead of `0.0.0.0`.
- Generate a separate 256-bit administrative key.
- Store the administrative key in VS Code SecretStorage.
- Require `x-ungate-admin-key` on settings, provider authentication, and analytics routes.
- Inject the key safely into the dashboard webview.
- Have the dashboard send the key with administrative requests.
- Restrict CORS to Cursor webviews and loopback origins.
- Keep `/health` unauthenticated for local health checks.

The proxy API key remains separate from the administrative key. It now fails closed when
missing or blank and protects:

- `/v1/chat/completions`
- `/v1/messages`
- `/v1/models`

### Move provider credentials out of SQLite

Claude, OpenAI, and MiniMax credentials now live in VS Code SecretStorage.

The API child accesses credentials through a validated Node IPC request/response channel.
Messages validate their channel, action, provider, payload, and correlation ID.

On startup, existing plaintext credentials are:

1. Copied to SecretStorage.
2. Confirmed stored.
3. Blanked in the legacy SQLite columns before the API starts listening.

New logins never write access or refresh tokens to SQLite.

The API fails closed when started without the extension credential channel. This intentionally
means the standalone API process can no longer authenticate providers without the extension.

### Verify native downloads

All managed native downloads are now pinned and SHA-256 verified before extraction or
execution:

- `cloudflared` 2026.8.2
- `better-sqlite3` 12.11.1 prebuilds
- SQLite tools 3.47.2

Unsupported platform, architecture, and Node ABI combinations fail before any network request
or execution.

Managed binaries receive an installation stamp. Unstamped or mismatched binaries left by
previous versions are replaced rather than trusted.

The SQLite 3.47.2 release does not provide macOS arm64 or Linux arm64 tool archives. Those
systems now receive an actionable instruction to install `sqlite3` on `PATH` instead of
attempting URLs that return 404.

### Select a supported Node runtime

The extension now checks the Node ABI instead of accepting the first executable that responds
to `node -v`.

Supported runtimes are Node 22, 24, 25, and 26. The resolver:

- Skips unsupported active runtimes such as Node 23.
- Searches system, Volta, NVM, and asdf installations.
- Searches actual asdf installations in addition to the active asdf shim.
- Validates `UNGATE_NODE_BIN` instead of accepting it blindly.
- Fails with an actionable message when no supported runtime exists.

## Security impact

Before this change, the public tunnel exposed administrative endpoints that did not require
authentication. The API also listened on every local network interface, and provider
credentials were stored as plaintext SQLite values.

After this change:

- Knowing the tunnel URL does not grant administrative access.
- The proxy key cannot authorize settings or provider-management requests.
- Administrative access requires a separate machine-local secret.
- Provider credentials are not present in SQLite.
- Local network peers cannot connect directly to the API.
- Downloaded executables must match a pinned digest.

## Compatibility notes

- Existing provider credentials migrate automatically on the first successful startup.
- Users may need to authenticate providers again if SecretStorage is unavailable during
migration.
- Node 23 remains unsupported. The resolver will select another installed supported version.
- Existing unverified managed binaries will be downloaded again.
- Standalone API startup without extension IPC now fails intentionally.
- `/health` remains available without credentials.
- Cursor's existing proxy API key configuration remains unchanged.

## Verification

Automated tests:

- Extension: 109 tests passed
- API unit: 114 tests passed
- API integration: 79 tests passed
- Total: 302 tests passed

Static checks:

- API TypeScript build passed
- Svelte check passed with 0 errors and 0 warnings
- API, extension, web, and shared lint passed
- VSIX packaging passed

Runtime smoke test:

- `GET /health` without credentials: `200`
- `GET /settings` without admin key: `403`
- `GET /settings` with admin key: `200`
- `GET /v1/models` without proxy key: `403`
- `GET /v1/models` with proxy key: `200`
- API connection through the machine's LAN address: refused
- Provider token fields returned by settings: none

The rebuilt VSIX was installed in Cursor and the API reached `running` state on
`127.0.0.1:47821` using an automatically selected Node 24 runtime.