### PR TITLE
fix(security): verify native downloads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,11 @@ User entry point. Manages the API server and tunnel lifecycle.
 **Native dependencies:**
 - better-sqlite3: prebuilt binary downloaded at first run from GitHub Releases matching host Node ABI (not Electron). VSIX ships only JS wrapper + bindings
 - cloudflared: binary downloaded to `~/.ungate/bin/`, managed by tsup bundling
+- sqlite3 CLI: `sqlite-tools` archive from sqlite.org, used only to read Cursor's `state.vscdb`
+- Every download goes through `utils/verified-artifact.ts`: one pinned upstream URL plus a SHA-256 allowlist per platform/arch (and per Node ABI for better-sqlite3). Bytes are hashed while streaming into a staging directory and compared with `timingSafeEqual`; nothing is extracted, copied, chmod-ed or executed before the digest matches, and staging is deleted on failure. Unknown platform/ABI tuples fail closed with an actionable error instead of falling back to a `latest` release
+- Pinned sets: better-sqlite3 12.11.1 for Node ABI 127/137/141/147 (Node 22/24/25/26) on glibc Linux, macOS and Windows; cloudflared 2026.8.2; sqlite-tools 3470200 (upstream publishes only `win-x64`, `linux-x64`, `osx-x64` — macOS arm64 and Linux arm64 must supply their own `sqlite3` on PATH)
+- Every binary Ungate installs carries a `<binary>.sha256` stamp written after verification: `~/.ungate/bin/` for cloudflared and the sqlite3 CLI, and `better_sqlite3.installed.node` in the API's `node_modules`. A managed binary without a matching stamp is treated as unverified — it is never loaded, executed or handed to the API child, and is replaced by a verified install. This retires binaries left behind by pre-pinning Ungate versions and by the `cloudflared` npm helper's `latest` install. The bundled/dev `better_sqlite3.node` binding shipped in the tree is still load-tested, since it is not a download
+- There is no manual drop-in override: on a platform with no pinned artifact the unsupported error says the feature cannot start, rather than pointing at a directory whose unstamped contents would be rejected anyway
 
 **Logs:**
 - Two ring buffers (500 entries each): API (stdout/stderr) and tunnel (stderr)

--- a/apps/extension/src/tunnel-manager.ts
+++ b/apps/extension/src/tunnel-manager.ts
@@ -2,10 +2,11 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { bin, install, use, Tunnel } from 'cloudflared';
+import { bin, use, Tunnel } from 'cloudflared';
 
 import { RuntimeStateStore } from './runtime-state';
 import { config } from './runtime-state/config';
+import { CLOUDFLARED_VERSION, CloudflaredInstaller } from './utils/cloudflared-installer';
 
 import type { LogEntry, TunnelState } from '@ungate/shared/frontend';
 
