### PR TITLE
fix(security): protect proxy administration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,17 +27,19 @@ Cursor → Cloudflare Tunnel → Ungate API → Provider API. Cursor cannot call
 Fastify server, spawned by the extension as a child Node.js process.
 
 **Entry points:**
-- `/v1/chat/completions` — OpenAI-compatible endpoint, accepts requests from Cursor
-- `/v1/messages` — Anthropic-compatible endpoint (direct proxy)
-- `/v1/analytics` — request statistics
-- `/v1/auth/*` — OAuth routes (Claude, ChatGPT)
-- `/v1/models` — model list
-- `/v1/settings` — settings
+- `/v1/chat/completions` — OpenAI-compatible endpoint, accepts requests from Cursor (proxy key)
+- `/v1/messages` — Anthropic-compatible endpoint (direct proxy, proxy key)
+- `/v1/models` — model list (proxy key)
+- `/v1/analytics` — request statistics (admin key)
+- `/v1/auth/*` — OAuth routes (Claude, ChatGPT) (admin key)
+- `/v1/settings` — settings (admin key)
+- `/health` — the only unauthenticated route; the extension polls it for liveness
 
 **Architecture:**
-- `src/server.ts` — Fastify initialization, plugin registration
-- `src/config.ts` — static configuration (URLs, OAuth, beta parameters)
-- `src/plugins/auth.ts` — preHandler for API-key authentication
+- `src/server.ts` — Fastify initialization, plugin registration. Binds `127.0.0.1` only (`LISTEN_HOST`); the Cloudflare tunnel is the sole remote path in.
+- `src/config.ts` — static configuration (URLs, OAuth, beta parameters). `getConfig` requires `UNGATE_ADMIN_KEY` in the environment and throws without it, so administrative routes can never come up unprotected.
+- `src/plugins/auth.ts` — `apiKeyAuth` (proxy key, `Authorization: Bearer` or `x-api-key`) and `adminKeyAuth` (admin key, `x-ungate-admin-key`). Both compare hashed digests through `timingSafeEqual`, and both fail closed: an absent or blank configured key rejects every request rather than opening the route. Registered as encapsulated `onRequest` hooks inside each route plugin, so a newly added route inherits its plugin's auth instead of defaulting to open.
+- `src/plugins/cors-origin.ts` — CORS origin policy: webview and loopback origins only, never a wildcard, so no web page can drive the dashboard API.
 
 **Routing (`src/routes/`):**
 - `openai.ts` — main router: determines provider by model (MiniMax → mapped → Claude). Branch order matters and must stay consistent.
@@ -105,11 +107,12 @@ Fastify server, spawned by the extension as a child Node.js process.
 
 User entry point. Manages the API server and tunnel lifecycle.
 
-- `extension.ts` — activate/deactivate
-- `extension-controller.ts` — main controller: manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
-- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex
+- `extension.ts` — activate/deactivate. `activate` is async: the admin key must be readable before anything starts
+- `extension-controller.ts` — main controller: loads the admin key, manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
+- `admin-key.ts` — owner of the administrative API key (`ungate.admin-api-key`) in VS Code SecretStorage. `AdminKey.load(storage)` mints a 256-bit base64url key on first run and replaces a stored value too short to carry 256 bits. The key reaches only the API child's environment and the dashboard webview — never SQLite, the runtime state file or the log
+- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex. Spawned with `UNGATE_ADMIN_KEY` in the environment
 - `tunnel-manager.ts` — Cloudflare tunnel (cloudflared) management. Quick tunnel only, no named tunnel config (avoids 404 conflicts). Not auto-started, only on explicit user action. Auto-restarts on port change if already running
-- `dashboard.ts` — WebView dashboard (Svelte UI). Reads `index.html` from `web/dist/`, rewrites `/assets/` to `vscode-resource:` URIs, injects `window.__PORT__`. Handshake: frontend sends `webview-ready` before extension sends initial state
+- `dashboard.ts` — WebView dashboard (Svelte UI). Reads `index.html` from `web/dist/`, rewrites `/assets/` to `vscode-resource:` URIs, injects `window.__PORT__` and `window.__ADMIN_KEY__` via `toInlineScriptJson` (JSON plus `<`/`>`/`&`/U+2028/U+2029 escaping, and a function replacer so `$&` patterns in a value are never expanded). Constructor takes `(context, adminApiKey, onMessage)`. Handshake: frontend sends `webview-ready` before extension sends initial state
 - `extension-status-bar.ts` — status bar (API + tunnel state)
 - `extension-commands.ts` — command registration (openDashboard, copyTunnelUrl, restartTunnel, toggleKeyFix)
 - `openai-key-fix.ts` — auto-enable OpenAI API Key in Cursor settings. Uses `aiSettings.usingOpenAIKey.toggle` command. SQLite writes to `state.vscdb` do not work — Cursor does not re-read reactive storage

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ If Cursor turns `OpenAI API Key` off on its own, Ungate should turn it back on a
 - Tunnel URL and proxy API key are secrets and should be treated like credentials.
 - Anyone with both values can send requests through your proxy.
 - Rotate your proxy key from the dashboard when you suspect leakage.
+- The proxy key only authorizes model routes: completions, messages, and the model list.
+- Settings, provider auth, and analytics require a separate admin key that never leaves your machine — the extension keeps it in Cursor's secret storage and injects it into the dashboard only.
+- The proxy binds `127.0.0.1`, so it is reachable through the tunnel and from your own machine, never from other hosts on your network.
+- Clearing the proxy key does not open the proxy up: model routes reject every request until a new key is set.
 
 ## Local build and install in Cursor
 

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,4 +1,4 @@
-import { MINIMAX_BASE_URLS, type AppSettings } from '@ungate/shared';
+import { ADMIN_KEY_ENV, ADMIN_KEY_MIN_LENGTH, MINIMAX_BASE_URLS, type AppSettings } from '@ungate/shared';
 
 import type { ProxyConfig } from './types';
 
@@ -59,6 +59,22 @@ export function getConfig(settings: AppSettings): ProxyConfig {
 	return {
 		port: envPort ?? settings.port,
 		apiKey: settings.apiKey ?? undefined,
+		adminApiKey: readAdminApiKey(),
 		quietMode: settings.quiet
 	};
+}
+
+// The admin key lives only in the environment. It is minted by the extension, stored in VS Code
+// SecretStorage and handed to this process at spawn time, so a missing value means the API was
+// launched outside the extension. Failing here keeps administrative routes from ever opening up.
+function readAdminApiKey(): string {
+	const value = process.env[ADMIN_KEY_ENV] ?? '';
+
+	if (value.length < ADMIN_KEY_MIN_LENGTH) {
+		throw new Error(
+			`${ADMIN_KEY_ENV} must hold a 256-bit key (at least ${ADMIN_KEY_MIN_LENGTH} characters). The Ungate extension supplies it when it spawns the API.`
+		);
+	}
+
+	return value;
 }

--- a/apps/api/src/plugins/auth.ts
+++ b/apps/api/src/plugins/auth.ts
@@ -1,15 +1,68 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+
 import type { Config } from '../config';
 import type { onRequestAsyncHookHandler } from 'fastify';
 
