### PR TITLE
fix(runtime): select supported node version

### DIFF
--- a/apps/extension/src/utils/node-resolver.ts
+++ b/apps/extension/src/utils/node-resolver.ts
@@ -4,6 +4,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 const DEFAULT_NODE_COMMAND = 'node';
+// Node ABI 127 = Node 22, 137 = Node 24, 141 = Node 25, 147 = Node 26
+// (nodejs/node abi_version_registry). Anything else cannot load our native bindings.
+const SUPPORTED_NODE_ABIS: Record<string, true> = { '127': true, '137': true, '141': true, '147': true };
+const SUPPORTED_NODE_VERSIONS = '22, 24, 25 or 26';
 
 interface RuntimeInfo {
 	abi: string;
@@ -14,18 +18,24 @@ interface RuntimeInfo {
 export class NodeResolver {
 	static resolve(overridePath?: string): string {
 		if (overridePath) {
-			return overridePath;
+			if (this.isSupported(overridePath)) {
+				return overridePath;
+			}
+
+			throw new Error(`[native] UNGATE_NODE_BIN must point to Node ${SUPPORTED_NODE_VERSIONS}: ${overridePath}`);
 		}
 
 		const candidates = this.getCandidates();
 
 		for (const candidate of candidates) {
-			if (this.isUsable(candidate)) {
+			if (this.isSupported(candidate)) {
 				return candidate;
 			}
 		}
 
-		return DEFAULT_NODE_COMMAND;
+		throw new Error(
+			`[native] No supported Node runtime found. Install Node ${SUPPORTED_NODE_VERSIONS}, or set UNGATE_NODE_BIN to one.`
+		);
 	}
 
 	static inspect(runtime: string): RuntimeInfo {
@@ -92,6 +102,7 @@ export class NodeResolver {
 		this.push(candidates, seen, path.join(homeDir, '.volta', 'bin', binaryName));
 		this.push(candidates, seen, path.join(homeDir, '.asdf', 'shims', binaryName));
 		this.pushFromDir(candidates, seen, path.join(homeDir, '.nvm', 'versions', 'node'), binaryName);
+		this.pushFromDir(candidates, seen, path.join(homeDir, '.asdf', 'installs', 'nodejs'), binaryName);
 
 		return candidates;
 	}
@@ -121,9 +132,11 @@ export class NodeResolver {
 		}
 	}
 
-	private static isUsable(candidate: string): boolean {
-		const result = cp.spawnSync(candidate, ['-v'], { encoding: 'utf8' });
-
-		return !result.error && result.status === 0;
+	private static isSupported(candidate: string): boolean {
+		try {
+			return SUPPORTED_NODE_ABIS[this.inspect(candidate).abi] === true;
+		} catch {
+			return false;
+		}
 	}
 }

--- a/apps/extension/tests/unit/api-server-health-check.test.ts
+++ b/apps/extension/tests/unit/api-server-health-check.test.ts
@@ -200,10 +200,10 @@ describe('ApiServer.runHealthCheckCycle', () => {
 			return {
 				error: undefined,
 				status: 0,
-				stdout: 'v24.0.0\n',
+				stdout: '{"abi":"137","platform":"darwin","arch":"arm64"}',
 				stderr: '',
 				pid: 1,
-				output: [null, 'v24.0.0\n', ''],
+				output: [null, '{"abi":"137","platform":"darwin","arch":"arm64"}', ''],
 				signal: null
 			};
 		});

--- a/apps/extension/tests/unit/node-resolver.test.ts
+++ b/apps/extension/tests/unit/node-resolver.test.ts
@@ -1,9 +1,11 @@
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const spawnSyncMock = vi.fn();
 const existsSyncMock = vi.fn();
+const readdirSyncMock = vi.fn();
 
 vi.mock('node:child_process', () => {
 	return {
@@ -15,7 +17,7 @@ vi.mock('node:child_process', () => {
 vi.mock('node:fs', () => {
 	return {
 		existsSync: (...args: unknown[]) => existsSyncMock(...args),
-		readdirSync: vi.fn(() => [])
+		readdirSync: (...args: unknown[]) => readdirSyncMock(...args)
 	};
 });
 
@@ -27,13 +29,24 @@ describe('NodeResolver', () => {
 	beforeEach(() => {
 		spawnSyncMock.mockReset();
 		existsSyncMock.mockReset();
+		readdirSyncMock.mockReset();
 	});
 
 	afterEach(() => {
 		Object.defineProperty(process, 'platform', { value: originalPlatform });
 	});
 
-	it('returns override path when UNGATE_NODE_BIN is provided via resolve argument', () => {
+	it('returns a supported override path when UNGATE_NODE_BIN is provided via resolve argument', () => {
+		spawnSyncMock.mockReturnValue({
+			error: undefined,
+			status: 0,
+			stdout: '{"abi":"137","platform":"win32","arch":"x64"}',
+			stderr: '',
+			pid: 1,
+			output: [null, '{"abi":"137","platform":"win32","arch":"x64"}', ''],
+			signal: null
+		});
+
 		expect(NodeResolver.resolve('C:\\Program Files\\nodejs\\node.exe')).toBe('C:\\Program Files\\nodejs\\node.exe');
 	});
 
@@ -53,10 +66,10 @@ describe('NodeResolver', () => {
 				return {
 					error: undefined,
 					status: 0,
-					stdout: 'v24.0.0\n',
+					stdout: '{"abi":"137","platform":"win32","arch":"x64"}',
 					stderr: '',
 					pid: 1,
-					output: [null, 'v24.0.0\n', ''],
+					output: [null, '{"abi":"137","platform":"win32","arch":"x64"}', ''],
 					signal: null
 				};
 			}
@@ -69,6 +82,76 @@ describe('NodeResolver', () => {
 		});
 
 		expect(NodeResolver.resolve()).toBe(programFilesNode);
+	});
+
+	it('skips an unsupported active Node and finds a supported asdf installation', () => {
+		Object.defineProperty(process, 'platform', { value: 'darwin' });
+		const asdfRoot = path.join(os.homedir(), '.asdf', 'installs', 'nodejs');
+		const supportedNode = path.join(asdfRoot, '24.16.0', 'bin', 'node');
+
+		existsSyncMock.mockImplementation((target) => String(target) === asdfRoot);
+		readdirSyncMock.mockImplementation((target) => (String(target) === asdfRoot ? ['23.9.0', '24.16.0'] : []));
+		spawnSyncMock.mockImplementation((command) => {
+			if (command === 'node') {
+				return {
+					error: undefined,
+					status: 0,
+					stdout: '{"abi":"131","platform":"darwin","arch":"arm64"}',
+					stderr: '',
+					pid: 1,
+					output: [null, '{"abi":"131","platform":"darwin","arch":"arm64"}', ''],
+					signal: null
+				};
+			}
+
+			if (command === supportedNode) {
+				return {
+					error: undefined,
+					status: 0,
+					stdout: '{"abi":"137","platform":"darwin","arch":"arm64"}',
+					stderr: '',
+					pid: 2,
+					output: [null, '{"abi":"137","platform":"darwin","arch":"arm64"}', ''],
+					signal: null
+				};
+			}
+
+			return { error: new Error('ENOENT'), status: 1, stdout: '', stderr: '', pid: 0, output: [null, '', ''], signal: null };
+		});
+
+		expect(NodeResolver.resolve()).toBe(supportedNode);
+	});
+
+	it('rejects an unsupported explicit override', () => {
+		spawnSyncMock.mockReturnValue({
+			error: undefined,
+			status: 0,
+			stdout: '{"abi":"131","platform":"darwin","arch":"arm64"}',
+			stderr: '',
+			pid: 1,
+			output: [null, '{"abi":"131","platform":"darwin","arch":"arm64"}', ''],
+			signal: null
+		});
+
+		expect(() => NodeResolver.resolve('/custom/node')).toThrow('must point to Node 22, 24, 25 or 26');
+	});
+
+	it('throws an actionable error when no candidate is supported', () => {
+		Object.defineProperty(process, 'platform', { value: 'darwin' });
+
+		existsSyncMock.mockReturnValue(false);
+		readdirSyncMock.mockReturnValue([]);
+		spawnSyncMock.mockReturnValue({
+			error: undefined,
+			status: 0,
+			stdout: '{"abi":"131","platform":"darwin","arch":"arm64"}',
+			stderr: '',
+			pid: 1,
+			output: [null, '{"abi":"131","platform":"darwin","arch":"arm64"}', ''],
+			signal: null
+		});
+
+		expect(() => NodeResolver.resolve()).toThrow('No supported Node runtime found');
 	});
 
 	it('inspect returns abi platform and arch from runtime output', () => {


### PR DESCRIPTION
## Summary

- Validate Node runtimes by ABI instead of accepting any executable that answers `node -v`.
- Skip unsupported active runtimes such as Node 23.
- Discover installed asdf runtimes in addition to the active shim.
- Validate `UNGATE_NODE_BIN` and fail with an actionable error when no supported runtime exists.

## Why

An unsupported active Node runtime can be selected even when a compatible Node version is already installed. That causes the native `better-sqlite3` setup to fail and suppresses API startup.

This is split from #42 following review feedback.

## Verification

- Extension: 74 tests passed
- API unit: 88 tests passed
- API integration: 59 tests passed
- Extension lint passed