@@ -84,12 +85,11 @@ export class TunnelManager {
 	}
 
 	private async ensureBinary(): Promise<void> {
-		const devBinExists = fs.existsSync(bin);
-		const userBinPath = this.resolveUserBinaryPath();
-
-		if (devBinExists) {
+		if (fs.existsSync(bin)) {
 			return;
 		}
+
+		const userBinPath = this.resolveUserBinaryPath();
 
 		if (userBinPath) {
 			use(userBinPath);
@@ -98,15 +98,17 @@ export class TunnelManager {
 		}
 
 		this.setState({ status: 'installing', url: null, error: null });
-		this.onLog({ timestamp: Date.now(), level: 'info', message: 'Downloading cloudflared binary...' });
+		this.onLog({ timestamp: Date.now(), level: 'info', message: `Downloading cloudflared ${CLOUDFLARED_VERSION}...` });
 
 		try {
-			fs.mkdirSync(CLOUDFLARED_BIN_DIR, { recursive: true });
-			const installPath = getCloudflaredBinPath();
-			const installedPath = await install(installPath);
+			const installedPath = await CloudflaredInstaller.install(getCloudflaredBinPath());
 
 			use(installedPath);
-			this.onLog({ timestamp: Date.now(), level: 'info', message: 'cloudflared installed successfully' });
+			this.onLog({
+				timestamp: Date.now(),
+				level: 'info',
+				message: `cloudflared ${CLOUDFLARED_VERSION} installed and checksum-verified`
+			});
 			this.setState({ status: 'starting', url: null, error: null });
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
@@ -115,18 +117,20 @@ export class TunnelManager {
 		}
 	}
 
+	/**
+	 * Returns a managed `~/.ungate/bin` binary only when it came from the pinned
+	 * release. Binaries from an earlier unverified `latest` install are ignored so
+	 * they get replaced by a checksum-verified one instead of being executed.
+	 */
 	private resolveUserBinaryPath(): string | null {
 		const binPath = getCloudflaredBinPath();
-
-		if (fs.existsSync(binPath)) {
-			return binPath;
-		}
-
 		const legacyPath = getCloudflaredLegacyBinPath();
 
-		if (process.platform === 'win32' && fs.existsSync(legacyPath)) {
+		if (process.platform === 'win32' && !fs.existsSync(binPath) && fs.existsSync(legacyPath)) {
 			fs.renameSync(legacyPath, binPath);
+		}
 
+		if (CloudflaredInstaller.isPinnedInstall(binPath)) {
 			return binPath;
 		}
 

--- a/apps/extension/src/utils/better-sqlite3-installer.ts
+++ b/apps/extension/src/utils/better-sqlite3-installer.ts
@@ -2,7 +2,6 @@ import * as cp from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { promisify } from 'node:util';
 import { createGunzip } from 'node:zlib';
@@ -13,13 +12,63 @@ import { RuntimeStateStore } from '../runtime-state';
 
 import { CrossProcessLock } from './cross-process-lock';
 import { NodeResolver } from './node-resolver';
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from './verified-artifact';
 
 const NATIVE_INSTALL_LOCK = 'native-install.lock';
 const INSTALLED_BINARY_NAME = 'better_sqlite3.installed.node';
 const execFile = promisify(cp.execFile);
 
+const PINNED_VERSION = '12.11.1';
+const RELEASE_BASE = `https://github.com/WiseLibs/better-sqlite3/releases/download/v${PINNED_VERSION}`;
+
+/**
+ * SHA-256 of every WiseLibs prebuild this extension is allowed to install, taken
+ * from the immutable v12.11.1 release assets. Node ABI 127 = Node 22,
+ * 137 = Node 24, 141 = Node 25, 147 = Node 26 (nodejs/node abi_version_registry).
+ * Tuples missing from this table fail closed instead of being fetched:
+ * musl Linux, 32-bit and Electron ABIs are deliberately absent because
+ * `process.platform` cannot distinguish them from the entries below.
+ */
+const PREBUILT_SHA256: Record<string, string> = {
+	'node-v127-darwin-arm64': '8855551fa9a93d7141c5ff2156dd418bde42f63c23255b309a5b29c7c77925e2',
+	'node-v127-darwin-x64': '9c76d0dd927ad83941d29ba9cd3a4f507a88c14057afa0a3e0dbe93b5e251f4d',
+	'node-v127-linux-arm64': '00f8035f4322c14ab4dbb3ee6f4b6c9ca25209fe2a77ac2759cd09dd42587d48',
+	'node-v127-linux-x64': '94ce113ea2d9347fcd1cf8e46445cc271d1dbd02d05a64aa460442222f023b11',
+	'node-v127-win32-arm64': '895af65f470351e6252b03249dbea123f3246175471c3f59801b87a22e6ed5bf',
+	'node-v127-win32-x64': '927b34496e946dc7c9a45636a03a039df72f10191ccc4960b8616d1a9319e45b',
+	'node-v137-darwin-arm64': '6eaefc8a9c088fea873365f7db2c0f89be6ea021ede62f6a71832f5130826a93',
+	'node-v137-darwin-x64': 'f9fe570a2ef7d6069196dd595f49bc8592574963dd1f249dcaa8878626773fc9',
+	'node-v137-linux-arm64': '60da4cbe1b1714c8db62f2ee71a9928cde5303dab57bde14c02debd12a784439',
+	'node-v137-linux-x64': '99c43785639d5d3690c396ba245ee680ac8b469a46b19233a3546f0eb7f8e312',
+	'node-v137-win32-arm64': 'a6d712a918ece580882f83aee8c02d37c8841036eef68d208d71eb255d041e80',
+	'node-v137-win32-x64': '4ee5e653174d6ddd301605d351798cdae2613da06c4f37ecdce263021fcf1255',
+	'node-v141-darwin-arm64': 'e5a528210e820667d0c00d72db88c54f49b651e0b2861c349efba1d7d35b5cd5',
+	'node-v141-darwin-x64': '27e8e4f4ccbd476271f607866cdbf1555fb75d7b35bc997520eb93da7c40ce50',
+	'node-v141-linux-arm64': 'a5c37512a904e88bda3ffa1d28c8fbbfa79eb786e95c2e0a6309d55377fa0135',
+	'node-v141-linux-x64': '6c9e172375f9fb73b6adcc59057e257a36cbea77a8ea337f41561f73949339a1',
+	'node-v141-win32-arm64': 'd472ea8b36ecf195e47bbcb70185bf3c3798ff0dde6ba211f8e884eb4768f3f5',
+	'node-v141-win32-x64': 'c3a1e9556bca6a517cc0b524a51585e648f2982fdff78c6bcb0b267f778238aa',
+	'node-v147-darwin-arm64': '449dc1a8d6faf652fd449a19af125746f45c0f0abb1a5d17ec9fd44e8f5e7e69',
+	'node-v147-darwin-x64': 'a2ecaf018ac3648dc752efa4a97de098d4d24b2425731c897de94ca1e8ae0b0e',
+	'node-v147-linux-arm64': 'e277fc5bae5847d54351b12f907e9b6929c8f2c5c0660520ae4632b4806ee6f8',
+	'node-v147-linux-x64': 'a90711eae785b646d6799b31cf8dd79a5d750b1af72d310472c3b996c5cee92d',
+	'node-v147-win32-arm64': '65f177370ca2b4917501686b295f977585977a1276cc69898a50744dadb282d2',
+	'node-v147-win32-x64': 'ff6d04d52e1625d4fbf4b7a62e4f282366953be40016ded4815a651b2160bff8'
+};
+
 interface InstallCallbacks {
 	onLog(level: 'info' | 'warn' | 'error', message: string): void;
+}
+
+/**
+ * The parts of a resolved Node runtime that decide which prebuild applies. Kept
+ * structural on purpose: `NodeResolver.inspect` reports exactly these fields, and
+ * matching them here keeps the pinned-artifact lookup independent of that module.
+ */
+interface RuntimeTarget {
+	readonly abi: string;
+	readonly platform: string;
+	readonly arch: string;
 }
 
 export class BetterSqlite3Installer {
@@ -47,11 +96,35 @@ export class BetterSqlite3Installer {
 		return installedBinaryPath;
 	}
 
+	/**
+	 * The binding path handed to the API child. The managed binary is only offered
+	 * once it carries a pinned checksum stamp, so a legacy `better_sqlite3.installed.node`
+	 * left by a pre-pinning Ungate is never loaded.
+	 */
 	static resolveBindingPath(apiDir: string): string {
 		const installed = this.getInstalledBinaryPath(apiDir);
-		if (fs.existsSync(installed)) return installed;
+
+		if (this.isVerifiedManagedBinary(installed)) {
+			return installed;
+		}
 
 		return this.getBinaryPath(apiDir);
+	}
+
+	/**
+	 * True when the file was written by a verified install of one of the pinned
+	 * prebuilds. Absent or foreign stamps mean the bytes were never checked, so the
+	 * binary must be replaced rather than executed. ABI correctness is enforced
+	 * separately by the load probe in {@link canLoad}.
+	 */
+	static isVerifiedManagedBinary(installedBinaryPath: string): boolean {
+		if (!fs.existsSync(installedBinaryPath)) {
+			return false;
+		}
+
+		const digest = InstallStamp.read(installedBinaryPath);
+
+		return digest !== null && Object.values(PREBUILT_SHA256).includes(digest);
 	}
 
 	static async ensureInstalled(apiDir: string, runtime: string, callbacks: InstallCallbacks): Promise<void> {
@@ -93,20 +166,25 @@ export class BetterSqlite3Installer {
 	private static async install(apiDir: string, runtime: string, callbacks: InstallCallbacks): Promise<void> {
 		const binaryPath = this.getBinaryPath(apiDir);
 		const installedBinaryPath = this.getInstalledBinaryPath(apiDir);
-		const version = this.readBundledVersion(apiDir);
 		const info = NodeResolver.inspect(runtime);
-		const tarName = `better-sqlite3-v${version}-node-v${info.abi}-${info.platform}-${info.arch}.tar.gz`;
-		const url = `https://github.com/WiseLibs/better-sqlite3/releases/download/v${version}/${tarName}`;
+		const artifact = this.getPinnedArtifact(apiDir, info);
+		const tarName = artifact.url.slice(artifact.url.lastIndexOf('/') + 1);
 
 		callbacks.onLog('info', `[native] Using runtime: ${runtime}`);
 		callbacks.onLog('info', `[native] Downloading ${tarName}...`);
 
 		const stagingRoot = path.join(os.tmpdir(), `ungate-better-sqlite3-${process.pid}-${Date.now()}`);
+		const archivePath = path.join(stagingRoot, tarName);
+		const extractDir = path.join(stagingRoot, 'extracted');
 
 		try {
-			fs.mkdirSync(stagingRoot, { recursive: true });
-			await this.downloadAndExtract(url, stagingRoot);
-			const stagedBinary = path.join(stagingRoot, 'build', 'Release', 'better_sqlite3.node');
+			fs.mkdirSync(extractDir, { recursive: true });
+
+			// Verified before extraction: a tampered archive never reaches tar.
+			await VerifiedArtifact.download(artifact, archivePath);
+			await this.extractArchive(archivePath, extractDir);
+
+			const stagedBinary = path.join(extractDir, 'build', 'Release', 'better_sqlite3.node');
 
 			if (!fs.existsSync(stagedBinary)) {
 				throw new Error('[native] Downloaded archive did not contain better_sqlite3.node');
@@ -118,14 +196,10 @@ export class BetterSqlite3Installer {
 
 			fs.copyFileSync(stagedBinary, tempTarget);
 			fs.renameSync(tempTarget, installedBinaryPath);
-			callbacks.onLog('info', '[native] better-sqlite3 binary installed');
+			InstallStamp.write(installedBinaryPath, artifact);
+			callbacks.onLog('info', `[native] better-sqlite3 binary installed (sha256 ${artifact.sha256})`);
 		} catch (err) {
 			const message = err instanceof Error ? err.message : String(err);
-
-			if (message.includes('HTTP 404')) {
-				callbacks.onLog('error', `[native] No prebuilt binary for ABI ${info.abi}`);
-				throw new Error(`[native] No prebuilt better-sqlite3 binary for Node ABI ${info.abi} (${info.platform}-${info.arch}).`);
-			}
 
 			callbacks.onLog('error', `[native] Prebuilt install failed: ${message}`);
 			throw err;
@@ -134,22 +208,40 @@ export class BetterSqlite3Installer {
 		}
 	}
 
-	private static async downloadAndExtract(url: string, extractDir: string): Promise<void> {
-		const response = await fetch(url, {
-			headers: { 'User-Agent': 'ungate-extension' }
-		});
+	/**
+	 * Resolves the single pinned prebuild for this runtime. Throws — never falls
+	 * back to an unpinned URL — when the bundled version drifts from the pinned
+	 * checksum set or the host ABI/platform/arch tuple has no entry.
+	 */
+	private static getPinnedArtifact(apiDir: string, info: RuntimeTarget): PinnedArtifact {
+		const version = this.readBundledVersion(apiDir);
 
-		if (!response.ok) {
-			throw new Error(`Download failed: HTTP ${response.status}`);
+		if (version !== PINNED_VERSION) {
+			throw new Error(
+				`[native] better-sqlite3 ${version} is bundled but only ${PINNED_VERSION} has pinned checksums. ` +
+					'Refresh PREBUILT_SHA256 from the upstream release assets before bumping the dependency.'
+			);
 		}
 
-		if (!response.body) {
-			throw new Error('Download failed: empty response body');
+		const tuple = `node-v${info.abi}-${info.platform}-${info.arch}`;
+		const sha256 = PREBUILT_SHA256[tuple];
+
+		if (!sha256) {
+			throw VerifiedArtifact.unsupportedError(
+				`[native] better-sqlite3 ${PINNED_VERSION}`,
+				tuple,
+				Object.keys(PREBUILT_SHA256),
+				'Point Ungate at a Node 22, 24, 25 or 26 runtime on glibc Linux, macOS or Windows.'
+			);
 		}
 
+		return { url: `${RELEASE_BASE}/better-sqlite3-v${PINNED_VERSION}-${tuple}.tar.gz`, sha256 };
+	}
+
+	private static async extractArchive(archivePath: string, extractDir: string): Promise<void> {
 		// tar types are loose in CJS; runtime extract is validated by canLoad().
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-		await pipeline(Readable.fromWeb(response.body), createGunzip(), tar.extract({ cwd: extractDir }));
+		await pipeline(fs.createReadStream(archivePath), createGunzip(), tar.extract({ cwd: extractDir }));
 	}
 
 	private static async canLoad(runtime: string, apiDir: string, callbacks: InstallCallbacks): Promise<boolean> {
@@ -157,7 +249,8 @@ export class BetterSqlite3Installer {
 		const installedBinaryPath = this.getInstalledBinaryPath(apiDir);
 		const defaultBinaryPath = this.getBinaryPath(apiDir);
 
-		if (fs.existsSync(installedBinaryPath)) {
+		// A managed binary without a pinned stamp predates checksum verification.
+		if (this.isVerifiedManagedBinary(installedBinaryPath)) {
 			pathsToTry.push(installedBinaryPath);
 		}
 

--- a/apps/extension/src/utils/cloudflared-installer.ts
+++ b/apps/extension/src/utils/cloudflared-installer.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from './verified-artifact';
+
+/**
+ * Exactly one pinned cloudflared release. The npm helper's `install()` resolves
+ * `latest/download/`, which silently changes bytes under us; Ungate must know
+ * up front which binary it is about to execute.
+ */
+export const CLOUDFLARED_VERSION = '2026.8.2';
+
+const RELEASE_BASE = `https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}`;
+
+interface CloudflaredEntry {
+	readonly file: string;
+	readonly sha256: string;
+	/** macOS assets are gzipped tarballs; every other platform ships a bare executable. */
+	readonly archived: boolean;
+}
+
+interface CloudflaredArtifact extends PinnedArtifact {
+	readonly archived: boolean;
+}
+
+/**
+ * SHA-256 of the upstream release assets for {@link CLOUDFLARED_VERSION}.
+ * Cloudflare ships macOS as a `.tgz` containing a single `cloudflared` entry and
+ * every other platform as a bare executable. There is no Windows arm64 build, so
+ * Windows on arm64 runs the amd64 executable under emulation — the same binary,
+ * and therefore the same pinned digest, as Windows x64.
+ */
+const CLOUDFLARED_ARTIFACTS: Record<string, CloudflaredEntry> = {
+	'darwin-arm64': {
+		file: 'cloudflared-darwin-arm64.tgz',
+		sha256: '9042c2c5d8b2de78e60f313d5fb31b6c5c1cebde787a3caf1f2c9588084ac442',
+		archived: true
+	},
+	'darwin-x64': {
+		file: 'cloudflared-darwin-amd64.tgz',
+		sha256: 'f1727723c586500e2092368ae21871b3df7ddfd2cb097f22d81bee4a9c458bb4',
+		archived: true
+	},
+	'linux-arm64': {
+		file: 'cloudflared-linux-arm64',
+		sha256: '7747d94570fb390cf47dcb4f9555c193c6355cda9793f0d878d9049e5d6a7790',
+		archived: false
+	},
+	'linux-x64': {
+		file: 'cloudflared-linux-amd64',
+		sha256: 'fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2',
+		archived: false
+	},
+	'win32-arm64': {
+		file: 'cloudflared-windows-amd64.exe',
+		sha256: 'c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5',
+		archived: false
+	},
+	'win32-x64': {
+		file: 'cloudflared-windows-amd64.exe',
+		sha256: 'c29eee2b121f5436a642eed69fd9767da7e7b8c510fa50aaa130337f931357b5',
+		archived: false
+	}
+};
+
+// Ungate refuses to execute a cloudflared it has not verified, and `resolveUserBinaryPath`
+// ignores unstamped files, so telling the user to drop a binary into ~/.ungate/bin would be
+// a lie. State the real consequence instead.
+const UNSUPPORTED_REMEDY = `Ungate only runs a cloudflared build it can verify against a pinned SHA-256, and Cloudflare publishes no ${CLOUDFLARED_VERSION} build for this platform, so the built-in tunnel cannot start here. Run cloudflared yourself and give Cursor that tunnel URL.`;
+
+export class CloudflaredInstaller {
+	/**
+	 * True when `binaryPath` was installed from the currently pinned artifact.
+	 * Binaries left behind by the npm helper's `latest` install carry no stamp and
+	 * are therefore reported as not current, so they get replaced rather than run.
+	 */
+	static isPinnedInstall(binaryPath: string): boolean {
+		const artifact = this.getPinnedArtifact();
+
+		return artifact !== null && fs.existsSync(binaryPath) && InstallStamp.matches(binaryPath, artifact);
+	}
+
+	/**
+	 * Installs the pinned cloudflared release at `binaryPath` and returns it.
+	 * Downloads into a staging directory, verifies the digest, and only then
+	 * extracts, copies and marks the binary executable.
+	 */
+	static async install(binaryPath: string): Promise<string> {
+		const artifact = this.getPinnedArtifact();
+
+		if (!artifact) {
+			throw VerifiedArtifact.unsupportedError(
+				`cloudflared ${CLOUDFLARED_VERSION}`,
+				`${process.platform}-${process.arch}`,
+				Object.keys(CLOUDFLARED_ARTIFACTS),
+				UNSUPPORTED_REMEDY
+			);
+		}
+
+		const stagingRoot = path.join(os.tmpdir(), `ungate-cloudflared-${process.pid}-${Date.now()}`);
+		const downloadPath = path.join(stagingRoot, artifact.url.slice(artifact.url.lastIndexOf('/') + 1));
+
+		try {
+			fs.mkdirSync(stagingRoot, { recursive: true });
+
+			// Verified before extraction and before any chmod/copy of an executable.
+			await VerifiedArtifact.download(artifact, downloadPath);
+
+			const stagedBinary = artifact.archived ? this.extractTarball(downloadPath, stagingRoot) : downloadPath;
+
+			fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
+			fs.copyFileSync(stagedBinary, binaryPath);
+
+			if (process.platform !== 'win32') {
+				fs.chmodSync(binaryPath, 0o755);
+			}
+
+			InstallStamp.write(binaryPath, artifact);
+
+			return binaryPath;
+		} finally {
+			fs.rmSync(stagingRoot, { recursive: true, force: true });
+		}
+	}
+
+	private static getPinnedArtifact(): CloudflaredArtifact | null {
+		const entry = CLOUDFLARED_ARTIFACTS[`${process.platform}-${process.arch}`];
+
+		if (!entry) {
+			return null;
+		}
+
+		return { url: `${RELEASE_BASE}/${entry.file}`, sha256: entry.sha256, archived: entry.archived };
+	}
+
+	private static extractTarball(tarballPath: string, stagingRoot: string): string {
+		execFileSync('tar', ['-xzf', tarballPath, '-C', stagingRoot]);
+
+		const extracted = path.join(stagingRoot, 'cloudflared');
+
+		if (!fs.existsSync(extracted)) {
+			throw new Error(`cloudflared ${CLOUDFLARED_VERSION} archive did not contain a cloudflared executable`);
+		}
+
+		return extracted;
+	}
+}

--- a/apps/extension/src/utils/sqlite3-cli-resolver.ts
+++ b/apps/extension/src/utils/sqlite3-cli-resolver.ts
@@ -4,19 +4,46 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from './verified-artifact';
+
 const execFileAsync = promisify(execFile);
 
 const BIN_DIR = path.join(os.homedir(), '.ungate', 'bin');
 const SQLITE_TOOLS_VERSION = '3470200';
 const SQLITE_YEAR = '2024';
 
+/**
+ * SHA-256 of the exact sqlite.org release archives for {@link SQLITE_TOOLS_VERSION}.
+ * sqlite.org publishes only these three tool bundles for 3.47.2 — there is no
+ * macOS arm64 or Linux arm64 archive, so those hosts must supply their own CLI.
+ * Regenerate by hashing the URLs below after bumping the version and year.
+ */
+const SQLITE_TOOLS_ARTIFACTS: Record<string, { readonly file: string; readonly sha256: string }> = {
+	'darwin-x64': {
+		file: `sqlite-tools-osx-x64-${SQLITE_TOOLS_VERSION}.zip`,
+		sha256: '5f7d782ded38a56377eb34b38a8020e9c2c6f908109c904fe4e032f4a8ea54d0'
+	},
+	'linux-x64': {
+		file: `sqlite-tools-linux-x64-${SQLITE_TOOLS_VERSION}.zip`,
+		sha256: '9043648ac1186308c212c82d32327f0f1351fdf9dfb56a2a58bcf9bc947e3f90'
+	},
+	'win32-x64': {
+		file: `sqlite-tools-win-x64-${SQLITE_TOOLS_VERSION}.zip`,
+		sha256: '8c7fffbf4eec1f43e63153cca6deb018e4360d4d6b0d99bbdd2a541c53b7fa1c'
+	}
+};
+
+const UNSUPPORTED_REMEDY =
+	'Install the sqlite3 command-line tool yourself so it is discoverable on PATH (macOS: `brew install sqlite`, Debian/Ubuntu: `apt install sqlite3`).';
+
 type InstallLogger = (message: string) => void;
 
 export class Sqlite3CliResolver {
 	static async resolve(onLog?: InstallLogger): Promise<string | null> {
+		const artifact = this.getPinnedArtifact();
 		const installedPath = this.getInstalledPath();
 
-		if (fs.existsSync(installedPath)) {
+		if (artifact && fs.existsSync(installedPath) && InstallStamp.matches(installedPath, artifact)) {
 			return installedPath;
 		}
 
@@ -26,7 +53,20 @@ export class Sqlite3CliResolver {
 			return systemPath;
 		}
 
-		return this.downloadAndInstall(onLog);
+		if (!artifact) {
+			onLog?.(
+				VerifiedArtifact.unsupportedError(
+					`SQLite CLI ${SQLITE_TOOLS_VERSION}`,
+					`${process.platform}-${process.arch}`,
+					Object.keys(SQLITE_TOOLS_ARTIFACTS),
+					UNSUPPORTED_REMEDY
+				).message
+			);
+
+			return null;
+		}
+
+		return this.downloadAndInstall(artifact, onLog);
 	}
 
 	static getBinaryName(): string {
@@ -62,59 +102,36 @@ export class Sqlite3CliResolver {
 		return null;
 	}
 
-	private static getDownloadUrl(): string | null {
-		const { platform, arch } = process;
+	/**
+	 * Returns the pinned archive for the current host, or `null` when upstream
+	 * publishes nothing for this platform/arch. A `null` result must never be
+	 * turned into a download attempt.
+	 */
+	private static getPinnedArtifact(): PinnedArtifact | null {
+		const entry = SQLITE_TOOLS_ARTIFACTS[`${process.platform}-${process.arch}`];
 
-		if (platform === 'win32' && arch === 'x64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-win-x64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'darwin' && arch === 'arm64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-osx-aarch64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'darwin' && (arch === 'x64' || arch === 'x86_64')) {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-osx-x86-64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'linux' && arch === 'x64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-linux-x64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		if (platform === 'linux' && arch === 'arm64') {
-			return `https://www.sqlite.org/${SQLITE_YEAR}/sqlite-tools-linux-aarch64-${SQLITE_TOOLS_VERSION}.zip`;
-		}
-
-		return null;
-	}
-
-	private static async downloadAndInstall(onLog?: InstallLogger): Promise<string | null> {
-		const url = this.getDownloadUrl();
-
-		if (!url) {
-			onLog?.(`SQLite CLI is not supported on ${process.platform}-${process.arch}`);
-
+		if (!entry) {
 			return null;
 		}
 
-		const zipPath = path.join(os.tmpdir(), `ungate-sqlite3-${process.pid}-${Date.now()}.zip`);
-		const extractDir = path.join(os.tmpdir(), `ungate-sqlite3-${process.pid}-${Date.now()}`);
+		return {
+			url: `https://www.sqlite.org/${SQLITE_YEAR}/${entry.file}`,
+			sha256: entry.sha256
+		};
+	}
+
+	private static async downloadAndInstall(artifact: PinnedArtifact, onLog?: InstallLogger): Promise<string | null> {
+		const stagingRoot = path.join(os.tmpdir(), `ungate-sqlite3-${process.pid}-${Date.now()}`);
+		const zipPath = path.join(stagingRoot, 'sqlite-tools.zip');
+		const extractDir = path.join(stagingRoot, 'extracted');
+		const installedPath = this.getInstalledPath();
 
 		try {
 			onLog?.('Downloading SQLite CLI...');
-			fs.mkdirSync(BIN_DIR, { recursive: true });
 			fs.mkdirSync(extractDir, { recursive: true });
 
-			const response = await fetch(url);
-
-			if (!response.ok) {
-				throw new Error(`HTTP ${response.status}`);
-			}
-
-			const arrayBuffer = await response.arrayBuffer();
-			const zipBytes = Buffer.from(arrayBuffer);
-
-			fs.writeFileSync(zipPath, zipBytes);
+			// Verified before extraction: a tampered archive never reaches unzip.
+			await VerifiedArtifact.download(artifact, zipPath);
 			await this.extractZip(zipPath, extractDir);
 
 			const extractedBinary = this.findExtractedBinary(extractDir);
@@ -123,22 +140,23 @@ export class Sqlite3CliResolver {
 				throw new Error('sqlite3 binary was not found in the downloaded archive');
 			}
 
-			fs.copyFileSync(extractedBinary, this.getInstalledPath());
+			fs.mkdirSync(BIN_DIR, { recursive: true });
+			fs.copyFileSync(extractedBinary, installedPath);
 
 			if (process.platform !== 'win32') {
-				fs.chmodSync(this.getInstalledPath(), 0o755);
+				fs.chmodSync(installedPath, 0o755);
 			}
 
+			InstallStamp.write(installedPath, artifact);
 			onLog?.('SQLite CLI installed');
 
-			return this.getInstalledPath();
+			return installedPath;
 		} catch (error) {
 			onLog?.(`Failed to install SQLite CLI: ${String(error)}`);
 
 			return null;
 		} finally {
-			fs.rmSync(zipPath, { force: true });
-			fs.rmSync(extractDir, { recursive: true, force: true });
+			fs.rmSync(stagingRoot, { recursive: true, force: true });
 		}
 	}
 

--- a/apps/extension/src/utils/verified-artifact.ts
+++ b/apps/extension/src/utils/verified-artifact.ts
@@ -1,0 +1,114 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import * as fs from 'node:fs';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const USER_AGENT = 'ungate-extension';
+const SHA256_HEX_LENGTH = 64;
+const STAMP_SUFFIX = '.sha256';
+
+export interface PinnedArtifact {
+	/** Absolute upstream release URL. Must point at an immutable, versioned artifact. */
+	readonly url: string;
+	/** Lowercase hex SHA-256 of the exact upstream bytes. */
+	readonly sha256: string;
+}
+
+/**
+ * Downloads pinned upstream artifacts and refuses to hand anything back until the
+ * bytes hash to the expected SHA-256. Nothing is copied, chmod-ed or executed by
+ * this module: callers only ever see a staging path that already passed verification.
+ */
+export class VerifiedArtifact {
+	/**
+	 * Streams `artifact` to `destPath` while hashing, then verifies the digest.
+	 * On any failure the partial file is removed and the error is rethrown, so a
+	 * rejected download can never leave a usable file behind.
+	 */
+	static async download(artifact: PinnedArtifact, destPath: string): Promise<void> {
+		const expected = this.parseDigest(artifact.sha256);
+		const response = await fetch(artifact.url, {
+			headers: { 'User-Agent': USER_AGENT },
+			redirect: 'follow'
+		});
+
+		if (!response.ok) {
+			throw new Error(`Download failed for ${artifact.url}: HTTP ${response.status}`);
+		}
+
+		if (!response.body) {
+			throw new Error(`Download failed for ${artifact.url}: empty response body`);
+		}
+
+		const hash = createHash('sha256');
+
+		try {
+			await pipeline(
+				Readable.fromWeb(response.body),
+				async function* (source: AsyncIterable<Uint8Array>) {
+					for await (const chunk of source) {
+						hash.update(chunk);
+						yield chunk;
+					}
+				},
+				fs.createWriteStream(destPath)
+			);
+
+			const actual = hash.digest();
+
+			if (!timingSafeEqual(actual, expected)) {
+				throw new Error(
+					`Checksum mismatch for ${artifact.url}: expected sha256 ${artifact.sha256}, got ${actual.toString('hex')}. ` +
+						'The artifact was rejected and discarded.'
+				);
+			}
+		} catch (error) {
+			fs.rmSync(destPath, { force: true });
+			throw error;
+		}
+	}
+
+	/**
+	 * Fail-closed error for a host tuple that has no pinned artifact. Unknown
+	 * tuples must never trigger a download, so the message has to tell the user
+	 * what is supported and how to work around the gap.
+	 */
+	static unsupportedError(subject: string, tuple: string, supported: readonly string[], remedy: string): Error {
+		return new Error(
+			`${subject} has no pinned, checksum-verified artifact for ${tuple}. ` +
+				`Supported: ${[...supported].sort().join(', ')}. ${remedy}`
+		);
+	}
+
+	private static parseDigest(sha256: string): Buffer {
+		if (sha256.length !== SHA256_HEX_LENGTH || !/^[0-9a-f]+$/.test(sha256)) {
+			throw new Error(`Malformed pinned SHA-256 digest: ${sha256}`);
+		}
+
+		return Buffer.from(sha256, 'hex');
+	}
+}
+
+/**
+ * Records which pinned artifact produced a managed binary in `~/.ungate/bin`.
+ * Installs made before artifact pinning existed carry no stamp, so they are
+ * treated as unverified and replaced instead of reused.
+ */
+export class InstallStamp {
+	/** The recorded digest, or `null` when the binary carries no stamp at all. */
+	static read(binaryPath: string): string | null {
+		try {
+			return fs.readFileSync(`${binaryPath}${STAMP_SUFFIX}`, 'utf8').trim();
+		} catch {
+			return null;
+		}
+	}
+
+	static matches(binaryPath: string, artifact: PinnedArtifact): boolean {
+		return this.read(binaryPath) === artifact.sha256;
+	}
+
+	static write(binaryPath: string, artifact: PinnedArtifact): void {
+		fs.writeFileSync(`${binaryPath}${STAMP_SUFFIX}`, artifact.sha256, 'utf8');
+	}
+}

--- a/apps/extension/tests/unit/better-sqlite3-installer.test.ts
+++ b/apps/extension/tests/unit/better-sqlite3-installer.test.ts
@@ -1,5 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+const PINNED_VERSION = '12.11.1';
+const WIN32_X64_ABI137_SHA256 = '4ee5e653174d6ddd301605d351798cdae2613da06c4f37ecdce263021fcf1255';
+
+/** Staging directory prefix used by BetterSqlite3Installer.install for the extracted archive. */
+const STAGING_PREFIX = 'ungate-better-sqlite3-';
+
+/** Serves the pinned checksum stamp for `<binary>.sha256` and the bundled package.json otherwise. */
+function readStampedFile(target: unknown): string {
+	if (String(target).endsWith('.sha256')) {
+		return WIN32_X64_ABI137_SHA256;
+	}
+
+	return JSON.stringify({ version: PINNED_VERSION });
+}
+
 const execFileMock = vi.fn();
 const existsSyncMock = vi.fn();
 const fetchMock = vi.fn();
@@ -7,6 +22,11 @@ const copyFileSyncMock = vi.fn();
 const renameSyncMock = vi.fn();
 const rmSyncMock = vi.fn();
 const mkdirSyncMock = vi.fn();
+const writeFileSyncMock = vi.fn();
+const readFileSyncMock = vi.fn(readStampedFile);
+const inspectMock = vi.fn(() => {
+	return { abi: '137', platform: 'win32', arch: 'x64' };
+});
 
 vi.mock('node:child_process', () => {
 	return {
@@ -17,12 +37,13 @@ vi.mock('node:child_process', () => {
 vi.mock('node:fs', () => {
 	return {
 		existsSync: (...args: unknown[]) => existsSyncMock(...args),
-		readFileSync: vi.fn(() => JSON.stringify({ version: '11.10.0' })),
+		readFileSync: (...args: unknown[]) => readFileSyncMock(...args),
 		realpathSync: vi.fn((target: string) => target),
 		mkdirSync: (...args: unknown[]) => mkdirSyncMock(...args),
 		copyFileSync: (...args: unknown[]) => copyFileSyncMock(...args),
 		rmSync: (...args: unknown[]) => rmSyncMock(...args),
-		renameSync: (...args: unknown[]) => renameSyncMock(...args)
+		renameSync: (...args: unknown[]) => renameSyncMock(...args),
+		writeFileSync: (...args: unknown[]) => writeFileSyncMock(...args)
 	};
 });
 
@@ -37,9 +58,7 @@ vi.mock('../../src/utils/cross-process-lock', () => {
 vi.mock('../../src/utils/node-resolver', () => {
 	return {
 		NodeResolver: {
-			inspect: vi.fn(() => {
-				return { abi: '137', platform: 'win32', arch: 'x64' };
-			})
+			inspect: (...args: unknown[]) => inspectMock(...args)
 		}
 	};
 });
@@ -65,6 +84,7 @@ vi.mock('../../src/runtime-state', () => {
 });
 
 import { BetterSqlite3Installer } from '../../src/utils/better-sqlite3-installer';
+import { VerifiedArtifact, type PinnedArtifact } from '../../src/utils/verified-artifact';
 
 type ExecFileCallback = (error: Error | null, result: { stdout: string; stderr: string }) => void;
 
@@ -72,6 +92,19 @@ function mockExecFileSuccess(): void {
 	execFileMock.mockImplementation((_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
 		callback(null, { stdout: '', stderr: '' });
 	});
+}
+
+function mockExecFileFailure(): void {
+	execFileMock.mockImplementation((_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
+		const error = new Error('load failed') as Error & { stderr?: string };
+		error.stderr = '';
+		callback(error, { stdout: '', stderr: '' });
+	});
+}
+
+/** Archive extraction is a private static; spying on it keeps the test off the filesystem. */
+function privateApi(): { extractArchive(archivePath: string, extractDir: string): Promise<void> } {
+	return BetterSqlite3Installer as unknown as { extractArchive(archivePath: string, extractDir: string): Promise<void> };
 }
 
 describe('BetterSqlite3Installer', () => {
@@ -87,13 +120,19 @@ describe('BetterSqlite3Installer', () => {
 		renameSyncMock.mockReset();
 		rmSyncMock.mockReset();
 		mkdirSyncMock.mockReset();
+		writeFileSyncMock.mockReset();
+		readFileSyncMock.mockReset();
+		readFileSyncMock.mockImplementation(readStampedFile);
+		inspectMock.mockReset();
+		inspectMock.mockReturnValue({ abi: '137', platform: 'win32', arch: 'x64' });
 	});
 
 	afterEach(() => {
 		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
 	});
 
-	it('skips download when the installed native binary already loads', async () => {
+	it('skips download when a pin-stamped installed native binary already loads', async () => {
 		mockExecFileSuccess();
 		existsSyncMock.mockImplementation((target) => String(target).endsWith('better_sqlite3.installed.node'));
 
@@ -107,6 +146,81 @@ describe('BetterSqlite3Installer', () => {
 
 		expect(script).toContain('nativeBinding');
 		expect(script).toContain('better_sqlite3.installed.node');
+	});
+
+	it('ignores an unstamped legacy managed binary and probes the bundled binding instead', async () => {
+		mockExecFileSuccess();
+		existsSyncMock.mockReturnValue(true);
+		readFileSyncMock.mockImplementation((target: unknown) => {
+			if (String(target).endsWith('.sha256')) {
+				throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			}
+
+			return JSON.stringify({ version: PINNED_VERSION });
+		});
+
+		await BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() });
+
+		const probedScripts = execFileMock.mock.calls.map(([, args]) => (Array.isArray(args) ? String(args[1]) : ''));
+
+		expect(probedScripts).toHaveLength(1);
+		expect(probedScripts[0]).not.toContain('better_sqlite3.installed.node');
+		expect(probedScripts[0]).toContain('build/Release/better_sqlite3.node');
+	});
+
+	it('replaces a managed binary whose stamp is not a pinned digest, then stamps the verified one', async () => {
+		let stamp = 'deadbeef'.repeat(8);
+
+		mockExecFileSuccess();
+		existsSyncMock.mockImplementation((target) => {
+			const value = String(target);
+
+			// The managed binary exists (with a foreign stamp) and so does the extracted
+			// staging binary; the bundled default binding does not, so canLoad has nothing
+			// trustworthy to probe and install has to run.
+			return value.endsWith('better_sqlite3.installed.node') || value.includes(STAGING_PREFIX);
+		});
+		readFileSyncMock.mockImplementation((target: unknown) =>
+			String(target).endsWith('.sha256') ? stamp : JSON.stringify({ version: PINNED_VERSION })
+		);
+		writeFileSyncMock.mockImplementation((target: unknown, data: unknown) => {
+			if (String(target).endsWith('.sha256')) {
+				stamp = String(data);
+			}
+		});
+
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download').mockResolvedValue(undefined);
+
+		vi.spyOn(privateApi(), 'extractArchive').mockResolvedValue(undefined);
+
+		await BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() });
+
+		expect(downloadSpy).toHaveBeenCalledTimes(1);
+		expect(writeFileSyncMock).toHaveBeenCalledWith(
+			expect.stringContaining('better_sqlite3.installed.node.sha256'),
+			WIN32_X64_ABI137_SHA256,
+			'utf8'
+		);
+		expect(stamp).toBe(WIN32_X64_ABI137_SHA256);
+	});
+
+	it('hands the API child the managed binding only once it carries a pinned stamp', () => {
+		existsSyncMock.mockReturnValue(true);
+
+		expect(BetterSqlite3Installer.resolveBindingPath('/tmp/ungate-api')).toContain('better_sqlite3.installed.node');
+
+		readFileSyncMock.mockImplementation((target: unknown) => {
+			if (String(target).endsWith('.sha256')) {
+				throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+			}
+
+			return JSON.stringify({ version: PINNED_VERSION });
+		});
+
+		const fallback = BetterSqlite3Installer.resolveBindingPath('/tmp/ungate-api');
+
+		expect(fallback).toContain('better_sqlite3.node');
+		expect(fallback).not.toContain('better_sqlite3.installed.node');
 	});
 
 	it('does not call https when a concurrent install already made the binary loadable', async () => {
@@ -141,7 +255,7 @@ describe('BetterSqlite3Installer', () => {
 		expect(execFileMock).not.toHaveBeenCalled();
 	});
 
-	it('stores the downloaded binary in the installed native path', async () => {
+	it('installs the pinned prebuild matching the host ABI tuple', async () => {
 		execFileMock
 			.mockImplementationOnce((_file: string, _args: string[], _options: unknown, callback: ExecFileCallback) => {
 				const error = new Error('load failed') as Error & { stderr?: string };
@@ -167,17 +281,63 @@ describe('BetterSqlite3Installer', () => {
 
 			return false;
 		});
-		const installer = BetterSqlite3Installer as unknown as {
-			downloadAndExtract(url: string, extractDir: string): Promise<void>;
-		};
 
-		installer.downloadAndExtract = vi.fn().mockResolvedValue(undefined);
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download').mockResolvedValue(undefined);
+
+		vi.spyOn(privateApi(), 'extractArchive').mockResolvedValue(undefined);
 
 		await BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() });
 
+		const artifact = downloadSpy.mock.calls[0]?.[0] as PinnedArtifact | undefined;
+
+		expect(artifact?.url).toBe(
+			`https://github.com/WiseLibs/better-sqlite3/releases/download/v${PINNED_VERSION}/better-sqlite3-v${PINNED_VERSION}-node-v137-win32-x64.tar.gz`
+		);
+		expect(artifact?.sha256).toBe(WIN32_X64_ABI137_SHA256);
 		expect(renameSyncMock).toHaveBeenCalledWith(
 			expect.stringContaining('better_sqlite3.installed.node'),
 			expect.stringContaining('better_sqlite3.installed.node')
 		);
+	});
+
+	it('fails closed for an ABI tuple that has no pinned checksum', async () => {
+		mockExecFileFailure();
+		existsSyncMock.mockReturnValue(true);
+		inspectMock.mockReturnValue({ abi: '115', platform: 'linux', arch: 'x64' });
+
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download');
+
+		await expect(BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() })).rejects.toThrow(
+			/no pinned, checksum-verified artifact for node-v115-linux-x64/
+		);
+
+		expect(downloadSpy).not.toHaveBeenCalled();
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('fails closed for a musl-only tuple that shares process.platform with glibc', async () => {
+		mockExecFileFailure();
+		existsSyncMock.mockReturnValue(true);
+		inspectMock.mockReturnValue({ abi: '137', platform: 'linuxmusl', arch: 'x64' });
+
+		await expect(BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() })).rejects.toThrow(
+			/no pinned, checksum-verified artifact for node-v137-linuxmusl-x64/
+		);
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('refuses to install when the bundled version drifts from the pinned checksums', async () => {
+		mockExecFileFailure();
+		existsSyncMock.mockReturnValue(true);
+		readFileSyncMock.mockReturnValue(JSON.stringify({ version: '12.12.0' }));
+
+		const downloadSpy = vi.spyOn(VerifiedArtifact, 'download');
+
+		await expect(BetterSqlite3Installer.ensureInstalled('/tmp/ungate-api', 'node', { onLog: vi.fn() })).rejects.toThrow(
+			`[native] better-sqlite3 12.12.0 is bundled but only ${PINNED_VERSION} has pinned checksums`
+		);
+
+		expect(downloadSpy).not.toHaveBeenCalled();
 	});
 });

--- a/apps/extension/tests/unit/cloudflared-installer.test.ts
+++ b/apps/extension/tests/unit/cloudflared-installer.test.ts
@@ -1,0 +1,118 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import { CLOUDFLARED_VERSION, CloudflaredInstaller } from '../../src/utils/cloudflared-installer';
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from '../../src/utils/verified-artifact';
+
+const LINUX_X64_SHA256 = 'fcfb02b575a52ca1af2e3267af4e1517bcdeb30ac48c834c69abaed3c0576ad2';
+
+function forceHost(platform: string, arch: string): void {
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+	Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+describe('CloudflaredInstaller', () => {
+	const originalPlatform = process.platform;
+	const originalArch = process.arch;
+	let binDir: string;
+	let fetchMock: Mock;
+
+	beforeEach(() => {
+		binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ungate-cloudflared-'));
+		fetchMock = vi.fn();
+		vi.stubGlobal('fetch', fetchMock);
+	});
+
+	afterEach(() => {
+		forceHost(originalPlatform, originalArch);
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		fs.rmSync(binDir, { recursive: true, force: true });
+	});
+
+	it('installs, marks executable and stamps the pinned artifact', async () => {
+		forceHost('linux', 'x64');
+
+		const downloadSpy = vi
+			.spyOn(VerifiedArtifact, 'download')
+			.mockImplementation((_artifact: PinnedArtifact, destPath: string) => {
+				fs.mkdirSync(path.dirname(destPath), { recursive: true });
+				fs.writeFileSync(destPath, 'verified-cloudflared');
+
+				return Promise.resolve();
+			});
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+		const installed = await CloudflaredInstaller.install(binaryPath);
+
+		expect(installed).toBe(binaryPath);
+		expect(fs.readFileSync(binaryPath, 'utf8')).toBe('verified-cloudflared');
+		expect(fs.statSync(binaryPath).mode & 0o777).toBe(0o755);
+		expect(fs.readFileSync(`${binaryPath}.sha256`, 'utf8')).toBe(LINUX_X64_SHA256);
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(true);
+
+		const artifact = downloadSpy.mock.calls[0]?.[0];
+
+		expect(artifact?.url).toBe(
+			`https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64`
+		);
+		expect(artifact?.sha256).toBe(LINUX_X64_SHA256);
+	});
+
+	it('rejects a tampered download without leaving an executable behind', async () => {
+		forceHost('linux', 'x64');
+		fetchMock.mockResolvedValue(new Response('tampered-cloudflared'));
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+
+		await expect(CloudflaredInstaller.install(binaryPath)).rejects.toThrow(/Checksum mismatch/);
+
+		expect(fs.existsSync(binaryPath)).toBe(false);
+		expect(fs.existsSync(`${binaryPath}.sha256`)).toBe(false);
+	});
+
+	it('fails closed on an unsupported platform without downloading anything', async () => {
+		forceHost('sunos', 'x64');
+
+		let message = '';
+
+		try {
+			await CloudflaredInstaller.install(path.join(binDir, 'cloudflared'));
+		} catch (error) {
+			message = error instanceof Error ? error.message : String(error);
+		}
+
+		expect(message).toContain('no pinned, checksum-verified artifact for sunos-x64');
+		expect(message).toContain('the built-in tunnel cannot start here');
+		// The remedy must not promise a manual drop-in: resolveUserBinaryPath rejects unstamped files.
+		expect(message).not.toContain('place it in ~/.ungate/bin');
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('ignores a binary left behind by an unverified latest install', () => {
+		forceHost('linux', 'x64');
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+
+		fs.writeFileSync(binaryPath, 'binary from an unpinned latest download');
+
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(false);
+
+		InstallStamp.write(binaryPath, { url: 'https://example.invalid/cloudflared', sha256: LINUX_X64_SHA256 });
+
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(true);
+	});
+
+	it('reports no pinned install on platforms with no pinned artifact', () => {
+		forceHost('sunos', 'x64');
+
+		const binaryPath = path.join(binDir, 'cloudflared');
+
+		fs.writeFileSync(binaryPath, 'anything');
+
+		expect(CloudflaredInstaller.isPinnedInstall(binaryPath)).toBe(false);
+	});
+});

--- a/apps/extension/tests/unit/sqlite3-cli-resolver.test.ts
+++ b/apps/extension/tests/unit/sqlite3-cli-resolver.test.ts
@@ -28,8 +28,27 @@ vi.mock('node:fs', async (importOriginal) => {
 });
 
 import { Sqlite3CliResolver } from '../../src/utils/sqlite3-cli-resolver';
+import { InstallStamp, VerifiedArtifact, type PinnedArtifact } from '../../src/utils/verified-artifact';
+
+const LINUX_X64_SHA256 = '9043648ac1186308c212c82d32327f0f1351fdf9dfb56a2a58bcf9bc947e3f90';
+const LINUX_X64_URL = 'https://www.sqlite.org/2024/sqlite-tools-linux-x64-3470200.zip';
+
+function forceHost(platform: string, arch: string): void {
+	Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+	Object.defineProperty(process, 'arch', { value: arch, configurable: true });
+}
+
+/** `which sqlite3` misses, so the resolver has to decide between a pinned download and failing closed. */
+function mockEmptyPath(): void {
+	mocks.execFileMock.mockImplementation((command: string, _args: string[], callback: (error: Error | null) => void) => {
+		callback(new Error(`not found: ${command}`));
+	});
+}
 
 describe('Sqlite3CliResolver', () => {
+	const originalPlatform = process.platform;
+	const originalArch = process.arch;
+
 	beforeEach(() => {
 		mocks.execFileMock.mockReset();
 		mocks.existsSyncMock.mockReset();
@@ -38,18 +57,45 @@ describe('Sqlite3CliResolver', () => {
 	});
 
 	afterEach(() => {
+		forceHost(originalPlatform, originalArch);
 		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
 	});
 
-	it('returns the bundled install path when it already exists', async () => {
-		mocks.existsSyncMock.mockImplementation(
-			(target) => String(target).endsWith('sqlite3.exe') || String(target).endsWith('/sqlite3')
-		);
+	it('returns the bundled install path when it was installed from the pinned archive', async () => {
+		forceHost('linux', 'x64');
+		mocks.existsSyncMock.mockImplementation((target) => String(target) === Sqlite3CliResolver.getInstalledPath());
+		vi.spyOn(InstallStamp, 'matches').mockReturnValue(true);
 
 		const resolved = await Sqlite3CliResolver.resolve();
 
 		expect(resolved).toBe(Sqlite3CliResolver.getInstalledPath());
 		expect(mocks.execFileMock).not.toHaveBeenCalled();
+	});
+
+	it('ignores an existing binary that carries no pinned checksum stamp', async () => {
+		forceHost('linux', 'x64');
+		mocks.existsSyncMock.mockImplementation((target) => {
+			const value = String(target);
+
+			return value === Sqlite3CliResolver.getInstalledPath() || value === '/usr/bin/sqlite3';
+		});
+		mocks.execFileMock.mockImplementation(
+			(command: string, args: string[], callback: (error: Error | null, result?: { stdout: string }) => void) => {
+				if (command === 'which' && args[0] === 'sqlite3') {
+					callback(null, { stdout: '/usr/bin/sqlite3\n' });
+
+					return;
+				}
+
+				callback(new Error('not found'));
+			}
+		);
+
+		const resolved = await Sqlite3CliResolver.resolve();
+
+		expect(resolved).toBe('/usr/bin/sqlite3');
+		expect(mocks.fetchMock).not.toHaveBeenCalled();
 	});
 
 	it('falls back to sqlite3 from PATH before downloading', async () => {
@@ -73,9 +119,7 @@ describe('Sqlite3CliResolver', () => {
 	});
 
 	it('uses where.exe on win32 when searching PATH', async () => {
-		const originalPlatform = process.platform;
-
-		Object.defineProperty(process, 'platform', { value: 'win32' });
+		forceHost('win32', 'x64');
 		mocks.existsSyncMock.mockImplementation((target) => String(target) === 'C:\\Tools\\sqlite3.exe');
 		mocks.execFileMock.mockImplementation(
 			(command: string, args: string[], callback: (error: Error | null, result: { stdout: string }) => void) => {
@@ -91,12 +135,12 @@ describe('Sqlite3CliResolver', () => {
 
 		const resolved = await Sqlite3CliResolver.resolve();
 
-		Object.defineProperty(process, 'platform', { value: originalPlatform });
-
 		expect(resolved).toBe('C:\\Tools\\sqlite3.exe');
 	});
 
-	it('downloads sqlite3 into ~/.ungate/bin when nothing is available locally', async () => {
+	it('downloads the pinned archive into ~/.ungate/bin when nothing is available locally', async () => {
+		forceHost('linux', 'x64');
+
 		const installedPath = Sqlite3CliResolver.getInstalledPath();
 
 		mocks.existsSyncMock.mockImplementation((target) => {
@@ -106,35 +150,67 @@ describe('Sqlite3CliResolver', () => {
 		});
 		mocks.execFileMock.mockImplementation(
 			(command: string, args: string[], callback: (error: Error | null, result?: { stdout: string }) => void) => {
-				if (command === 'which') {
-					callback(new Error('not found'));
-
-					return;
-				}
-
 				if (command === 'unzip') {
 					const destDir = args[args.indexOf('-d') + 1];
 
 					fs.mkdirSync(destDir, { recursive: true });
-					fs.writeFileSync(path.join(destDir, Sqlite3CliResolver.getBinaryName()), '');
+					fs.writeFileSync(path.join(destDir, 'sqlite3'), '');
 					callback(null);
 
 					return;
 				}
 
-				callback(new Error(`unexpected command: ${command}`));
+				callback(new Error(`not found: ${command}`));
 			}
 		);
-		mocks.fetchMock.mockResolvedValue({
-			ok: true,
-			arrayBuffer: () => Promise.resolve(new Uint8Array([0x50, 0x4b, 0x03, 0x04]).buffer)
-		});
+
+		const downloadSpy = vi
+			.spyOn(VerifiedArtifact, 'download')
+			.mockImplementation((_artifact: PinnedArtifact, destPath: string) => {
+				fs.mkdirSync(path.dirname(destPath), { recursive: true });
+				fs.writeFileSync(destPath, 'verified-zip');
+
+				return Promise.resolve();
+			});
 
 		const resolved = await Sqlite3CliResolver.resolve();
+		const artifact = downloadSpy.mock.calls[0]?.[0];
 
 		fs.rmSync(installedPath, { force: true });
+		fs.rmSync(`${installedPath}.sha256`, { force: true });
 
 		expect(resolved).toBe(installedPath);
-		expect(mocks.fetchMock).toHaveBeenCalledWith(expect.stringMatching(/^https:\/\/www\.sqlite\.org\/\d{4}\/sqlite-tools-/));
+		expect(artifact?.url).toBe(LINUX_X64_URL);
+		expect(artifact?.sha256).toBe(LINUX_X64_SHA256);
+	});
+
+	it('rejects a tampered archive before extraction and installs nothing', async () => {
+		forceHost('linux', 'x64');
+		mocks.existsSyncMock.mockReturnValue(false);
+		mockEmptyPath();
+		mocks.fetchMock.mockResolvedValue(new Response('tampered-sqlite-tools-zip'));
+
+		const logs: string[] = [];
+		const resolved = await Sqlite3CliResolver.resolve((message) => logs.push(message));
+
+		expect(resolved).toBeNull();
+		expect(logs.join('\n')).toMatch(/Checksum mismatch/);
+		expect(mocks.execFileMock.mock.calls.some(([command]) => command === 'unzip')).toBe(false);
+	});
+
+	it('fails closed with an actionable message where upstream publishes no archive', async () => {
+		forceHost('darwin', 'arm64');
+		mocks.existsSyncMock.mockReturnValue(false);
+		mockEmptyPath();
+
+		const logs: string[] = [];
+		const resolved = await Sqlite3CliResolver.resolve((message) => logs.push(message));
+		const log = logs.join('\n');
+
+		expect(resolved).toBeNull();
+		expect(log).toContain('no pinned, checksum-verified artifact for darwin-arm64');
+		expect(log).toContain('darwin-x64, linux-x64, win32-x64');
+		expect(log).toContain('brew install sqlite');
+		expect(mocks.fetchMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/extension/tests/unit/tunnel-manager-binary-path.test.ts
+++ b/apps/extension/tests/unit/tunnel-manager-binary-path.test.ts
@@ -7,7 +7,6 @@ const mocks = vi.hoisted(() => {
 	return {
 		existsSyncMock: vi.fn(),
 		renameSyncMock: vi.fn(),
-		installMock: vi.fn(),
 		useMock: vi.fn(),
 		binExport: '/dev/cloudflared-package/bin/cloudflared'
 	};
@@ -16,7 +15,6 @@ const mocks = vi.hoisted(() => {
 vi.mock('cloudflared', () => {
 	return {
 		bin: mocks.binExport,
-		install: mocks.installMock,
 		use: mocks.useMock,
 		Tunnel: {
 			quick: vi.fn(() => ({
@@ -48,66 +46,93 @@ vi.mock('../../src/runtime-state', () => {
 });
 
 import { TunnelManager } from '../../src/tunnel-manager';
+import { CloudflaredInstaller } from '../../src/utils/cloudflared-installer';
+
+function createManager(): TunnelManager {
+	return new TunnelManager(
+		'window-a',
+		() => true,
+		() => {},
+		() => {}
+	);
+}
 
 describe('TunnelManager cloudflared binary path', () => {
 	const binDir = path.join(os.homedir(), '.ungate', 'bin');
+	const originalPlatform = process.platform;
 
 	afterEach(() => {
+		Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
 		vi.clearAllMocks();
+		vi.restoreAllMocks();
 	});
 
-	it('installs cloudflared.exe on win32', async () => {
-		const originalPlatform = process.platform;
-
-		Object.defineProperty(process, 'platform', { value: 'win32' });
+	it('installs cloudflared.exe from the pinned artifact on win32', async () => {
+		Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
 		const expectedPath = path.join(binDir, 'cloudflared.exe');
 
 		mocks.existsSyncMock.mockReturnValue(false);
-		mocks.installMock.mockResolvedValue(expectedPath);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(false);
 
-		const manager = new TunnelManager(
-			'window-a',
-			() => true,
-			() => {},
-			() => {}
-		);
+		const installSpy = vi.spyOn(CloudflaredInstaller, 'install').mockResolvedValue(expectedPath);
 
-		await manager.start(47821);
+		await createManager().start(47821);
 
-		Object.defineProperty(process, 'platform', { value: originalPlatform });
-
-		expect(mocks.installMock).toHaveBeenCalledWith(expectedPath);
+		expect(installSpy).toHaveBeenCalledWith(expectedPath);
 		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
 	});
 
-	it('renames a legacy Windows install without .exe extension', async () => {
-		const originalPlatform = process.platform;
+	it('reuses a managed binary that carries the pinned checksum stamp', async () => {
+		Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
-		Object.defineProperty(process, 'platform', { value: 'win32' });
+		const expectedPath = path.join(binDir, 'cloudflared.exe');
+
+		mocks.existsSyncMock.mockReturnValue(false);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(true);
+
+		const installSpy = vi.spyOn(CloudflaredInstaller, 'install');
+
+		await createManager().start(47821);
+
+		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
+		expect(installSpy).not.toHaveBeenCalled();
+	});
+
+	it('renames a legacy Windows install without .exe extension, then replaces it because it is unverified', async () => {
+		Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
 
 		const legacyPath = path.join(binDir, 'cloudflared');
 		const expectedPath = path.join(binDir, 'cloudflared.exe');
 
-		mocks.existsSyncMock.mockImplementation((target) => {
-			const value = String(target);
+		mocks.existsSyncMock.mockImplementation((target) => String(target) === legacyPath);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(false);
 
-			return value === legacyPath;
-		});
+		const installSpy = vi.spyOn(CloudflaredInstaller, 'install').mockResolvedValue(expectedPath);
 
-		const manager = new TunnelManager(
-			'window-a',
-			() => true,
-			() => {},
-			() => {}
-		);
+		await createManager().start(47821);
+
+		expect(mocks.renameSyncMock).toHaveBeenCalledWith(legacyPath, expectedPath);
+		expect(installSpy).toHaveBeenCalledWith(expectedPath);
+		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
+	});
+
+	it('surfaces a failed verification as a tunnel error instead of starting cloudflared', async () => {
+		Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+
+		mocks.existsSyncMock.mockReturnValue(false);
+		vi.spyOn(CloudflaredInstaller, 'isPinnedInstall').mockReturnValue(false);
+		vi.spyOn(CloudflaredInstaller, 'install').mockRejectedValue(new Error('Checksum mismatch for cloudflared-linux-amd64'));
+
+		const manager = createManager();
 
 		await manager.start(47821);
 
-		Object.defineProperty(process, 'platform', { value: originalPlatform });
-
-		expect(mocks.renameSyncMock).toHaveBeenCalledWith(legacyPath, expectedPath);
-		expect(mocks.useMock).toHaveBeenCalledWith(expectedPath);
-		expect(mocks.installMock).not.toHaveBeenCalled();
+		expect(manager.getState()).toEqual({
+			status: 'error',
+			url: null,
+			error: 'Install failed: Checksum mismatch for cloudflared-linux-amd64'
+		});
+		expect(mocks.useMock).not.toHaveBeenCalled();
 	});
 });

--- a/apps/extension/tests/unit/verified-artifact.test.ts
+++ b/apps/extension/tests/unit/verified-artifact.test.ts
@@ -1,0 +1,122 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InstallStamp, VerifiedArtifact } from '../../src/utils/verified-artifact';
+
+const PAYLOAD = Buffer.from('ungate pinned artifact payload');
+const PAYLOAD_SHA256 = createHash('sha256').update(PAYLOAD).digest('hex');
+const OTHER_SHA256 = createHash('sha256').update('a different artifact').digest('hex');
+
+function respondWith(body: Buffer): void {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(() => Promise.resolve(new Response(new Uint8Array(body))))
+	);
+}
+
+describe('VerifiedArtifact', () => {
+	let stagingRoot: string;
+
+	beforeEach(() => {
+		stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ungate-verified-artifact-'));
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+		fs.rmSync(stagingRoot, { recursive: true, force: true });
+	});
+
+	it('writes the artifact when the streamed bytes match the pinned digest', async () => {
+		respondWith(PAYLOAD);
+
+		const destPath = path.join(stagingRoot, 'artifact.bin');
+
+		await VerifiedArtifact.download({ url: 'https://example.invalid/artifact.bin', sha256: PAYLOAD_SHA256 }, destPath);
+
+		expect(fs.readFileSync(destPath)).toEqual(PAYLOAD);
+	});
+
+	it('rejects a one-byte modification and discards the staged file', async () => {
+		const tampered = Buffer.from(PAYLOAD);
+
+		tampered[0] ^= 0x01;
+		respondWith(tampered);
+
+		const destPath = path.join(stagingRoot, 'artifact.bin');
+
+		await expect(
+			VerifiedArtifact.download({ url: 'https://example.invalid/artifact.bin', sha256: PAYLOAD_SHA256 }, destPath)
+		).rejects.toThrow(/Checksum mismatch/);
+
+		expect(fs.existsSync(destPath)).toBe(false);
+	});
+
+	it('discards the staged file when the response is not ok', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => Promise.resolve(new Response('nope', { status: 404 })))
+		);
+
+		const destPath = path.join(stagingRoot, 'artifact.bin');
+
+		await expect(
+			VerifiedArtifact.download({ url: 'https://example.invalid/artifact.bin', sha256: PAYLOAD_SHA256 }, destPath)
+		).rejects.toThrow('HTTP 404');
+
+		expect(fs.existsSync(destPath)).toBe(false);
+	});
+
+	it('refuses a malformed pinned digest before making a request', async () => {
+		const fetchMock = vi.fn();
+
+		vi.stubGlobal('fetch', fetchMock);
+
+		await expect(
+			VerifiedArtifact.download(
+				{ url: 'https://example.invalid/artifact.bin', sha256: 'not-a-digest' },
+				path.join(stagingRoot, 'artifact.bin')
+			)
+		).rejects.toThrow(/Malformed pinned SHA-256 digest/);
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it('names the host tuple, the supported tuples and a remedy when nothing is pinned', () => {
+		const error = VerifiedArtifact.unsupportedError('cloudflared 1.2.3', 'sunos-mips', ['linux-x64', 'darwin-arm64'], 'Do X.');
+
+		expect(error.message).toContain('sunos-mips');
+		expect(error.message).toContain('darwin-arm64, linux-x64');
+		expect(error.message).toContain('Do X.');
+	});
+});
+
+describe('InstallStamp', () => {
+	let stagingRoot: string;
+
+	beforeEach(() => {
+		stagingRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ungate-install-stamp-'));
+	});
+
+	afterEach(() => {
+		fs.rmSync(stagingRoot, { recursive: true, force: true });
+	});
+
+	it('treats an unstamped binary as unverified and a stamped one as current', () => {
+		const artifact = { url: 'https://example.invalid/tool', sha256: PAYLOAD_SHA256 };
+		const binaryPath = path.join(stagingRoot, 'tool');
+
+		fs.writeFileSync(binaryPath, PAYLOAD);
+
+		expect(InstallStamp.matches(binaryPath, artifact)).toBe(false);
+
+		InstallStamp.write(binaryPath, artifact);
+
+		expect(InstallStamp.matches(binaryPath, artifact)).toBe(true);
+		expect(InstallStamp.matches(binaryPath, { ...artifact, sha256: OTHER_SHA256 })).toBe(false);
+	});
+});

--- a/scripts/reset-sqlite-binary/run.sh
+++ b/scripts/reset-sqlite-binary/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
-# Removes the runtime-installed better-sqlite3 binary so the extension
-# re-downloads it on the next API start (reproduces prebuild failures).
+# Removes the runtime-installed better-sqlite3 binary and its pinned-checksum
+# stamp so the extension re-downloads and re-verifies it on the next API start
+# (reproduces prebuild failures).
 
 rm -f apps/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node
-echo "removed better_sqlite3.installed.node"
+rm -f apps/api/node_modules/better-sqlite3/build/Release/better_sqlite3.installed.node.sha256
+echo "removed better_sqlite3.installed.node and its checksum stamp"


### PR DESCRIPTION
## Summary

- Pin and SHA-256 verify managed `cloudflared`, SQLite tools, and `better-sqlite3` downloads.
- Reject unsupported platform and ABI tuples before download.
- Refuse unstamped managed binaries left by older versions.
- Verify bytes before extraction, chmod, copy, or execution.

Pinned releases:

- `cloudflared` 2026.8.2
- SQLite tools 3.47.2
- `better-sqlite3` 12.11.1

This is split from #42 following review feedback.

## Verification

- Extension: 93 tests passed
- API unit: 88 tests passed
- API integration: 59 tests passed
- Extension lint and build passed