+const BEARER_PREFIX = 'Bearer ';
+
+/**
+ * Compares two secrets without leaking their contents or length through timing.
+ * Hashing first equalises the buffer length, which `timingSafeEqual` requires and
+ * which a raw length check would otherwise reveal. An absent or empty `expected`
+ * never matches, so an unconfigured key locks the route instead of opening it.
+ */
+function secretsMatch(provided: string | undefined, expected: string | undefined): boolean {
+	if (provided === undefined || expected === undefined || expected.length === 0) return false;
+
+	const providedDigest = createHash('sha256').update(provided, 'utf8').digest();
+	const expectedDigest = createHash('sha256').update(expected, 'utf8').digest();
+
+	return timingSafeEqual(providedDigest, expectedDigest);
+}
+
+/** Duplicate headers arrive as arrays; treat them as absent rather than guessing which one counts. */
+function singleHeader(raw: string | string[] | undefined): string | undefined {
+	return typeof raw === 'string' ? raw : undefined;
+}
+
+/**
+ * Proxy-key auth for the routes Cursor calls: both completion endpoints and the model list.
+ * Cursor sends the key as `Authorization: Bearer <key>` or `x-api-key`.
+ *
+ * Fails closed when no proxy key is configured. These routes are reachable through the public
+ * tunnel, so an absent key must lock them down rather than open them to anyone holding the URL.
+ * `Settings.get()` mints a key on first run; blanking it in the dashboard therefore disables the
+ * proxy until a new one is set.
+ */
 export function apiKeyAuth(config: Config): onRequestAsyncHookHandler {
 	return async (request, reply) => {
-		if (!config.apiKey) return;
-		const bearer = request.headers.authorization?.slice(7);
-		const key = bearer ?? (request.headers['x-api-key'] as string | undefined);
-		if (key !== config.apiKey) {
+		const authorization = singleHeader(request.headers.authorization);
+		const bearer = authorization?.startsWith(BEARER_PREFIX) ? authorization.slice(BEARER_PREFIX.length) : undefined;
+		const key = bearer ?? singleHeader(request.headers['x-api-key']);
+
+		if (!secretsMatch(key, config.apiKey)) {
 			return reply
 				.code(403)
 				.send({ type: 'error', error: { type: 'authentication_error', message: 'Unauthorized: Invalid API key' } });
+		}
+	};
+}
+
+/**
+ * Admin-key auth for every administrative route (settings, provider auth, analytics).
+ * Distinct from the proxy key so that exposing the tunnel URL to Cursor never grants
+ * control over provider credentials or local settings. Fails closed when unconfigured.
+ */
+export function adminKeyAuth(config: Config): onRequestAsyncHookHandler {
+	return async (request, reply) => {
+		const key = singleHeader(request.headers[ADMIN_KEY_HEADER]);
+
+		if (!secretsMatch(key, config.adminApiKey)) {
+			return reply
+				.code(403)
+				.send({ type: 'error', error: { type: 'authentication_error', message: 'Unauthorized: Invalid admin key' } });
 		}
 	};
 }

--- a/apps/api/src/plugins/cors-origin.ts
+++ b/apps/api/src/plugins/cors-origin.ts
@@ -1,0 +1,28 @@
+// Origins the dashboard can legitimately run under. VS Code and Cursor serve webview content
+// from `vscode-webview://<uuid>`; the workbench shell itself is `vscode-file://vscode-app`.
+// Loopback origins cover `pnpm dev` on apps/web. Anything else is a web page that must not be
+// able to read settings or drive provider auth from a victim's browser, even over the tunnel.
+const ALLOWED_SCHEMES = ['vscode-webview:', 'vscode-file:'];
+const LOOPBACK_HOSTNAMES = ['localhost', '127.0.0.1', '[::1]'];
+
+export function isAllowedDashboardOrigin(origin: string | undefined): boolean {
+	// Requests without an Origin header are not browser cross-origin requests: Cursor's backend
+	// and any CLI client fall here. CORS has nothing to decide, so they pass through untouched.
+	// A literal `null` origin is different — it comes from a sandboxed or file:// document, so
+	// it is refused rather than trusted.
+	if (origin === undefined || origin === '') return true;
+
+	let parsed: URL;
+
+	try {
+		parsed = new URL(origin);
+	} catch {
+		return false;
+	}
+
+	if (ALLOWED_SCHEMES.includes(parsed.protocol)) return true;
+
+	if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+	return LOOPBACK_HOSTNAMES.includes(parsed.hostname);
+}

--- a/apps/api/src/routes/analytics.ts
+++ b/apps/api/src/routes/analytics.ts
@@ -1,6 +1,7 @@
 import { hoursToMilliseconds } from 'date-fns';
 
 import { Analytics } from '../database/analytics';
+import { adminKeyAuth } from '../plugins/auth';
 
 import type { Period } from '@ungate/shared';
 import type { FastifyPluginCallback } from 'fastify';
@@ -21,6 +22,9 @@ function toPeriod(value: string | undefined): Period {
 }
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Encapsulated hook: covers every route this plugin registers, present and future.
+	app.addHook('onRequest', adminKeyAuth(app.config));
+
 	app.get('/analytics', async (request, reply) => {
 		const period = toPeriod((request.query as Record<string, string>).period);
 		const now = Date.now();

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -2,10 +2,15 @@ import { OAuth } from '../auth/oauth';
 import { OpenAIOAuthService } from '../auth/openai/openai-oauth-service';
 import { config } from '../config';
 import { ProviderSettings } from '../database/provider-settings';
+import { adminKeyAuth } from '../plugins/auth';
 
 import type { FastifyPluginCallback } from 'fastify';
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Encapsulated hook: covers every route this plugin registers, including the OAuth callback.
+	// Provider login and logout are the most damaging routes to leave open.
+	app.addHook('onRequest', adminKeyAuth(app.config));
+
 	app.post('/auth/claude/start', async (_request, reply) => {
 		const result = await OAuth.startLogin();
 

--- a/apps/api/src/routes/models.ts
+++ b/apps/api/src/routes/models.ts
@@ -1,8 +1,13 @@
 import { Settings } from '../database/app-settings';
+import { apiKeyAuth } from '../plugins/auth';
 
 import type { FastifyPluginCallback } from 'fastify';
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Cursor discovers models through this route, so it carries the proxy key rather than
+	// the admin key. Left open it let anyone with the tunnel URL enumerate the model registry.
+	app.addHook('onRequest', apiKeyAuth(app.config));
+
 	app.get('/v1/models', async (_request, reply) => {
 		const settings = Settings.get();
 		const data = settings.models.map((model) => ({

--- a/apps/api/src/routes/settings.ts
+++ b/apps/api/src/routes/settings.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { isModelMappingProvider, isModelServiceTier, isReasoningBudgetTier, type AppSettings } from '@ungate/shared';
 
 import { Settings } from '../database/app-settings';
+import { adminKeyAuth } from '../plugins/auth';
 import { logger } from '../utils/logger';
 
 import type { FastifyPluginCallback } from 'fastify';
@@ -50,6 +51,9 @@ function validateSettingsUpdate(payload: unknown): { ok: true; value: Partial<Ap
 }
 
 const plugin: FastifyPluginCallback = (app) => {
+	// Encapsulated hook: covers every route this plugin registers, present and future.
+	app.addHook('onRequest', adminKeyAuth(app.config));
+
 	app.get('/settings', async (_request, reply) => {
 		const settings = Settings.get();
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,13 +1,13 @@
 import cors from '@fastify/cors';
 import Fastify from 'fastify';
 
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
 import { logger, setQuietMode } from 'src/utils/logger';
-
-const BODY_LIMIT_BYTES = 256 * 1024 * 1024;
 
 import { getConfig } from './config';
 import { getDb } from './database/index';
 import { Settings } from './database/settings';
+import { isAllowedDashboardOrigin } from './plugins/cors-origin';
 import analyticsPlugin from './routes/analytics';
 import anthropicPlugin from './routes/anthropic';
 import authPlugin from './routes/auth';
@@ -15,6 +15,12 @@ import healthPlugin from './routes/health';
 import modelsPlugin from './routes/models';
 import openaiPlugin from './routes/openai';
 import settingsPlugin from './routes/settings';
+
+const BODY_LIMIT_BYTES = 256 * 1024 * 1024;
+
+// Cursor reaches the API through the Cloudflare tunnel, never by connecting to a LAN
+// interface. Binding loopback keeps every other host on the network out.
+export const LISTEN_HOST = '127.0.0.1';
 
 export async function startServer(): Promise<void> {
 	globalThis.console.log('[startup] getDb...');
@@ -41,7 +47,13 @@ export async function startServer(): Promise<void> {
 	});
 
 	globalThis.console.log('[startup] register cors...');
-	await app.register(cors, { origin: '*' });
+	await app.register(cors, {
+		origin: (origin, callback) => {
+			callback(null, isAllowedDashboardOrigin(origin));
+		},
+		credentials: false,
+		allowedHeaders: ['content-type', 'authorization', 'x-api-key', ADMIN_KEY_HEADER]
+	});
 
 	globalThis.console.log('[startup] register plugins...');
 	await app.register(healthPlugin);
@@ -53,7 +65,7 @@ export async function startServer(): Promise<void> {
 	await app.register(settingsPlugin);
 
 	globalThis.console.log(`[startup] listen ${config.port}...`);
-	await app.listen({ port: config.port, host: '0.0.0.0' });
+	await app.listen({ port: config.port, host: LISTEN_HOST });
 
 	// Always print port to stdout — extension parses this to detect the running port.
 	// Uses globalThis.console to bypass quiet mode.

--- a/apps/api/src/types/index.ts
+++ b/apps/api/src/types/index.ts
@@ -1,6 +1,9 @@
 export interface ProxyConfig {
 	port: number;
+	/** Proxy key Cursor sends on completion and model-listing routes. */
 	apiKey?: string;
+	/** Separate 256-bit key required on every administrative route. Never persisted to SQLite. */
+	adminApiKey: string;
 	quietMode: boolean;
 }
 

--- a/apps/api/src/types/shims/fastify.d.ts
+++ b/apps/api/src/types/shims/fastify.d.ts
@@ -1,4 +1,4 @@
-import type { Config } from '../config';
+import type { Config } from '../../config';
 
 declare module 'fastify' {
 	interface FastifyInstance {

--- a/apps/api/tests/integration/plugins/plugins-auth.test.ts
+++ b/apps/api/tests/integration/plugins/plugins-auth.test.ts
@@ -1,24 +1,46 @@
 import { describe, expect, it } from 'vitest';
 
-import { apiKeyAuth } from 'src/plugins/auth';
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+import { adminKeyAuth, apiKeyAuth } from 'src/plugins/auth';
 
-import { createTestApp } from '../test-harness';
+import { createTestApp, TEST_ADMIN_KEY } from '../test-harness';
+
+const ADMIN_CONFIG = { port: 0, adminApiKey: TEST_ADMIN_KEY, quietMode: true };
 
 describe('plugins-auth', () => {
-	it('allows request when api key is not configured', async () => {
+	it('fails closed on proxy routes when no api key is configured', async () => {
+		// These routes are reachable through the public tunnel; an absent key must lock them,
+		// never open them to anyone who knows the URL.
 		const app = createTestApp({});
-		app.get('/x', { onRequest: apiKeyAuth({ port: 0, quietMode: true }) }, async () => ({ ok: true }));
+		app.get('/x', { onRequest: apiKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
 		await app.ready();
 
-		const response = await app.inject({ method: 'GET', url: '/x' });
-		expect(response.statusCode).toBe(200);
-		expect(response.json()).toEqual({ ok: true });
+		const anonymous = await app.inject({ method: 'GET', url: '/x' });
+		expect(anonymous.statusCode).toBe(403);
+		expect(anonymous.json().error.type).toBe('authentication_error');
+
+		// Nor can a caller authenticate by guessing that the configured key is blank.
+		const blankBearer = await app.inject({ method: 'GET', url: '/x', headers: { authorization: 'Bearer ' } });
+		expect(blankBearer.statusCode).toBe(403);
+
+		const blankHeader = await app.inject({ method: 'GET', url: '/x', headers: { 'x-api-key': '' } });
+		expect(blankHeader.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('fails closed on proxy routes when the configured api key is blank', async () => {
+		const app = createTestApp({ apiKey: '' });
+		app.get('/x', { onRequest: apiKeyAuth({ ...ADMIN_CONFIG, apiKey: '' }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({ method: 'GET', url: '/x', headers: { 'x-api-key': '' } });
+		expect(response.statusCode).toBe(403);
 		await app.close();
 	});
 
 	it('rejects request with invalid key and accepts valid key', async () => {
 		const app = createTestApp({ apiKey: 'secret' });
-		app.get('/x', { onRequest: apiKeyAuth({ port: 0, apiKey: 'secret', quietMode: true }) }, async () => ({ ok: true }));
+		app.get('/x', { onRequest: apiKeyAuth({ ...ADMIN_CONFIG, apiKey: 'secret' }) }, async () => ({ ok: true }));
 		await app.ready();
 
 		const bad = await app.inject({ method: 'GET', url: '/x', headers: { 'x-api-key': 'wrong' } });
@@ -31,6 +53,97 @@ describe('plugins-auth', () => {
 			headers: { authorization: 'Bearer secret' }
 		});
 		expect(good.statusCode).toBe(200);
+		await app.close();
+	});
+
+	it('rejects an authorization header that is not a bearer token', async () => {
+		const app = createTestApp({ apiKey: 'secret' });
+		app.get('/x', { onRequest: apiKeyAuth({ ...ADMIN_CONFIG, apiKey: 'secret' }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({ method: 'GET', url: '/x', headers: { authorization: 'Basic secret' } });
+		expect(response.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('rejects an admin request with no key at all', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({ method: 'GET', url: '/x' });
+		expect(response.statusCode).toBe(403);
+		expect(response.json().error.message).toBe('Unauthorized: Invalid admin key');
+		await app.close();
+	});
+
+	it('rejects an admin request carrying the wrong key', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { [ADMIN_KEY_HEADER]: 'a'.repeat(64) }
+		});
+		expect(response.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('rejects an admin request that presents the proxy key instead', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth({ ...ADMIN_CONFIG, apiKey: 'proxy-key' }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { authorization: 'Bearer proxy-key', 'x-api-key': 'proxy-key' }
+		});
+		expect(response.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('accepts an admin request carrying the correct key', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { [ADMIN_KEY_HEADER]: TEST_ADMIN_KEY }
+		});
+		expect(response.statusCode).toBe(200);
+		expect(response.json()).toEqual({ ok: true });
+		await app.close();
+	});
+
+	it('fails closed when the admin key is missing from config', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth({ port: 0, adminApiKey: '', quietMode: true }) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const empty = await app.inject({ method: 'GET', url: '/x' });
+		expect(empty.statusCode).toBe(403);
+
+		const alsoEmpty = await app.inject({ method: 'GET', url: '/x', headers: { [ADMIN_KEY_HEADER]: '' } });
+		expect(alsoEmpty.statusCode).toBe(403);
+		await app.close();
+	});
+
+	it('rejects a request that sends the admin key header twice', async () => {
+		const app = createTestApp({});
+		app.get('/x', { onRequest: adminKeyAuth(ADMIN_CONFIG) }, async () => ({ ok: true }));
+		await app.ready();
+
+		const response = await app.inject({
+			method: 'GET',
+			url: '/x',
+			headers: { [ADMIN_KEY_HEADER]: ['wrong', TEST_ADMIN_KEY] }
+		});
+		expect(response.statusCode).toBe(403);
 		await app.close();
 	});
 });

--- a/apps/api/tests/integration/routes/routes-auth.test.ts
+++ b/apps/api/tests/integration/routes/routes-auth.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import authPlugin from 'src/routes/auth';
 
-import { withPlugin } from '../test-harness';
+import { ADMIN_HEADERS, withPlugin } from '../test-harness';
 
 const oauthStartLoginMock = vi.fn();
 const oauthCompleteLoginMock = vi.fn();
@@ -56,24 +56,30 @@ describe('routes-auth', () => {
 
 		const app = await withPlugin(authPlugin);
 
-		const start = await app.inject({ method: 'POST', url: '/auth/claude/start' });
+		const start = await app.inject({ method: 'POST', url: '/auth/claude/start', headers: ADMIN_HEADERS });
 		expect(start.statusCode).toBe(200);
 		expect(start.json()).toEqual({ authUrl: 'u', sessionId: 's' });
 
-		const bad = await app.inject({ method: 'POST', url: '/auth/claude/complete', payload: { code: 'x' } });
+		const bad = await app.inject({
+			method: 'POST',
+			url: '/auth/claude/complete',
+			headers: ADMIN_HEADERS,
+			payload: { code: 'x' }
+		});
 		expect(bad.statusCode).toBe(400);
 
 		const complete = await app.inject({
 			method: 'POST',
 			url: '/auth/claude/complete',
+			headers: ADMIN_HEADERS,
 			payload: { code: 'x', sessionId: 'sid' }
 		});
 		expect(complete.json()).toEqual({ ok: true, email: 'e@e.com' });
 
-		const status = await app.inject({ method: 'GET', url: '/auth/claude/status' });
+		const status = await app.inject({ method: 'GET', url: '/auth/claude/status', headers: ADMIN_HEADERS });
 		expect(status.json()).toEqual({ authenticated: true });
 
-		const logout = await app.inject({ method: 'POST', url: '/auth/claude/logout' });
+		const logout = await app.inject({ method: 'POST', url: '/auth/claude/logout', headers: ADMIN_HEADERS });
 		expect(logout.json()).toEqual({ ok: true });
 		expect(oauthLogoutMock).toHaveBeenCalled();
 		await app.close();
@@ -83,12 +89,13 @@ describe('routes-auth', () => {
 		providerGetMock.mockReturnValueOnce({ accessToken: 'k', baseUrl: 'https://x' });
 		const app = await withPlugin(authPlugin);
 
-		const status = await app.inject({ method: 'GET', url: '/auth/minimax/status' });
+		const status = await app.inject({ method: 'GET', url: '/auth/minimax/status', headers: ADMIN_HEADERS });
 		expect(status.json()).toEqual({ authenticated: true, baseUrl: 'https://x' });
 
 		const badLogin = await app.inject({
 			method: 'POST',
 			url: '/auth/minimax/login',
+			headers: ADMIN_HEADERS,
 			payload: { apiKey: '   ' }
 		});
 		expect(badLogin.statusCode).toBe(400);
@@ -96,12 +103,13 @@ describe('routes-auth', () => {
 		const login = await app.inject({
 			method: 'POST',
 			url: '/auth/minimax/login',
+			headers: ADMIN_HEADERS,
 			payload: { apiKey: ' key ', baseUrl: ' https://m ' }
 		});
 		expect(login.json()).toEqual({ ok: true });
 		expect(providerUpsertApiKeyMock).toHaveBeenCalledWith('minimax', 'key', 'https://m');
 
-		const logout = await app.inject({ method: 'POST', url: '/auth/minimax/logout' });
+		const logout = await app.inject({ method: 'POST', url: '/auth/minimax/logout', headers: ADMIN_HEADERS });
 		expect(logout.json()).toEqual({ ok: true });
 		expect(providerRemoveMock).toHaveBeenCalledWith('minimax');
 		await app.close();
@@ -113,26 +121,60 @@ describe('routes-auth', () => {
 		openaiCompleteLoginMock.mockResolvedValueOnce({ ok: true });
 		const app = await withPlugin(authPlugin);
 
-		const start = await app.inject({ method: 'GET', url: '/auth/openai/start' });
+		const start = await app.inject({ method: 'GET', url: '/auth/openai/start', headers: ADMIN_HEADERS });
 		expect(start.json().authUrl).toBe('openai-url');
 
-		const missing = await app.inject({ method: 'GET', url: '/auth/openai/callback' });
+		const missing = await app.inject({ method: 'GET', url: '/auth/openai/callback', headers: ADMIN_HEADERS });
 		expect(missing.statusCode).toBe(200);
 		expect(missing.body).toContain('Missing code or session');
 
-		const success = await app.inject({ method: 'GET', url: '/auth/openai/callback?code=abc&state=state1' });
+		const success = await app.inject({
+			method: 'GET',
+			url: '/auth/openai/callback?code=abc&state=state1',
+			headers: ADMIN_HEADERS
+		});
 		expect(success.body).toContain('Connected!');
 
 		openaiCompleteLoginMock.mockResolvedValueOnce({ ok: false, error: 'boom' });
-		const failure = await app.inject({ method: 'GET', url: '/auth/openai/callback?code=abc&state=state2' });
+		const failure = await app.inject({
+			method: 'GET',
+			url: '/auth/openai/callback?code=abc&state=state2',
+			headers: ADMIN_HEADERS
+		});
 		expect(failure.body).toContain('Error');
 		expect(failure.body).toContain('boom');
 
-		const status = await app.inject({ method: 'GET', url: '/auth/openai/status' });
+		const status = await app.inject({ method: 'GET', url: '/auth/openai/status', headers: ADMIN_HEADERS });
 		expect(status.json()).toEqual({ authenticated: false });
 
-		await app.inject({ method: 'POST', url: '/auth/openai/logout' });
+		await app.inject({ method: 'POST', url: '/auth/openai/logout', headers: ADMIN_HEADERS });
 		expect(openaiLogoutMock).toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses provider auth routes without the admin key', async () => {
+		const app = await withPlugin(authPlugin);
+
+		const start = await app.inject({ method: 'POST', url: '/auth/claude/start' });
+		expect(start.statusCode).toBe(403);
+
+		const login = await app.inject({
+			method: 'POST',
+			url: '/auth/minimax/login',
+			payload: { apiKey: 'stolen', baseUrl: 'https://m' }
+		});
+		expect(login.statusCode).toBe(403);
+
+		const callback = await app.inject({ method: 'GET', url: '/auth/openai/callback?code=abc&state=s' });
+		expect(callback.statusCode).toBe(403);
+
+		const logout = await app.inject({ method: 'POST', url: '/auth/claude/logout' });
+		expect(logout.statusCode).toBe(403);
+
+		expect(oauthStartLoginMock).not.toHaveBeenCalled();
+		expect(providerUpsertApiKeyMock).not.toHaveBeenCalled();
+		expect(openaiCompleteLoginMock).not.toHaveBeenCalled();
+		expect(oauthLogoutMock).not.toHaveBeenCalled();
 		await app.close();
 	});
 });

--- a/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
+++ b/apps/api/tests/integration/routes/routes-health-settings-models-analytics.test.ts
@@ -1,11 +1,13 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+
 import analyticsPlugin from 'src/routes/analytics';
 import healthPlugin from 'src/routes/health';
 import modelsPlugin from 'src/routes/models';
 import settingsPlugin from 'src/routes/settings';
 
-import { withPlugin } from '../test-harness';
+import { ADMIN_HEADERS, withPlugin } from '../test-harness';
 
 const settingsGetMock = vi.fn();
 const settingsUpdateMock = vi.fn();
@@ -48,6 +50,7 @@ describe('routes: health/settings/models/analytics', () => {
 		const res = await app.inject({
 			method: 'POST',
 			url: '/settings',
+			headers: ADMIN_HEADERS,
 			payload: {
 				models: [
 					{
@@ -90,13 +93,14 @@ describe('routes: health/settings/models/analytics', () => {
 		});
 
 		const app = await withPlugin(settingsPlugin);
-		const getRes = await app.inject({ method: 'GET', url: '/settings' });
+		const getRes = await app.inject({ method: 'GET', url: '/settings', headers: ADMIN_HEADERS });
 		expect(getRes.statusCode).toBe(200);
 		expect(getRes.json().port).toBe(4783);
 
 		const postRes = await app.inject({
 			method: 'POST',
 			url: '/settings',
+			headers: ADMIN_HEADERS,
 			payload: { quiet: true }
 		});
 		expect(postRes.statusCode).toBe(200);
@@ -113,8 +117,12 @@ describe('routes: health/settings/models/analytics', () => {
 			]
 		});
 
-		const app = await withPlugin(modelsPlugin);
-		const response = await app.inject({ method: 'GET', url: '/v1/models' });
+		const app = await withPlugin(modelsPlugin, { apiKey: 'proxy-key' });
+		const response = await app.inject({
+			method: 'GET',
+			url: '/v1/models',
+			headers: { authorization: 'Bearer proxy-key' }
+		});
 		expect(response.statusCode).toBe(200);
 		expect(response.json()).toEqual({
 			object: 'list',
@@ -143,16 +151,90 @@ describe('routes: health/settings/models/analytics', () => {
 
 		const app = await withPlugin(analyticsPlugin);
 
-		const summary = await app.inject({ method: 'GET', url: '/analytics?period=all' });
+		const summary = await app.inject({ method: 'GET', url: '/analytics?period=all', headers: ADMIN_HEADERS });
 		expect(summary.statusCode).toBe(200);
 		expect(summary.json().period).toBe('all');
 		expect(summary.json().note).toContain('Costs are estimates');
 
-		await app.inject({ method: 'GET', url: '/analytics/requests?limit=9999' });
+		await app.inject({ method: 'GET', url: '/analytics/requests?limit=9999', headers: ADMIN_HEADERS });
 		expect(analyticsRecentMock).toHaveBeenCalledWith(1000);
 
-		const reset = await app.inject({ method: 'POST', url: '/analytics/reset' });
+		const reset = await app.inject({ method: 'POST', url: '/analytics/reset', headers: ADMIN_HEADERS });
 		expect(reset.json()).toEqual({ success: true, deletedCount: 4 });
+		await app.close();
+	});
+
+	it('refuses settings reads and writes without the admin key', async () => {
+		const app = await withPlugin(settingsPlugin);
+
+		const read = await app.inject({ method: 'GET', url: '/settings' });
+		expect(read.statusCode).toBe(403);
+
+		const write = await app.inject({ method: 'POST', url: '/settings', payload: { quiet: true } });
+		expect(write.statusCode).toBe(403);
+
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		expect(settingsUpdateMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses settings requests carrying a wrong admin key', async () => {
+		const app = await withPlugin(settingsPlugin);
+
+		const read = await app.inject({
+			method: 'GET',
+			url: '/settings',
+			headers: { [ADMIN_KEY_HEADER]: 'not-the-key' }
+		});
+		expect(read.statusCode).toBe(403);
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses every analytics route without the admin key', async () => {
+		const app = await withPlugin(analyticsPlugin);
+
+		for (const url of ['/analytics', '/analytics/requests', '/analytics/tokens']) {
+			const response = await app.inject({ method: 'GET', url });
+			expect(response.statusCode).toBe(403);
+		}
+
+		const reset = await app.inject({ method: 'POST', url: '/analytics/reset' });
+		expect(reset.statusCode).toBe(403);
+
+		expect(analyticsSummaryMock).not.toHaveBeenCalled();
+		expect(analyticsResetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses the model list without the proxy key', async () => {
+		const app = await withPlugin(modelsPlugin, { apiKey: 'proxy-key' });
+
+		const anonymous = await app.inject({ method: 'GET', url: '/v1/models' });
+		expect(anonymous.statusCode).toBe(403);
+
+		const wrong = await app.inject({ method: 'GET', url: '/v1/models', headers: { 'x-api-key': 'nope' } });
+		expect(wrong.statusCode).toBe(403);
+
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('refuses the model list when no proxy key is configured at all', async () => {
+		const app = await withPlugin(modelsPlugin);
+
+		const response = await app.inject({ method: 'GET', url: '/v1/models' });
+		expect(response.statusCode).toBe(403);
+
+		expect(settingsGetMock).not.toHaveBeenCalled();
+		await app.close();
+	});
+
+	it('keeps health reachable without any key', async () => {
+		const app = await withPlugin(healthPlugin);
+
+		const response = await app.inject({ method: 'GET', url: '/health' });
+		expect(response.statusCode).toBe(200);
 		await app.close();
 	});
 });

--- a/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
+++ b/apps/api/tests/integration/routes/routes-settings-real-db.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import settingsPlugin from 'src/routes/settings';
 
-import { withPlugin } from '../test-harness';
+import { ADMIN_HEADERS, TEST_ADMIN_KEY, withPlugin } from '../test-harness';
 
 describe('routes: settings (real database)', () => {
 	it('strips unknown fields and saves model to database', async () => {
@@ -11,6 +11,7 @@ describe('routes: settings (real database)', () => {
 		const postRes = await app.inject({
 			method: 'POST',
 			url: '/settings',
+			headers: ADMIN_HEADERS,
 			payload: {
 				quiet: false,
 				models: [
@@ -29,7 +30,7 @@ describe('routes: settings (real database)', () => {
 		});
 		expect(postRes.statusCode).toBe(200);
 
-		const getRes = await app.inject({ method: 'GET', url: '/settings' });
+		const getRes = await app.inject({ method: 'GET', url: '/settings', headers: ADMIN_HEADERS });
 		expect(getRes.statusCode).toBe(200);
 
 		const body = getRes.json();
@@ -37,6 +38,10 @@ describe('routes: settings (real database)', () => {
 
 		expect(saved).toBeDefined();
 		expect(saved).not.toHaveProperty('enabled');
+
+		// The admin key lives in the environment only; it must never travel back through settings.
+		expect(body).not.toHaveProperty('adminApiKey');
+		expect(getRes.body).not.toContain(TEST_ADMIN_KEY);
 
 		await app.close();
 	});

--- a/apps/api/tests/integration/test-harness.ts
+++ b/apps/api/tests/integration/test-harness.ts
@@ -1,7 +1,15 @@
 import Fastify, { type FastifyInstance, type FastifyPluginCallback } from 'fastify';
 
+import { ADMIN_KEY_HEADER } from '@ungate/shared';
+
+/** Stand-in for the 256-bit key the extension mints; length matches a hex-encoded key. */
+export const TEST_ADMIN_KEY = 'f'.repeat(64);
+
+export const ADMIN_HEADERS = { [ADMIN_KEY_HEADER]: TEST_ADMIN_KEY };
+
 export interface HarnessConfig {
 	apiKey?: string;
+	adminApiKey?: string;
 }
 
 export function createTestApp(config: HarnessConfig = {}): FastifyInstance {
@@ -9,6 +17,7 @@ export function createTestApp(config: HarnessConfig = {}): FastifyInstance {
 	app.decorate('config', {
 		port: 0,
 		apiKey: config.apiKey,
+		adminApiKey: config.adminApiKey ?? TEST_ADMIN_KEY,
 		quietMode: true
 	});
 

--- a/apps/api/tests/unit/config/config.test.ts
+++ b/apps/api/tests/unit/config/config.test.ts
@@ -1,8 +1,15 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { ADMIN_KEY_ENV } from '@ungate/shared';
 import { getConfig } from 'src/config';
 
+const ADMIN_KEY = 'f'.repeat(64);
+
 describe('config', () => {
+	beforeEach(() => {
+		vi.stubEnv(ADMIN_KEY_ENV, ADMIN_KEY);
+	});
+
 	afterEach(() => {
 		vi.unstubAllEnvs();
 	});
@@ -18,7 +25,7 @@ describe('config', () => {
 			models: []
 		});
 
-		expect(cfg).toEqual({ port: 7777, apiKey: 'abc', quietMode: true });
+		expect(cfg).toEqual({ port: 7777, apiKey: 'abc', adminApiKey: ADMIN_KEY, quietMode: true });
 	});
 
 	it('falls back to settings when env is absent', () => {
@@ -32,7 +39,7 @@ describe('config', () => {
 			models: []
 		});
 
-		expect(cfg).toEqual({ port: 3000, apiKey: undefined, quietMode: false });
+		expect(cfg).toEqual({ port: 3000, apiKey: undefined, adminApiKey: ADMIN_KEY, quietMode: false });
 	});
 
 	it('falls back to settings when env port is invalid number', () => {
@@ -46,6 +53,32 @@ describe('config', () => {
 			models: []
 		});
 
-		expect(cfg).toEqual({ port: 4123, apiKey: undefined, quietMode: false });
+		expect(cfg).toEqual({ port: 4123, apiKey: undefined, adminApiKey: ADMIN_KEY, quietMode: false });
+	});
+
+	it('refuses to build a config when the admin key is absent', () => {
+		vi.stubEnv(ADMIN_KEY_ENV, '');
+
+		expect(() =>
+			getConfig({ port: 4123, apiKey: null, quiet: false, extraInstruction: null, models: [] })
+		).toThrowError(ADMIN_KEY_ENV);
+	});
+
+	it('refuses an admin key too short to carry 256 bits', () => {
+		vi.stubEnv(ADMIN_KEY_ENV, 'short-key');
+
+		expect(() =>
+			getConfig({ port: 4123, apiKey: null, quiet: false, extraInstruction: null, models: [] })
+		).toThrowError(ADMIN_KEY_ENV);
+	});
+
+	it('accepts a base64url-encoded 256-bit key', () => {
+		const base64UrlKey = 'A'.repeat(43);
+		vi.stubEnv(ADMIN_KEY_ENV, base64UrlKey);
+		vi.stubEnv('PORT', '');
+
+		const cfg = getConfig({ port: 4123, apiKey: null, quiet: false, extraInstruction: null, models: [] });
+
+		expect(cfg.adminApiKey).toBe(base64UrlKey);
 	});
 });

--- a/apps/api/tests/unit/plugins/cors-origin.test.ts
+++ b/apps/api/tests/unit/plugins/cors-origin.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAllowedDashboardOrigin } from 'src/plugins/cors-origin';
+
+describe('cors-origin', () => {
+	it('allows requests that carry no Origin header', () => {
+		// Cursor's backend and CLI clients reach the proxy without an Origin; CORS is not involved.
+		expect(isAllowedDashboardOrigin(undefined)).toBe(true);
+		expect(isAllowedDashboardOrigin('')).toBe(true);
+	});
+
+	it('allows the VS Code and Cursor webview origins', () => {
+		expect(isAllowedDashboardOrigin('vscode-webview://1a2b3c4d-5e6f-7788-99aa-bbccddeeff00')).toBe(true);
+		expect(isAllowedDashboardOrigin('vscode-file://vscode-app')).toBe(true);
+	});
+
+	it('allows loopback origins for local web development', () => {
+		expect(isAllowedDashboardOrigin('http://localhost:5173')).toBe(true);
+		expect(isAllowedDashboardOrigin('http://127.0.0.1:4783')).toBe(true);
+		expect(isAllowedDashboardOrigin('http://[::1]:5173')).toBe(true);
+	});
+
+	it('refuses arbitrary web origins', () => {
+		expect(isAllowedDashboardOrigin('https://evil.example')).toBe(false);
+		expect(isAllowedDashboardOrigin('http://attacker.test:8080')).toBe(false);
+		expect(isAllowedDashboardOrigin('https://ungate.dev')).toBe(false);
+	});
+
+	it('refuses hostnames that merely embed a loopback name', () => {
+		expect(isAllowedDashboardOrigin('https://localhost.evil.example')).toBe(false);
+		expect(isAllowedDashboardOrigin('https://127.0.0.1.evil.example')).toBe(false);
+		expect(isAllowedDashboardOrigin('https://notlocalhost')).toBe(false);
+	});
+
+	it('refuses opaque and unparseable origins', () => {
+		expect(isAllowedDashboardOrigin('null')).toBe(false);
+		expect(isAllowedDashboardOrigin('not an origin')).toBe(false);
+		expect(isAllowedDashboardOrigin('file:///etc/passwd')).toBe(false);
+	});
+
+	it('refuses a tunnel hostname, which is where remote traffic arrives', () => {
+		expect(isAllowedDashboardOrigin('https://random-words-1234.trycloudflare.com')).toBe(false);
+	});
+});

--- a/apps/api/tests/unit/server/server-boundary.test.ts
+++ b/apps/api/tests/unit/server/server-boundary.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ADMIN_KEY_ENV, ADMIN_KEY_HEADER } from '@ungate/shared';
+import { LISTEN_HOST, startServer } from 'src/server';
+
+import type { FastifyCorsOptions, OriginFunction } from '@fastify/cors';
+
+const ADMIN_KEY = 'f'.repeat(64);
+
+const fastifyFactoryMock = vi.fn();
+const decorateMock = vi.fn();
+const addHookMock = vi.fn();
+const registerMock = vi.fn();
+const listenMock = vi.fn();
+const settingsGetMock = vi.fn();
+const getDbMock = vi.fn();
+
+vi.mock('fastify', () => ({
+	default: (...args: unknown[]) => fastifyFactoryMock(...args)
+}));
+
+vi.mock('@fastify/cors', () => ({
+	default: 'cors-plugin'
+}));
+
+vi.mock('src/database/index', () => ({
+	getDb: (...args: unknown[]) => getDbMock(...args),
+	getSqlite: vi.fn(),
+	getCurrentDbPath: vi.fn(),
+	schema: {}
+}));
+
+vi.mock('src/database/settings', () => ({
+	Settings: { get: (...args: unknown[]) => settingsGetMock(...args) }
+}));
+
+function corsOptions(): FastifyCorsOptions {
+	const registration = registerMock.mock.calls.find(([plugin]) => plugin === 'cors-plugin');
+
+	if (!registration) {
+		throw new Error('CORS plugin was never registered');
+	}
+
+	return registration[1] as FastifyCorsOptions;
+}
+
+function resolveOrigin(origin: string | undefined): boolean {
+	// The server registers the callback form of `origin`; the FastifyCorsOptions union also covers
+	// static values and async delegates, so it cannot narrow to that form structurally.
+	const policy = corsOptions().origin as OriginFunction;
+
+	if (typeof policy !== 'function') {
+		throw new Error('CORS origin must be decided by a policy function, not a static value');
+	}
+
+	let allowed: unknown;
+
+	policy(origin, (error, allow) => {
+		if (error) throw error;
+		allowed = allow;
+	});
+
+	if (typeof allowed !== 'boolean') {
+		throw new Error(`CORS origin policy answered with ${String(allowed)} instead of a boolean`);
+	}
+
+	return allowed;
+}
+
+describe('server boundary', () => {
+	beforeEach(() => {
+		vi.stubEnv(ADMIN_KEY_ENV, ADMIN_KEY);
+		vi.stubEnv('PORT', '');
+		vi.spyOn(globalThis.console, 'log').mockImplementation(() => {});
+
+		fastifyFactoryMock.mockReturnValue({
+			decorate: decorateMock,
+			addHook: addHookMock,
+			register: registerMock,
+			listen: listenMock
+		});
+		registerMock.mockResolvedValue(undefined);
+		listenMock.mockResolvedValue(undefined);
+		settingsGetMock.mockReturnValue({
+			port: 4783,
+			apiKey: 'proxy-key',
+			quiet: true,
+			extraInstruction: null,
+			models: []
+		});
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
+	});
+
+	it('listens on loopback only, never a LAN interface', async () => {
+		await startServer();
+
+		expect(LISTEN_HOST).toBe('127.0.0.1');
+		expect(listenMock).toHaveBeenCalledWith({ port: 4783, host: '127.0.0.1' });
+	});
+
+	it('hands the environment admin key to the request pipeline', async () => {
+		await startServer();
+
+		expect(decorateMock).toHaveBeenCalledWith(
+			'config',
+			expect.objectContaining({ adminApiKey: ADMIN_KEY, apiKey: 'proxy-key' })
+		);
+	});
+
+	it('refuses to start without an admin key', async () => {
+		vi.stubEnv(ADMIN_KEY_ENV, '');
+
+		await expect(startServer()).rejects.toThrow(ADMIN_KEY_ENV);
+		expect(listenMock).not.toHaveBeenCalled();
+	});
+
+	it('replaces wildcard CORS with an origin policy', async () => {
+		await startServer();
+
+		expect(corsOptions().origin).not.toBe('*');
+		expect(resolveOrigin('vscode-webview://1a2b3c4d-5e6f-7788-99aa-bbccddeeff00')).toBe(true);
+		expect(resolveOrigin(undefined)).toBe(true);
+		expect(resolveOrigin('https://evil.example')).toBe(false);
+		expect(resolveOrigin('https://random-words-1234.trycloudflare.com')).toBe(false);
+	});
+
+	it('permits the admin key header through CORS preflight', async () => {
+		await startServer();
+
+		expect(corsOptions().allowedHeaders).toContain(ADMIN_KEY_HEADER);
+		expect(corsOptions().credentials).toBe(false);
+	});
+});

--- a/apps/extension/src/admin-key.ts
+++ b/apps/extension/src/admin-key.ts
@@ -1,0 +1,35 @@
+import { randomBytes } from 'node:crypto';
+
+import { ADMIN_KEY_MIN_LENGTH, ADMIN_KEY_SECRET_KEY } from '@ungate/shared';
+
+/**
+ * The slice of `vscode.SecretStorage` this module needs. Narrowing it keeps the key logic
+ * independent of the `vscode` module so it can be driven directly.
+ */
+export interface SecretStore {
+	get(key: string): Thenable<string | undefined>;
+	store(key: string, value: string): Thenable<void>;
+}
+
+/**
+ * Owner of the administrative API key that gates the settings, provider-auth and analytics
+ * routes. It lives only in VS Code SecretStorage, the API child's environment and the
+ * dashboard webview — never in SQLite, the runtime state file or the log. Provider
+ * credentials are not this module's business; they stay where they already live.
+ */
+export class AdminKey {
+	/** Loads the key, minting a 256-bit one on first run or when the stored value is unusable. */
+	static async load(storage: SecretStore): Promise<string> {
+		const stored = await storage.get(ADMIN_KEY_SECRET_KEY);
+
+		if (stored && stored.length >= ADMIN_KEY_MIN_LENGTH) {
+			return stored;
+		}
+
+		const minted = randomBytes(32).toString('base64url');
+
+		await storage.store(ADMIN_KEY_SECRET_KEY, minted);
+
+		return minted;
+	}
+}

--- a/apps/extension/src/api-server.ts
+++ b/apps/extension/src/api-server.ts
@@ -2,7 +2,7 @@ import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { sleep, type ApiStatus as ServerStatus, type LogEntry } from '@ungate/shared';
+import { ADMIN_KEY_ENV, sleep, type ApiStatus as ServerStatus, type LogEntry } from '@ungate/shared';
 import * as vscode from 'vscode';
 
 import { RuntimeStateStore } from './runtime-state';
@@ -38,6 +38,7 @@ export class ApiServer {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
+		private readonly adminApiKey: string,
 		private readonly callbacks: ApiServerCallbacks
 	) {}
 
@@ -196,6 +197,8 @@ export class ApiServer {
 		const env: NodeJS.ProcessEnv = {
 			...process.env,
 			UNGATE_BETTER_SQLITE3_NATIVE_BINDING: BetterSqlite3Installer.resolveBindingPath(cwd),
+			// Administrative routes are gated by this key; it never reaches SQLite or the log.
+			[ADMIN_KEY_ENV]: this.adminApiKey,
 			...(isDev ? { DB_PATH: path.join(os.homedir(), '.ungate', 'data-dev.db') } : { DRIZZLE_PATH: path.join(cwd, 'drizzle') })
 		};
 

--- a/apps/extension/src/dashboard.ts
+++ b/apps/extension/src/dashboard.ts
@@ -19,6 +19,21 @@ export type Msg =
 	| { type: 'clear-logs'; source: 'api' | 'tunnel' }
 	| Extract<WebviewToExtension, { type: (typeof MSGS_SIMPLE)[number] }>;
 
+/**
+ * Serialises a value for embedding inside an inline `<script>` element. JSON alone is not enough:
+ * a literal `</script` inside a string would close the element, and U+2028/U+2029 are line
+ * terminators in JavaScript source but legal inside JSON strings. Escaping the three HTML-special
+ * characters and both separators keeps the payload inert no matter what the value contains.
+ */
+export function toInlineScriptJson(value: unknown): string {
+	return JSON.stringify(value ?? null)
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/&/g, '\\u0026')
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029');
+}
+
 export class Dashboard {
 	private panel: vscode.WebviewPanel | null = null;
 	private readonly apiLogBuffer = new LogRingBuffer(LOG_BUFFER_SIZE);
@@ -30,6 +45,7 @@ export class Dashboard {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
+		private readonly adminApiKey: string,
 		private readonly onMessage: (message: Msg) => void
 	) {}
 
@@ -247,10 +263,15 @@ export class Dashboard {
 		html = html.replace(/src="\/assets\//g, `src="${assetsUri.toString()}/`);
 		html = html.replace(/href="\/assets\//g, `href="${assetsUri.toString()}/`);
 		html = html.replace('href="/favicon.png"', `href="${faviconUri.toString()}"`);
-		html = html.replace(
-			'</head>',
-			`<script>window.__PORT__ = ${this.currentPort}; window.__TS__ = ${Date.now()};</script>\n\t</head>`
-		);
+
+		const bootstrap =
+			`<script>window.__PORT__ = ${toInlineScriptJson(this.currentPort)}; ` +
+			`window.__ADMIN_KEY__ = ${toInlineScriptJson(this.adminApiKey)}; ` +
+			`window.__TS__ = ${Date.now()};</script>`;
+
+		// The replacement is a function so that `$&`-style patterns inside the injected values
+		// are never interpreted by String.replace.
+		html = html.replace('</head>', () => `${bootstrap}\n\t</head>`);
 
 		return html;
 	}

--- a/apps/extension/src/extension-controller.ts
+++ b/apps/extension/src/extension-controller.ts
@@ -10,6 +10,7 @@ import {
 } from '@ungate/shared/frontend';
 import * as vscode from 'vscode';
 
+import { AdminKey } from './admin-key';
 import { ApiServer } from './api-server';
 import { Dashboard, type Msg } from './dashboard';
 import { extensionCommands } from './extension-commands';
@@ -41,7 +42,7 @@ export class ExtensionController {
 
 	constructor(private readonly context: vscode.ExtensionContext) {}
 
-	public activate(): void {
+	public async activate(): Promise<void> {
 		this.extensionHostActive = true;
 		this.outputChannel = vscode.window.createOutputChannel('Ungate');
 		this.context.subscriptions.push(this.outputChannel);
@@ -50,7 +51,11 @@ export class ExtensionController {
 		this.statusBar.command = extensionCommands.openDashboard;
 		this.context.subscriptions.push(this.statusBar);
 
-		this.dashboard = new Dashboard(this.context, (message) => {
+		// Nothing may start before the administrative key is readable: it gates the dashboard
+		// and every administrative route on the API child.
+		const adminApiKey = await this.loadAdminApiKey();
+
+		this.dashboard = new Dashboard(this.context, adminApiKey, (message) => {
 			this.handleDashboardMessage(message);
 		});
 		this.keyFix = new OpenAiKeyFix(
@@ -81,7 +86,7 @@ export class ExtensionController {
 			}
 		);
 
-		this.apiServer = new ApiServer(this.context, {
+		this.apiServer = new ApiServer(this.context, adminApiKey, {
 			onLog: (level: LogEntry['level'], message: string) => {
 				this.log(message);
 				this.dashboard.pushLog('api', { timestamp: Date.now(), level, message });
@@ -142,7 +147,7 @@ export class ExtensionController {
 
 		const disposeState = RuntimeStateStore.read();
 		if (this.isLeaderWindow(disposeState)) {
-			void this.apiServer.stop().catch(() => {});
+			void this.apiServer?.stop().catch(() => {});
 		}
 
 		if (this.heartbeatTimer) {
@@ -171,6 +176,23 @@ export class ExtensionController {
 
 		if (!hasLiveClients) {
 			this.tunnelManager?.stop();
+		}
+	}
+
+	/**
+	 * Fails closed: when VS Code SecretStorage cannot be reached there is no administrative key,
+	 * so activation must not continue and leave the API running without one.
+	 */
+	private async loadAdminApiKey(): Promise<string> {
+		try {
+			return await AdminKey.load(this.context.secrets);
+		} catch (error: unknown) {
+			const message = this.formatError(error);
+
+			this.log(`[admin-key] secret storage unavailable: ${message}`);
+			void vscode.window.showErrorMessage(`Ungate cannot start: secret storage is unavailable (${message}).`);
+
+			throw error;
 		}
 	}
 

--- a/apps/extension/src/extension.ts
+++ b/apps/extension/src/extension.ts
@@ -5,11 +5,13 @@ import { ExtensionController } from './extension-controller';
 // Keep a single controller instance between activate/deactivate hooks.
 let active: ExtensionController | undefined;
 
-export function activate(context: vscode.ExtensionContext): void {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	const app = new ExtensionController(context);
 
-	app.activate();
+	// Registered before awaiting so deactivate can tear down a half-started controller.
 	active = app;
+
+	await app.activate();
 }
 
 export function deactivate(): void {

--- a/apps/extension/tests/unit/admin-key.test.ts
+++ b/apps/extension/tests/unit/admin-key.test.ts
@@ -1,0 +1,76 @@
+import { ADMIN_KEY_MIN_LENGTH, ADMIN_KEY_SECRET_KEY } from '@ungate/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { AdminKey, type SecretStore } from '../../src/admin-key';
+
+/** Stands in for vscode.SecretStorage. */
+class MemorySecretStore implements SecretStore {
+	readonly values: Record<string, string> = {};
+	failOn: string | null = null;
+
+	get(key: string): Promise<string | undefined> {
+		return Promise.resolve(this.values[key]);
+	}
+
+	store(key: string, value: string): Promise<void> {
+		if (this.failOn === key) {
+			return Promise.reject(new Error('keychain is locked'));
+		}
+
+		this.values[key] = value;
+
+		return Promise.resolve();
+	}
+}
+
+describe('AdminKey', () => {
+	let storage: MemorySecretStore;
+
+	beforeEach(() => {
+		storage = new MemorySecretStore();
+	});
+
+	it('mints a 256-bit key once and reuses the stored one', async () => {
+		const first = await AdminKey.load(storage);
+
+		expect(first.length).toBeGreaterThanOrEqual(ADMIN_KEY_MIN_LENGTH);
+		expect(first).toMatch(/^[A-Za-z0-9_-]+$/);
+		expect(storage.values[ADMIN_KEY_SECRET_KEY]).toBe(first);
+
+		const second = await AdminKey.load(storage);
+
+		expect(second).toBe(first);
+	});
+
+	it('mints a distinct key per install', async () => {
+		const other = new MemorySecretStore();
+		const first = await AdminKey.load(storage);
+		const second = await AdminKey.load(other);
+
+		expect(first).not.toBe(second);
+	});
+
+	it('replaces a stored key that is too short to carry 256 bits', async () => {
+		storage.values[ADMIN_KEY_SECRET_KEY] = 'too-short';
+
+		const key = await AdminKey.load(storage);
+
+		expect(key).not.toBe('too-short');
+		expect(key.length).toBeGreaterThanOrEqual(ADMIN_KEY_MIN_LENGTH);
+		expect(storage.values[ADMIN_KEY_SECRET_KEY]).toBe(key);
+	});
+
+	it('fails closed when secret storage refuses the write', async () => {
+		// Without a key there is nothing to gate the administrative routes with, so activation
+		// must fail rather than continue and spawn an API that cannot be locked.
+		storage.failOn = ADMIN_KEY_SECRET_KEY;
+
+		await expect(AdminKey.load(storage)).rejects.toThrow('keychain is locked');
+	});
+
+	it('never stores the key anywhere but the administrative secret slot', async () => {
+		await AdminKey.load(storage);
+
+		expect(Object.keys(storage.values)).toEqual([ADMIN_KEY_SECRET_KEY]);
+	});
+});

--- a/apps/extension/tests/unit/api-server-health-check.test.ts
+++ b/apps/extension/tests/unit/api-server-health-check.test.ts
@@ -77,7 +77,8 @@ vi.mock('../../src/utils/better-sqlite3-installer', () => {
 
 vi.mock('@ungate/shared', () => {
 	return {
-		sleep: sleepMock
+		sleep: sleepMock,
+		ADMIN_KEY_ENV: 'UNGATE_ADMIN_KEY'
 	};
 });
 
@@ -124,6 +125,9 @@ interface ApiServerInternals {
 	shouldRespawn(): boolean;
 }
 
+/** Stand-in for the base64url 256-bit key AdminKey mints. */
+const TEST_ADMIN_KEY = 'a'.repeat(43);
+
 function createRuntimeState(): RuntimeState {
 	const runtimeState = TestHelper.createRuntimeState([], 4783);
 
@@ -153,6 +157,7 @@ function createServer(options?: { isLeaderWindow?: boolean; isExtensionHostActiv
 			extensionMode: 1,
 			extensionPath: '/tmp/ungate-extension'
 		} as never,
+		TEST_ADMIN_KEY,
 		{
 			onLog,
 			onPortDetected,
@@ -298,7 +303,8 @@ describe('ApiServer.runHealthCheckCycle', () => {
 			expect.any(Array),
 			expect.objectContaining({
 				env: expect.objectContaining({
-					UNGATE_BETTER_SQLITE3_NATIVE_BINDING: expect.stringContaining('better_sqlite3.installed.node')
+					UNGATE_BETTER_SQLITE3_NATIVE_BINDING: expect.stringContaining('better_sqlite3.installed.node'),
+					UNGATE_ADMIN_KEY: TEST_ADMIN_KEY
 				})
 			})
 		);

--- a/apps/extension/tests/unit/dashboard-admin-key.test.ts
+++ b/apps/extension/tests/unit/dashboard-admin-key.test.ts
@@ -1,0 +1,155 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TestHelper } from './helpers/test-helper';
+
+const createWebviewPanelMock = vi.fn();
+const fileUriMock = vi.fn((value: string) => {
+	return { fsPath: value, toString: () => value };
+});
+
+let indexHtml = '<html><head></head><body></body></html>';
+
+vi.mock('node:fs', () => {
+	return {
+		readFileSync: vi.fn(() => indexHtml)
+	};
+});
+
+vi.mock('../../src/runtime-state/shared-log-store', () => {
+	return {
+		SharedLogStore: {
+			append() {},
+			readAll() {
+				return [];
+			},
+			readSince() {
+				return { entries: [], nextOffset: 0 };
+			},
+			getFileSize() {
+				return 0;
+			},
+			clear() {}
+		}
+	};
+});
+
+vi.mock('vscode', () => {
+	class Disposable {
+		dispose(): void {}
+	}
+
+	return {
+		window: {
+			createWebviewPanel: createWebviewPanelMock
+		},
+		ViewColumn: {
+			One: 1
+		},
+		Uri: {
+			file: fileUriMock
+		},
+		ExtensionMode: {
+			Development: 1,
+			Production: 2
+		},
+		MarkdownString: TestHelper.createMarkdownStringClass(),
+		Disposable
+	};
+});
+
+let Dashboard: typeof import('../../src/dashboard').Dashboard;
+let toInlineScriptJson: typeof import('../../src/dashboard').toInlineScriptJson;
+
+function createPanel() {
+	return {
+		webview: {
+			html: '',
+			postMessage: vi.fn(),
+			asWebviewUri: vi.fn((value) => value),
+			onDidReceiveMessage: vi.fn()
+		},
+		onDidChangeViewState: vi.fn(),
+		onDidDispose: vi.fn(),
+		reveal: vi.fn(),
+		visible: true,
+		iconPath: null
+	};
+}
+
+function showDashboard(adminApiKey: string) {
+	const panel = createPanel();
+	createWebviewPanelMock.mockReturnValue(panel);
+
+	const dashboard = new Dashboard(
+		{
+			extensionMode: 1,
+			extensionPath: '/tmp/ungate-extension'
+		} as never,
+		adminApiKey,
+		() => {}
+	);
+	dashboard.show();
+
+	return { dashboard, panel };
+}
+
+describe('Dashboard admin key injection', () => {
+	beforeAll(async () => {
+		const module = await import('../../src/dashboard');
+		Dashboard = module.Dashboard;
+		toInlineScriptJson = module.toInlineScriptJson;
+	});
+
+	beforeEach(() => {
+		createWebviewPanelMock.mockReset();
+		fileUriMock.mockClear();
+		indexHtml = '<html><head></head><body></body></html>';
+	});
+
+	it('injects the admin key and port into the webview bootstrap', () => {
+		const { panel } = showDashboard('f'.repeat(64));
+
+		expect(panel.webview.html).toContain(`window.__ADMIN_KEY__ = "${'f'.repeat(64)}"`);
+		expect(panel.webview.html).toContain('window.__PORT__ = null');
+	});
+
+	it('keeps the injected key inside the script element when it contains HTML', () => {
+		// A key can only be hex or base64url in practice, but the injection must stay inert for any
+		// value: an unescaped `</script>` would end the element and turn the rest into markup.
+		const hostileKey = '</script><img src=x onerror=alert(1)>';
+		const { panel } = showDashboard(hostileKey);
+
+		expect(panel.webview.html).not.toContain('</script><img');
+		expect(panel.webview.html).not.toContain('<img src=x');
+		expect(panel.webview.html).toContain('\\u003c/script\\u003e');
+	});
+
+	it('escapes every character that could break out of an inline script', () => {
+		expect(toInlineScriptJson('</script>')).toBe('"\\u003c/script\\u003e"');
+		expect(toInlineScriptJson('a&b')).toBe('"a\\u0026b"');
+		expect(toInlineScriptJson('line\u2028break')).toBe('"line\\u2028break"');
+		expect(toInlineScriptJson('para\u2029break')).toBe('"para\\u2029break"');
+		expect(toInlineScriptJson(null)).toBe('null');
+		expect(toInlineScriptJson(4783)).toBe('4783');
+	});
+
+	it('does not let a key containing $ patterns corrupt the surrounding html', () => {
+		// A plain replacement string would expand `$&` into the matched `</head>` and `` $` `` into
+		// everything before it. The `&` is separately escaped as \u0026; the `$` runs must survive
+		// verbatim, which is what proves no replacement-pattern expansion happened.
+		const { panel } = showDashboard('$&$`$0');
+
+		expect(panel.webview.html).toContain('window.__ADMIN_KEY__ = "$\\u0026$`$0"');
+		expect(panel.webview.html).toContain('</head>');
+		expect(panel.webview.html).toContain('<body></body>');
+	});
+
+	it('re-injects the current port on rebuild without dropping the admin key', () => {
+		const { dashboard, panel } = showDashboard('f'.repeat(64));
+
+		dashboard.setPort(4783);
+
+		expect(panel.webview.html).toContain('window.__PORT__ = 4783');
+		expect(panel.webview.html).toContain(`window.__ADMIN_KEY__ = "${'f'.repeat(64)}"`);
+	});
+});

--- a/apps/extension/tests/unit/dashboard-set-port.test.ts
+++ b/apps/extension/tests/unit/dashboard-set-port.test.ts
@@ -104,6 +104,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		dashboard.show();
@@ -128,6 +129,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		dashboard.show();
@@ -147,6 +149,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		const dashboardB = new Dashboard(
@@ -154,6 +157,7 @@ describe('Dashboard.setPort', () => {
 				extensionMode: 1,
 				extensionPath: '/tmp/ungate-extension'
 			} as never,
+			'admin-key',
 			() => {}
 		);
 		dashboardA.pushLog('api', { timestamp: 1, level: 'info', message: 'started elsewhere' });

--- a/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
+++ b/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
@@ -192,9 +192,24 @@ function createRuntimeState(windowIds: string[], apiPort: number | null = 4783):
 }
 
 function createContext() {
+	const stored: Record<string, string> = {};
+
 	return {
 		subscriptions: [],
-		extensionPath: '/tmp/ungate-extension'
+		extensionPath: '/tmp/ungate-extension',
+		secrets: {
+			get: (key: string) => Promise.resolve(stored[key]),
+			store: (key: string, value: string) => {
+				stored[key] = value;
+
+				return Promise.resolve();
+			},
+			delete: (key: string) => {
+				delete stored[key];
+
+				return Promise.resolve();
+			}
+		}
 	};
 }
 
@@ -329,7 +344,7 @@ describe('ExtensionController', () => {
 			startRuntimeSync: vi.fn()
 		});
 
-		controller.activate();
+		await controller.activate();
 
 		await vi.waitFor(() => {
 			expect(apiServerStartMock).toHaveBeenCalledTimes(1);
@@ -376,7 +391,7 @@ describe('ExtensionController', () => {
 			startRuntimeSync: vi.fn()
 		});
 
-		controller.activate();
+		await controller.activate();
 
 		await vi.waitFor(() => {
 			expect(apiServerStartMock).toHaveBeenCalledTimes(1);

--- a/apps/web/src/shared/api.ts
+++ b/apps/web/src/shared/api.ts
@@ -1,4 +1,5 @@
 import {
+	ADMIN_KEY_HEADER,
 	sleep,
 	type AnalyticsSummary,
 	type AppSettings,
@@ -8,7 +9,7 @@ import {
 } from '@ungate/shared/frontend';
 
 export class Api {
-	private static port: number | null = (window as unknown as { __PORT__?: number | null }).__PORT__ ?? null;
+	private static port: number | null = window.__PORT__ ?? null;
 	private static readonly portWaiters = new Set<(port: number) => void>();
 
 	static {
@@ -30,7 +31,7 @@ export class Api {
 	}
 
 	private static async getPort(): Promise<number> {
-		const injected = (window as unknown as { __PORT__?: number | null }).__PORT__;
+		const injected = window.__PORT__;
 
 		if (injected) {
 			return injected;
@@ -65,9 +66,25 @@ export class Api {
 		return `http://localhost:${port}`;
 	}
 
+	/**
+	 * Administrative routes (settings, provider auth, analytics) require the admin key that the
+	 * extension injects into this webview. It is read per request rather than cached, so a webview
+	 * HTML rebuild always wins. Proxy routes are never called from here.
+	 */
+	private static adminHeaders(base?: Record<string, string>): Record<string, string> {
+		const key = window.__ADMIN_KEY__;
+		const headers: Record<string, string> = { ...base };
+
+		if (key) {
+			headers[ADMIN_KEY_HEADER] = key;
+		}
+
+		return headers;
+	}
+
 	private static async get<T>(path: string): Promise<T> {
 		const baseUrl = await this.baseUrl();
-		const response = await fetch(`${baseUrl}${path}`);
+		const response = await fetch(`${baseUrl}${path}`, { headers: this.adminHeaders() });
 
 		if (!response.ok) {
 			throw new Error(`GET ${path} failed: ${response.status}`);
@@ -80,7 +97,7 @@ export class Api {
 		const baseUrl = await this.baseUrl();
 		const response = await fetch(`${baseUrl}${path}`, {
 			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
+			headers: this.adminHeaders({ 'Content-Type': 'application/json' }),
 			body: JSON.stringify(body ?? {})
 		});
 

--- a/apps/web/src/types/shims/webview-globals.d.ts
+++ b/apps/web/src/types/shims/webview-globals.d.ts
@@ -1,0 +1,8 @@
+// Globals the extension injects into the dashboard webview HTML before any module runs.
+// `__PORT__` is the port the local API listens on; `__ADMIN_KEY__` is the key required by
+// administrative routes and is deliberately never persisted anywhere the webview can write.
+interface Window {
+	__PORT__?: number | null;
+	__ADMIN_KEY__?: string | null;
+	__TS__?: number;
+}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,17 @@
+// Administrative routes (settings, provider auth, analytics) are gated by a key that is
+// separate from the proxy API key Cursor uses. The extension mints it per install and
+// keeps it in VS Code SecretStorage, so it never reaches the SQLite settings table.
+export const ADMIN_KEY_HEADER = 'x-ungate-admin-key';
+
+export const ADMIN_KEY_ENV = 'UNGATE_ADMIN_KEY';
+
+/** VS Code SecretStorage key holding the administrative API key the extension mints per install. */
+export const ADMIN_KEY_SECRET_KEY = 'ungate.admin-api-key';
+
+// A 256-bit key is 43 characters base64url-encoded and 64 characters hex-encoded.
+// Anything shorter than the base64url length cannot carry 256 bits of entropy.
+export const ADMIN_KEY_MIN_LENGTH = 43;
+
 export const DEFAULT_KEY_FIX_ENABLED = false;
 
 export const MINIMAX_BASE_URLS = {


### PR DESCRIPTION
## Summary

- Bind the API to `127.0.0.1` instead of every network interface.
- Protect settings, provider auth, and analytics with a separate 256-bit admin key.
- Store the admin key in VS Code SecretStorage and inject it safely into the dashboard.
- Make proxy authentication fail closed and protect `/v1/models`.
- Replace wildcard CORS with a Cursor webview and loopback origin policy.

`/health` remains unauthenticated for local health checks. Provider credential persistence is intentionally unchanged in this PR.

This is split from #42 following review feedback.

## Verification

- Extension: 81 tests passed
- API unit: 103 tests passed
- API integration: 74 tests passed
- API TypeScript build passed
- Svelte check passed with 0 errors and 0 warnings
- Extension build passed
