### PR TITLE
fix(security): move credentials to SecretStorage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Fastify server, spawned by the extension as a child Node.js process.
 
 **Database (`src/database/`):**
 - SQLite via Drizzle ORM + better-sqlite3
-- Tables: `app_settings` (port, apiKey, quiet, extraInstruction), `provider_settings` (per-provider OAuth tokens, refresh tokens, expiry), `model_mappings` (id, label, provider, upstreamModel, reasoningBudget), `requests` (analytics)
+- Tables: `app_settings` (port, apiKey, quiet, extraInstruction), `provider_settings` (per-provider metadata: expiry, email, accountId, baseUrl — the `access_token`/`refresh_token` columns are legacy and always blank), `model_mappings` (id, label, provider, upstreamModel, reasoningBudget), `requests` (analytics)
 - Migrations: `apps/api/drizzle/` — idempotent (`CREATE TABLE IF NOT EXISTS`, `INSERT OR IGNORE`)
 
 **Types (`src/types/`):**
@@ -100,14 +100,21 @@ Fastify server, spawned by the extension as a child Node.js process.
 
 **Auth (`src/auth/`):**
 - OAuth PKCE flow for Anthropic: `startLogin()` generates verifier/challenge, `completeLogin()` exchanges code for tokens. Manual `CODE#STATE` entry required (Anthropic rejects localhost redirect_uri for claude.ai OAuth).
+- Provider methods are async — credentials come from the extension, not the database.
+
+**Security (`src/security/`):**
+- `provider-secrets.ts` — process-wide credential facade over a pluggable transport. Reads deny when no transport is installed, writes throw `SecretStorageUnavailableError`
+- `ipc-secret-transport.ts` — request/response client over the child process IPC channel
+- `credential-channel.ts` — `requireCredentialChannel()`: installs the transport or throws `CredentialChannelMissingError`, then exits the process if the channel is later lost. Called first from `main.ts`, before the legacy migration and before `startServer()`
 
 ## apps/extension — VS Code extension
 
 User entry point. Manages the API server and tunnel lifecycle.
 
 - `extension.ts` — activate/deactivate
-- `extension-controller.ts` — main controller: manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
-- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex
+- `extension-controller.ts` — main controller: creates the `ProviderSecretBroker`, manages API server, tunnel, WebView dashboard, OpenAI Key Fix, heartbeat, runtime state sync
+- `provider-secret-broker.ts` — owner of the provider credentials in VS Code SecretStorage. `handleApiChildMessage` answers the API child's credential requests; nothing is written to SQLite, the runtime state file, or the log
+- `api-server.ts` — start/stop Node.js API as child process. Production: `cp.spawn(runtime, ['bundle/main.cjs'])`. Dev: `cp.spawn('node', ['-r', 'source-map-support/register', 'dist/main.js'])`. Port detected from stdout via `localhost:(\d+)` regex. Spawned with a fourth `ipc` stdio slot for credential requests
 - `tunnel-manager.ts` — Cloudflare tunnel (cloudflared) management. Quick tunnel only, no named tunnel config (avoids 404 conflicts). Not auto-started, only on explicit user action. Auto-restarts on port change if already running
 - `dashboard.ts` — WebView dashboard (Svelte UI). Reads `index.html` from `web/dist/`, rewrites `/assets/` to `vscode-resource:` URIs, injects `window.__PORT__`. Handshake: frontend sends `webview-ready` before extension sends initial state
 - `extension-status-bar.ts` — status bar (API + tunnel state)
@@ -139,7 +146,7 @@ Dashboard for managing providers, tunnel, settings.
 
 Types, constants, Zod schemas, helpers.
 
-- `src/types/` — `settings.ts`, `runtime.ts`, `tunnel.ts`, `analytics.ts`, `log.ts`
+- `src/types/` — `settings.ts`, `runtime.ts`, `tunnel.ts`, `analytics.ts`, `log.ts`, `secrets.ts`
 - `src/constants/` — `routes.ts`
 - `src/enums/` — `common.ts`
 - `src/helpers/` — `model-provider.ts`, `provider-labels.ts`, `utils.ts`
@@ -149,7 +156,9 @@ Types, constants, Zod schemas, helpers.
 
 ## Key mechanisms
 
-**Claude OAuth authentication:** acquires token via Anthropic OAuth PKCE flow, stores in SQLite. Refreshes token on 401. Anthropic requires exact request fingerprint: `?beta=true` URL suffix, `User-Agent: claude-cli/2.1.9`, full `x-stainless-*` headers, `anthropic-dangerous-direct-browser-access: true`, three `anthropic-beta` feature flags (oauth, claude-code, interleaved-thinking). Manual `CODE#STATE` entry required — Anthropic does not accept localhost as redirect_uri for claude.ai OAuth.
+**Claude OAuth authentication:** acquires token via Anthropic OAuth PKCE flow, stores the credential in the extension secret store (never SQLite). Refreshes token on 401. Anthropic requires exact request fingerprint: `?beta=true` URL suffix, `User-Agent: claude-cli/2.1.9`, full `x-stainless-*` headers, `anthropic-dangerous-direct-browser-access: true`, three `anthropic-beta` feature flags (oauth, claude-code, interleaved-thinking). Manual `CODE#STATE` entry required — Anthropic does not accept localhost as redirect_uri for claude.ai OAuth.
+
+**Credential storage:** provider access and refresh tokens live in VS Code SecretStorage under `ungate.provider.<provider>`, owned by the extension (`provider-secret-broker.ts`). The API child process asks for them over its IPC channel (`ungate.provider-secret` messages, protocol in `packages/shared/src/types/secrets.ts`); `ProviderSettings` joins that credential with the SQLite metadata row. Every message is validated and correlated by request id; a missing or closed channel fails closed — reads deny, writes throw. `main.ts` refuses to start at all without the channel (`requireCredentialChannel()`), so the API is never up while unable to serve any provider, and the legacy migration never blanks a column it cannot drain. Then `ProviderSettings.migrateLegacySecrets()` moves credentials left in the legacy SQLite columns into the secret store and blanks them. Losing the channel later is equally fatal: the process exits on `disconnect` and the leader window respawns it.
 
 **System prompt conflict:** Claude Code's system prompt describing tools conflicts with Cursor's actual `input_schema`. The prompt must be minimal (just identity) and delegate tool shape to `input_schema`. The `extraInstruction` field in `app_settings` reinforces this priority. Full removal breaks API contract (empty blocks error), long prompts cause `invalid arguments` on large plans.
 

--- a/apps/api/src/auth/base-provider.ts
+++ b/apps/api/src/auth/base-provider.ts
@@ -8,9 +8,10 @@ export interface OAuthCredentials {
 	accountId?: string | null;
 }
 
+/** Every member is async: credentials live in the extension secret store, one IPC hop away. */
 export interface AIProvider {
 	readonly name: AIProviderName;
-	getAuthHeader(): string | null | Promise<string | null>;
-	isAuthenticated(): boolean;
-	logout(): void;
+	getAuthHeader(): Promise<string | null>;
+	isAuthenticated(): Promise<boolean>;
+	logout(): Promise<void>;
 }

--- a/apps/api/src/auth/claude-provider.ts
+++ b/apps/api/src/auth/claude-provider.ts
@@ -15,11 +15,13 @@ export class ClaudeProvider implements AIProvider {
 		return `Bearer ${token.accessToken}`;
 	}
 
-	isAuthenticated(): boolean {
-		return OAuth.getAuthStatus().authenticated;
+	async isAuthenticated(): Promise<boolean> {
+		const status = await OAuth.getAuthStatus();
+
+		return status.authenticated;
 	}
 
-	logout(): void {
-		OAuth.logout();
+	async logout(): Promise<void> {
+		await OAuth.logout();
 	}
 }

--- a/apps/api/src/auth/oauth.ts
+++ b/apps/api/src/auth/oauth.ts
@@ -120,7 +120,7 @@ export class OAuth {
 			const expiresAt = Date.now() + data.expires_in * 1000;
 			const email = data.account?.email_address;
 
-			ProviderSettings.upsertOAuth('claude', {
+			await ProviderSettings.upsertOAuth('claude', {
 				accessToken: data.access_token,
 				refreshToken: data.refresh_token,
 				expiresAt,
@@ -167,7 +167,7 @@ export class OAuth {
 			const data: TokenRefreshResponse = await response.json();
 			const expiresAt = Date.now() + data.expires_in * 1000;
 
-			ProviderSettings.upsertOAuth('claude', {
+			await ProviderSettings.upsertOAuth('claude', {
 				accessToken: data.access_token,
 				refreshToken: data.refresh_token,
 				expiresAt
@@ -191,9 +191,9 @@ export class OAuth {
 	}
 
 	static async getValidToken(): Promise<TokenInfo | null> {
-		const row = ProviderSettings.get('claude');
+		const row = await ProviderSettings.get('claude');
 
-		if (!row) {
+		if (!row?.accessToken) {
 			return null;
 		}
 
@@ -208,24 +208,28 @@ export class OAuth {
 			return result;
 		}
 
-		return this.refreshToken(row.refreshToken!);
+		if (!row.refreshToken) {
+			return null;
+		}
+
+		return this.refreshToken(row.refreshToken);
 	}
 
-	// No-op — token state is DB-backed, no in-memory cache to clear
+	// No-op — token state lives in the extension secret store, no in-memory cache to clear
 	static clearCachedToken(): void {}
 
-	static getAuthStatus(): AuthStatus {
-		const row = ProviderSettings.get('claude');
+	static async getAuthStatus(): Promise<AuthStatus> {
+		const row = await ProviderSettings.get('claude');
 
-		if (!row) {
+		if (!row?.accessToken) {
 			return { authenticated: false };
 		}
 
 		return { authenticated: true, email: row.email ?? undefined };
 	}
 
-	static logout(): void {
-		ProviderSettings.remove('claude');
+	static async logout(): Promise<void> {
+		await ProviderSettings.remove('claude');
 		logger.log('✓ Logged out, OAuth tokens deleted');
 	}
 }

--- a/apps/api/src/auth/openai/openai-oauth-service.ts
+++ b/apps/api/src/auth/openai/openai-oauth-service.ts
@@ -83,16 +83,16 @@ export class OpenAIOAuthService {
 			accountId: accountId ?? undefined
 		};
 
-		ProviderSettings.upsertOAuth('openai', credentials);
+		await ProviderSettings.upsertOAuth('openai', credentials);
 		logger.log('✓ OpenAI OAuth login complete', email ? `(${email})` : '');
 
 		return { ok: true, email: email ?? undefined };
 	}
 
 	public static async getValidToken(): Promise<OAuthCredentials | null> {
-		const credentials = ProviderSettings.get('openai');
+		const credentials = await ProviderSettings.get('openai');
 
-		if (!credentials) {
+		if (!credentials?.accessToken) {
 			return null;
 		}
 
@@ -113,7 +113,7 @@ export class OpenAIOAuthService {
 			return null;
 		}
 
-		const existingCredentials = ProviderSettings.get('openai');
+		const existingCredentials = ProviderSettings.getMetadata('openai');
 		const expiresIn = typeof tokens.expires_in === 'number' ? tokens.expires_in : 3600;
 		const credentials: OAuthCredentials = {
 			accessToken: tokens.access_token as string,
@@ -123,14 +123,14 @@ export class OpenAIOAuthService {
 			accountId: existingCredentials?.accountId ?? undefined
 		};
 
-		ProviderSettings.upsertOAuth('openai', credentials);
+		await ProviderSettings.upsertOAuth('openai', credentials);
 		logger.log('OpenAI token refreshed successfully');
 
 		return credentials;
 	}
 
-	public static getAuthStatus(): { authenticated: boolean; email?: string } {
-		const credentials = ProviderSettings.get('openai');
+	public static async getAuthStatus(): Promise<{ authenticated: boolean; email?: string }> {
+		const credentials = await ProviderSettings.get('openai');
 
 		return {
 			authenticated: !!credentials?.accessToken,
@@ -138,8 +138,8 @@ export class OpenAIOAuthService {
 		};
 	}
 
-	public static logout(): void {
-		ProviderSettings.remove('openai');
+	public static async logout(): Promise<void> {
+		await ProviderSettings.remove('openai');
 		logger.log('✓ OpenAI OAuth logged out, tokens deleted');
 	}
 

--- a/apps/api/src/auth/static-token-provider.ts
+++ b/apps/api/src/auth/static-token-provider.ts
@@ -9,8 +9,8 @@ export class StaticTokenProvider implements AIProvider {
 		this.name = name;
 	}
 
-	getAuthHeader(): string | null {
-		const creds = ProviderSettings.get(this.name);
+	async getAuthHeader(): Promise<string | null> {
+		const creds = await ProviderSettings.get(this.name);
 
 		if (!creds?.accessToken) {
 			return null;
@@ -19,13 +19,11 @@ export class StaticTokenProvider implements AIProvider {
 		return `Bearer ${creds.accessToken}`;
 	}
 
-	isAuthenticated(): boolean {
-		const creds = ProviderSettings.get(this.name);
-
-		return !!creds?.accessToken;
+	async isAuthenticated(): Promise<boolean> {
+		return ProviderSettings.hasCredentials(this.name);
 	}
 
-	logout(): void {
-		ProviderSettings.remove(this.name);
+	async logout(): Promise<void> {
+		await ProviderSettings.remove(this.name);
 	}
 }

--- a/apps/api/src/database/provider-settings.ts
+++ b/apps/api/src/database/provider-settings.ts
@@ -1,59 +1,128 @@
 import { eq } from 'drizzle-orm';
 
+import { isModelMappingProvider } from '@ungate/shared';
+import { logger } from 'src/utils/logger';
+
+import { ProviderSecrets } from '../security/provider-secrets';
+
 import { providerSettings } from './schema';
 
 import { getDb } from './index';
 
 import type { AIProviderName, OAuthCredentials } from '../auth/base-provider';
 
+/** Everything about a provider that is safe to keep in SQLite. */
+export interface ProviderMetadata {
+	provider: string;
+	expiresAt: number | null;
+	email: string | null;
+	accountId: string | null;
+	createdAt: number;
+	baseUrl: string | null;
+}
+
+/** Metadata joined with the credentials held by the extension. */
+export interface ProviderCredentials extends ProviderMetadata {
+	/** Empty when no credential is stored for an otherwise known provider. */
+	accessToken: string;
+	refreshToken: string | null;
+}
+
+/**
+ * `access_token` / `refresh_token` are legacy columns. They are never written with a real
+ * value anymore — {@link ProviderSettings.migrateLegacySecrets} moves pre-existing values
+ * into the extension secret store and blanks them.
+ */
+const METADATA_COLUMNS = {
+	provider: providerSettings.provider,
+	expiresAt: providerSettings.expiresAt,
+	email: providerSettings.email,
+	accountId: providerSettings.accountId,
+	createdAt: providerSettings.createdAt,
+	baseUrl: providerSettings.baseUrl
+};
+
+const BLANK_LEGACY_SECRETS = { accessToken: '', refreshToken: null };
+
 export class ProviderSettings {
-	static get(provider: AIProviderName) {
+	/** Non-secret fields only. Cheap: no round trip to the extension. */
+	static getMetadata(provider: AIProviderName): ProviderMetadata | undefined {
 		const db = getDb();
 
-		return db.select().from(providerSettings).where(eq(providerSettings.provider, provider)).get();
+		return db.select(METADATA_COLUMNS).from(providerSettings).where(eq(providerSettings.provider, provider)).get();
 	}
 
-	static upsertApiKey(provider: AIProviderName, accessToken: string, baseUrl?: string): void {
+	static async get(provider: AIProviderName): Promise<ProviderCredentials | undefined> {
+		const metadata = this.getMetadata(provider);
+
+		if (!metadata) {
+			return undefined;
+		}
+
+		const secret = await ProviderSecrets.read(provider);
+
+		return {
+			...metadata,
+			accessToken: secret?.accessToken ?? '',
+			refreshToken: secret?.refreshToken ?? null
+		};
+	}
+
+	static async hasCredentials(provider: AIProviderName): Promise<boolean> {
+		const credentials = await this.get(provider);
+
+		return !!credentials?.accessToken;
+	}
+
+	static async upsertApiKey(provider: AIProviderName, accessToken: string, baseUrl?: string): Promise<void> {
+		// Secret first: a metadata row without a credential is merely unauthenticated, while a
+		// credential without a row is unreachable.
+		await ProviderSecrets.write(provider, { accessToken, refreshToken: null });
+
 		const db = getDb();
 
 		db.insert(providerSettings)
 			.values({
 				provider,
-				accessToken,
+				...BLANK_LEGACY_SECRETS,
 				createdAt: Date.now(),
 				...(baseUrl && { baseUrl })
 			})
 			.onConflictDoUpdate({
 				target: providerSettings.provider,
 				set: {
-					accessToken,
+					...BLANK_LEGACY_SECRETS,
 					...(baseUrl !== undefined && { baseUrl })
 				}
 			})
 			.run();
 	}
 
-	static upsertOAuth(provider: AIProviderName, data: OAuthCredentials): void {
+	static async upsertOAuth(provider: AIProviderName, data: OAuthCredentials): Promise<void> {
+		await ProviderSecrets.write(provider, {
+			accessToken: data.accessToken,
+			refreshToken: data.refreshToken ?? null
+		});
+
 		const db = getDb();
+		const metadata = {
+			expiresAt: data.expiresAt,
+			email: data.email ?? null,
+			accountId: data.accountId ?? null
+		};
 
 		db.insert(providerSettings)
 			.values({
 				provider,
-				accessToken: data.accessToken,
-				refreshToken: data.refreshToken,
-				expiresAt: data.expiresAt,
-				email: data.email ?? null,
-				accountId: data.accountId ?? null,
+				...BLANK_LEGACY_SECRETS,
+				...metadata,
 				createdAt: Date.now()
 			})
 			.onConflictDoUpdate({
 				target: providerSettings.provider,
 				set: {
-					accessToken: data.accessToken,
-					refreshToken: data.refreshToken,
-					expiresAt: data.expiresAt,
-					email: data.email ?? null,
-					accountId: data.accountId ?? null
+					...BLANK_LEGACY_SECRETS,
+					...metadata
 				}
 			})
 			.run();
@@ -61,9 +130,8 @@ export class ProviderSettings {
 
 	static updateBaseUrl(provider: AIProviderName, baseUrl: string): boolean {
 		const db = getDb();
-		const existing = this.get(provider);
 
-		if (!existing) {
+		if (!this.getMetadata(provider)) {
 			return false;
 		}
 
@@ -72,9 +140,52 @@ export class ProviderSettings {
 		return true;
 	}
 
-	static remove(provider: AIProviderName): void {
-		const db = getDb();
+	static async remove(provider: AIProviderName): Promise<void> {
+		try {
+			await ProviderSecrets.erase(provider);
+		} finally {
+			getDb().delete(providerSettings).where(eq(providerSettings.provider, provider)).run();
+		}
+	}
 
-		db.delete(providerSettings).where(eq(providerSettings.provider, provider)).run();
+	/**
+	 * Moves credentials written by older versions out of SQLite and blanks the columns. Runs
+	 * once per database: after the first pass there is nothing left to move. Throws when the
+	 * secret store is unreachable so that plaintext is never dropped without a safe copy.
+	 */
+	static async migrateLegacySecrets(): Promise<void> {
+		const db = getDb();
+		const legacyRows = db
+			.select({
+				provider: providerSettings.provider,
+				accessToken: providerSettings.accessToken,
+				refreshToken: providerSettings.refreshToken
+			})
+			.from(providerSettings)
+			.all();
+
+		for (const row of legacyRows) {
+			const accessToken = row.accessToken ?? '';
+			const refreshToken = row.refreshToken ?? '';
+
+			if (!accessToken && !refreshToken) {
+				continue;
+			}
+
+			if (isModelMappingProvider(row.provider)) {
+				const stored = await ProviderSecrets.read(row.provider);
+
+				// A credential written since the last restart is newer than the legacy column.
+				if (!stored?.accessToken) {
+					await ProviderSecrets.write(row.provider, { accessToken, refreshToken: refreshToken || null });
+				}
+
+				logger.log(`[secrets] moved legacy ${row.provider} credentials into the extension secret store`);
+			} else {
+				logger.error(`[secrets] scrubbed legacy credentials of unknown provider "${row.provider}"`);
+			}
+
+			db.update(providerSettings).set(BLANK_LEGACY_SECRETS).where(eq(providerSettings.provider, row.provider)).run();
+		}
 	}
 }

--- a/apps/api/src/database/schema.ts
+++ b/apps/api/src/database/schema.ts
@@ -12,6 +12,11 @@ export const appSettings = sqliteTable('app_settings', {
 
 export const providerSettings = sqliteTable('provider_settings', {
 	provider: text().primaryKey(),
+	/**
+	 * Legacy: credentials moved to the extension secret store. Kept so
+	 * `ProviderSettings.migrateLegacySecrets()` can drain and blank pre-existing rows; new
+	 * writes always store an empty string / null here.
+	 */
 	accessToken: text().notNull(),
 	refreshToken: text(),
 	expiresAt: integer(),

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,6 +1,17 @@
+import { ProviderSettings } from './database/provider-settings';
+import { requireCredentialChannel } from './security/credential-channel';
 import { startServer } from './server';
 
-startServer().catch((err) => {
+async function bootstrap(): Promise<void> {
+	// Nothing may start without the extension credential channel: it is the only source of
+	// provider credentials, and the legacy migration must not blank a column it cannot drain.
+	requireCredentialChannel();
+
+	await ProviderSettings.migrateLegacySecrets();
+	await startServer();
+}
+
+bootstrap().catch((err: unknown) => {
 	console.error(err);
 	process.exit(1);
 });

--- a/apps/api/src/proxy/anthropic-client.ts
+++ b/apps/api/src/proxy/anthropic-client.ts
@@ -67,7 +67,7 @@ async function makeClaudeCodeRequest(
 			const errorBody = await response.clone().text();
 			logger.error(`Claude Code 401 error: ${errorBody}`);
 
-			const row = ProviderSettings.get('claude');
+			const row = await ProviderSettings.get('claude');
 
 			if (row?.refreshToken) {
 				logger.log('Attempting token refresh after 401...');

--- a/apps/api/src/proxy/minimax-client.ts
+++ b/apps/api/src/proxy/minimax-client.ts
@@ -11,8 +11,8 @@ export async function proxyMiniMaxRequest(body: OpenAIChatRequest): Promise<{
 	response: Response;
 	context: RequestContext;
 }> {
-	const creds = ProviderSettings.get('minimax');
-	const minimaxUrl = creds?.baseUrl ?? config.minimax.baseUrlGlobal;
+	const metadata = ProviderSettings.getMetadata('minimax');
+	const minimaxUrl = metadata?.baseUrl ?? config.minimax.baseUrlGlobal;
 	const provider = getProvider('minimax');
 	const authHeader = await provider.getAuthHeader();
 

--- a/apps/api/src/proxy/openai-client.ts
+++ b/apps/api/src/proxy/openai-client.ts
@@ -28,7 +28,7 @@ export class OpenAiClient {
 		const model = body.model;
 		const resolvedModel = ResponsesModelResolver.resolveModel(model);
 		const normalizedModel = resolvedModel.model;
-		const creds = ProviderSettings.get('openai');
+		const creds = await ProviderSettings.get('openai');
 
 		if (!creds?.accessToken) {
 			return this.authErrorResult(model, startTime, 'Not authenticated with OpenAI');

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -24,18 +24,20 @@ const plugin: FastifyPluginCallback = (app) => {
 		return reply.send(result);
 	});
 
-	app.get('/auth/claude/status', (_request, reply) => {
-		return reply.send(OAuth.getAuthStatus());
+	app.get('/auth/claude/status', async (_request, reply) => {
+		const status = await OAuth.getAuthStatus();
+
+		return reply.send(status);
 	});
 
-	app.post('/auth/claude/logout', (_request, reply) => {
-		OAuth.logout();
+	app.post('/auth/claude/logout', async (_request, reply) => {
+		await OAuth.logout();
 
 		return reply.send({ ok: true });
 	});
 
-	app.get('/auth/minimax/status', (_request, reply) => {
-		const creds = ProviderSettings.get('minimax');
+	app.get('/auth/minimax/status', async (_request, reply) => {
+		const creds = await ProviderSettings.get('minimax');
 
 		return reply.send({
 			authenticated: !!creds?.accessToken,
@@ -50,7 +52,7 @@ const plugin: FastifyPluginCallback = (app) => {
 			return reply.code(400).send({ ok: false, error: 'API key is required' });
 		}
 
-		ProviderSettings.upsertApiKey('minimax', apiKey.trim(), baseUrl?.trim());
+		await ProviderSettings.upsertApiKey('minimax', apiKey.trim(), baseUrl?.trim());
 
 		return reply.send({ ok: true });
 	});
@@ -72,8 +74,8 @@ const plugin: FastifyPluginCallback = (app) => {
 		return reply.send({ ok: true });
 	});
 
-	app.post('/auth/minimax/logout', (_request, reply) => {
-		ProviderSettings.remove('minimax');
+	app.post('/auth/minimax/logout', async (_request, reply) => {
+		await ProviderSettings.remove('minimax');
 
 		return reply.send({ ok: true });
 	});
@@ -101,12 +103,14 @@ const plugin: FastifyPluginCallback = (app) => {
 		return reply.type('text/html').send(`<html><body><h1>Error</h1><p>${result.error ?? 'Unknown error'}</p></body></html>`);
 	});
 
-	app.get('/auth/openai/status', (_request, reply) => {
-		return reply.send(OpenAIOAuthService.getAuthStatus());
+	app.get('/auth/openai/status', async (_request, reply) => {
+		const status = await OpenAIOAuthService.getAuthStatus();
+
+		return reply.send(status);
 	});
 
-	app.post('/auth/openai/logout', (_request, reply) => {
-		OpenAIOAuthService.logout();
+	app.post('/auth/openai/logout', async (_request, reply) => {
+		await OpenAIOAuthService.logout();
 
 		return reply.send({ ok: true });
 	});

--- a/apps/api/src/security/credential-channel.ts
+++ b/apps/api/src/security/credential-channel.ts
@@ -1,0 +1,36 @@
+import { IpcSecretTransport, type SecretIpcHost } from './ipc-secret-transport';
+
+/** Process surface the credential channel needs: IPC plus the ability to end the process. */
+export interface CredentialChannelHost extends SecretIpcHost {
+	exit(code?: number): never;
+}
+
+export class CredentialChannelMissingError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'CredentialChannelMissingError';
+	}
+}
+
+/**
+ * Claims the credential channel the extension owns. Provider credentials exist nowhere else,
+ * so a process without the channel can serve no provider at all — start-up fails instead of
+ * coming up half-usable. Losing the channel later is equally fatal: the process exits so the
+ * leader window respawns it with a live channel instead of leaving an orphan on the port.
+ */
+export function requireCredentialChannel(host: CredentialChannelHost = process): IpcSecretTransport {
+	const transport = IpcSecretTransport.install(host);
+
+	if (!transport) {
+		throw new CredentialChannelMissingError(
+			'The API process was started without an IPC credential channel. Start Ungate from the extension.'
+		);
+	}
+
+	// Registered after the transport, so in-flight requests reject before the process ends.
+	host.on('disconnect', () => {
+		host.exit(0);
+	});
+
+	return transport;
+}

--- a/apps/api/src/security/ipc-secret-transport.ts
+++ b/apps/api/src/security/ipc-secret-transport.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from 'node:crypto';
+
+import {
+	PROVIDER_SECRET_CHANNEL,
+	parseProviderSecretResponse,
+	readProviderSecretEnvelope,
+	type ProviderSecret,
+	type ProviderSecretAction,
+	type ProviderSecretRequest
+} from '@ungate/shared';
+import { logger } from 'src/utils/logger';
+
+import { SecretStorageUnavailableError, useProviderSecretTransport, type ProviderSecretTransport } from './provider-secrets';
+
+import type { AIProviderName } from '../auth/base-provider';
+
+/** The extension answers from VS Code SecretStorage, which is local; a slow answer means it is gone. */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+interface PendingRequest {
+	resolve(secret: ProviderSecret | null): void;
+	reject(error: Error): void;
+	timer: NodeJS.Timeout;
+}
+
+/** Slice of `process` the transport drives. Method syntax keeps `process` assignable. */
+export interface SecretIpcHost {
+	send?(message: unknown): boolean;
+	on(event: string, listener: (payload: unknown) => void): unknown;
+}
+
+/**
+ * Request/response client for the extension-owned credential store, riding the IPC channel
+ * of the child process. Every inbound message is validated and correlated by request id;
+ * unknown ids, malformed payloads and channel loss all fail closed.
+ */
+export class IpcSecretTransport implements ProviderSecretTransport {
+	private readonly pending = new Map<string, PendingRequest>();
+	private connected = true;
+
+	private constructor(private readonly host: SecretIpcHost) {
+		this.host.on('message', (message) => {
+			this.onMessage(message);
+		});
+		this.host.on('disconnect', () => {
+			this.onDisconnect();
+		});
+	}
+
+	/** Installs the transport when the process owns an IPC channel, returns null when it does not. */
+	static install(host: SecretIpcHost = process): IpcSecretTransport | null {
+		if (typeof host.send !== 'function') {
+			return null;
+		}
+
+		const transport = new IpcSecretTransport(host);
+
+		useProviderSecretTransport(transport);
+
+		return transport;
+	}
+
+	async read(provider: AIProviderName): Promise<ProviderSecret | null> {
+		return this.request('get', provider);
+	}
+
+	async write(provider: AIProviderName, secret: ProviderSecret): Promise<void> {
+		await this.request('set', provider, secret);
+	}
+
+	async erase(provider: AIProviderName): Promise<void> {
+		await this.request('delete', provider);
+	}
+
+	private request(
+		action: ProviderSecretAction,
+		provider: AIProviderName,
+		secret?: ProviderSecret
+	): Promise<ProviderSecret | null> {
+		const send = this.host.send?.bind(this.host);
+
+		if (!this.connected || typeof send !== 'function') {
+			return Promise.reject(
+				new SecretStorageUnavailableError('The extension credential channel is closed; restart the API from the dashboard.')
+			);
+		}
+
+		const id = randomUUID();
+		const message: ProviderSecretRequest = {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id,
+			action,
+			provider,
+			...(secret && { secret })
+		};
+
+		return new Promise<ProviderSecret | null>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id);
+				reject(
+					new SecretStorageUnavailableError(`The extension did not answer a credential ${action} within ${REQUEST_TIMEOUT_MS}ms.`)
+				);
+			}, REQUEST_TIMEOUT_MS);
+
+			timer.unref?.();
+			this.pending.set(id, { resolve, reject, timer });
+
+			try {
+				// A `false` return only means the channel backlog is full; the message stays queued.
+				send(message);
+			} catch (error) {
+				this.pending.delete(id);
+				clearTimeout(timer);
+				reject(
+					new SecretStorageUnavailableError(
+						`Failed to reach the extension credential store: ${error instanceof Error ? error.message : String(error)}`
+					)
+				);
+			}
+		});
+	}
+
+	private onMessage(message: unknown): void {
+		const envelope = readProviderSecretEnvelope(message);
+
+		if (!envelope) {
+			return;
+		}
+
+		const pending = this.pending.get(envelope.id);
+
+		if (!pending) {
+			logger.error('[secrets] discarded a credential response with an unknown request id');
+
+			return;
+		}
+
+		this.pending.delete(envelope.id);
+		clearTimeout(pending.timer);
+
+		const response = parseProviderSecretResponse(message);
+
+		if (!response) {
+			pending.reject(new SecretStorageUnavailableError('The extension sent a malformed credential response.'));
+
+			return;
+		}
+
+		if (!response.ok) {
+			pending.reject(new Error(`The extension refused the credential request: ${response.error}`));
+
+			return;
+		}
+
+		pending.resolve(response.secret);
+	}
+
+	private onDisconnect(): void {
+		this.connected = false;
+
+		const abandoned = [...this.pending.values()];
+
+		this.pending.clear();
+
+		for (const request of abandoned) {
+			clearTimeout(request.timer);
+			request.reject(new SecretStorageUnavailableError('The extension closed the credential channel.'));
+		}
+
+		if (abandoned.length > 0) {
+			logger.error(`[secrets] credential channel closed with ${abandoned.length} request(s) in flight`);
+		}
+	}
+}

--- a/apps/api/src/security/provider-secrets.ts
+++ b/apps/api/src/security/provider-secrets.ts
@@ -1,0 +1,74 @@
+import { logger } from 'src/utils/logger';
+
+import type { AIProviderName } from '../auth/base-provider';
+import type { ProviderSecret } from '@ungate/shared';
+
+/**
+ * Raised when provider credentials cannot be reached at all — no IPC channel, a closed
+ * channel, or a channel that stopped answering. Writes must fail loudly rather than fall
+ * back to the database, which no longer stores credentials.
+ */
+export class SecretStorageUnavailableError extends Error {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'SecretStorageUnavailableError';
+	}
+}
+
+/** Credential store owned by the extension host. The API process only ever talks to a transport. */
+export interface ProviderSecretTransport {
+	read(provider: AIProviderName): Promise<ProviderSecret | null>;
+	write(provider: AIProviderName, secret: ProviderSecret): Promise<void>;
+	erase(provider: AIProviderName): Promise<void>;
+}
+
+let activeTransport: ProviderSecretTransport | null = null;
+
+/** Installs (or clears, with `null`) the process-wide credential transport. */
+export function useProviderSecretTransport(transport: ProviderSecretTransport | null): void {
+	activeTransport = transport;
+}
+
+export class ProviderSecrets {
+	/**
+	 * Reads deny by default: without a working channel the provider counts as unauthenticated
+	 * instead of falling back to any other source. Failures are logged by provider name only.
+	 */
+	static async read(provider: AIProviderName): Promise<ProviderSecret | null> {
+		if (!activeTransport) {
+			logger.error(`[secrets] no credential channel available, treating ${provider} as unauthenticated`);
+
+			return null;
+		}
+
+		try {
+			return await activeTransport.read(provider);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+
+			logger.error(`[secrets] failed to read ${provider} credentials: ${message}`);
+
+			return null;
+		}
+	}
+
+	static async write(provider: AIProviderName, secret: ProviderSecret): Promise<void> {
+		if (!activeTransport) {
+			throw new SecretStorageUnavailableError(
+				`Cannot store ${provider} credentials: the extension credential channel is unavailable.`
+			);
+		}
+
+		await activeTransport.write(provider, secret);
+	}
+
+	static async erase(provider: AIProviderName): Promise<void> {
+		if (!activeTransport) {
+			throw new SecretStorageUnavailableError(
+				`Cannot delete ${provider} credentials: the extension credential channel is unavailable.`
+			);
+		}
+
+		await activeTransport.erase(provider);
+	}
+}

--- a/apps/api/tests/helpers/fake-ipc-host.ts
+++ b/apps/api/tests/helpers/fake-ipc-host.ts
@@ -1,0 +1,59 @@
+import type { CredentialChannelHost } from 'src/security/credential-channel';
+import type { ProviderSecretRequest } from '@ungate/shared';
+
+/** Stands in for the IPC channel the extension host owns. */
+export class FakeIpcHost implements CredentialChannelHost {
+	readonly sent: ProviderSecretRequest[] = [];
+	exitCode: number | null = null;
+	private readonly listeners: Record<string, ((payload: unknown) => void)[]> = {};
+
+	send(message: unknown): boolean {
+		this.sent.push(message as ProviderSecretRequest);
+
+		return true;
+	}
+
+	on(event: string, listener: (payload: unknown) => void): this {
+		this.listeners[event] ??= [];
+		this.listeners[event].push(listener);
+
+		return this;
+	}
+
+	/** Records the exit instead of ending the test worker; execution continues past the call. */
+	exit(code?: number): never {
+		this.exitCode = code ?? 0;
+
+		return undefined as never;
+	}
+
+	emit(event: string, payload?: unknown): void {
+		for (const listener of this.listeners[event] ?? []) {
+			listener(payload);
+		}
+	}
+
+	listenerCount(event: string): number {
+		return this.listeners[event]?.length ?? 0;
+	}
+
+	lastRequest(): ProviderSecretRequest {
+		const request = this.sent.at(-1);
+
+		if (!request) {
+			throw new Error('No credential request was sent.');
+		}
+
+		return request;
+	}
+}
+
+/** A host that was started without an IPC channel: no `send`, so nothing can be installed. */
+export function createHostWithoutIpc(): FakeIpcHost {
+	const host = new FakeIpcHost();
+
+	// `send` is the only signal Node gives that an IPC channel exists.
+	Object.defineProperty(host, 'send', { value: undefined, configurable: true });
+
+	return host;
+}

--- a/apps/api/tests/helpers/memory-secret-transport.ts
+++ b/apps/api/tests/helpers/memory-secret-transport.ts
@@ -1,0 +1,39 @@
+import { useProviderSecretTransport, type ProviderSecretTransport } from 'src/security/provider-secrets';
+
+import type { AIProviderName } from 'src/auth/base-provider';
+import type { ProviderSecret } from '@ungate/shared';
+
+/** Stands in for the extension-owned VS Code SecretStorage during tests. */
+export class MemorySecretTransport implements ProviderSecretTransport {
+	private readonly secrets = new Map<AIProviderName, ProviderSecret>();
+
+	async read(provider: AIProviderName): Promise<ProviderSecret | null> {
+		return this.secrets.get(provider) ?? null;
+	}
+
+	async write(provider: AIProviderName, secret: ProviderSecret): Promise<void> {
+		this.secrets.set(provider, { ...secret });
+	}
+
+	async erase(provider: AIProviderName): Promise<void> {
+		this.secrets.delete(provider);
+	}
+
+	/** Direct view for assertions that must not go through the production read path. */
+	peek(provider: AIProviderName): ProviderSecret | undefined {
+		return this.secrets.get(provider);
+	}
+
+	clear(): void {
+		this.secrets.clear();
+	}
+}
+
+/** Installs a fresh in-memory credential store and returns it. */
+export function useMemorySecretTransport(): MemorySecretTransport {
+	const transport = new MemorySecretTransport();
+
+	useProviderSecretTransport(transport);
+
+	return transport;
+}

--- a/apps/api/tests/integration/auth/auth-oauth-lifecycle.test.ts
+++ b/apps/api/tests/integration/auth/auth-oauth-lifecycle.test.ts
@@ -1,29 +1,43 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OAuth } from 'src/auth/oauth';
 import { ProviderSettings } from 'src/database/provider-settings';
 
+import { useMemorySecretTransport, type MemorySecretTransport } from '../../helpers/memory-secret-transport';
+
 describe('auth-oauth-lifecycle', () => {
-	it('returns unauthenticated status when row missing', () => {
-		expect(OAuth.getAuthStatus()).toEqual({ authenticated: false });
+	let secrets: MemorySecretTransport;
+
+	beforeEach(() => {
+		secrets = useMemorySecretTransport();
 	});
 
-	it('returns authenticated status with email and can logout', () => {
-		ProviderSettings.upsertOAuth('claude', {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it('returns unauthenticated status when row missing', async () => {
+		expect(await OAuth.getAuthStatus()).toEqual({ authenticated: false });
+	});
+
+	it('returns authenticated status with email and can logout', async () => {
+		await ProviderSettings.upsertOAuth('claude', {
 			accessToken: 'access',
 			refreshToken: 'refresh',
 			expiresAt: Date.now() + 10 * 60_000,
 			email: 'user@example.com'
 		});
-		expect(OAuth.getAuthStatus()).toEqual({ authenticated: true, email: 'user@example.com' });
 
-		OAuth.logout();
-		expect(ProviderSettings.get('claude')).toBeUndefined();
+		expect(await OAuth.getAuthStatus()).toEqual({ authenticated: true, email: 'user@example.com' });
+
+		await OAuth.logout();
+		expect(await ProviderSettings.get('claude')).toBeUndefined();
+		expect(secrets.peek('claude')).toBeUndefined();
 	});
 
 	it('returns valid token when not expired and null when no row', async () => {
 		const now = Date.now();
-		ProviderSettings.upsertOAuth('claude', {
+		await ProviderSettings.upsertOAuth('claude', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: now + 10 * 60_000
@@ -32,7 +46,36 @@ describe('auth-oauth-lifecycle', () => {
 		const token = await OAuth.getValidToken();
 		expect(token?.accessToken).toBe('a');
 
-		ProviderSettings.remove('claude');
+		await ProviderSettings.remove('claude');
 		expect(await OAuth.getValidToken()).toBeNull();
+	});
+
+	it('persists refreshed tokens to the credential store and not to sqlite', async () => {
+		await ProviderSettings.upsertOAuth('claude', {
+			accessToken: 'stale',
+			refreshToken: 'old-refresh',
+			// Already inside the five-minute refresh window.
+			expiresAt: Date.now() + 60_000,
+			email: 'user@example.com'
+		});
+
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(() => {
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve({ access_token: 'fresh', refresh_token: 'new-refresh', expires_in: 3600 })
+				});
+			})
+		);
+
+		const token = await OAuth.getValidToken();
+
+		expect(token?.accessToken).toBe('fresh');
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'fresh', refreshToken: 'new-refresh' });
+		expect(await ProviderSettings.get('claude')).toMatchObject({ accessToken: 'fresh', refreshToken: 'new-refresh' });
+		// The refreshed row is still usable; only the credential moved.
+		expect(await OAuth.getAuthStatus()).toEqual({ authenticated: true, email: undefined });
 	});
 });

--- a/apps/api/tests/integration/auth/auth-openai-oauth-lifecycle.test.ts
+++ b/apps/api/tests/integration/auth/auth-openai-oauth-lifecycle.test.ts
@@ -1,31 +1,40 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import { OpenAIOAuthService } from 'src/auth/openai/openai-oauth-service';
 import { ProviderSettings } from 'src/database/provider-settings';
 
-describe('auth-openai-oauth-lifecycle', () => {
-	it('returns auth status from provider settings', () => {
-		expect(OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: false, email: undefined });
+import { useMemorySecretTransport, type MemorySecretTransport } from '../../helpers/memory-secret-transport';
 
-		ProviderSettings.upsertOAuth('openai', {
+describe('auth-openai-oauth-lifecycle', () => {
+	let secrets: MemorySecretTransport;
+
+	beforeEach(() => {
+		secrets = useMemorySecretTransport();
+	});
+
+	it('returns auth status from provider settings', async () => {
+		expect(await OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: false, email: undefined });
+
+		await ProviderSettings.upsertOAuth('openai', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: Date.now() + 10 * 60_000,
 			email: 'u@example.com'
 		});
-		expect(OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: true, email: 'u@example.com' });
+		expect(await OpenAIOAuthService.getAuthStatus()).toEqual({ authenticated: true, email: 'u@example.com' });
 	});
 
 	it('returns null token when no credentials and logout removes tokens', async () => {
 		expect(await OpenAIOAuthService.getValidToken()).toBeNull();
 
-		ProviderSettings.upsertOAuth('openai', {
+		await ProviderSettings.upsertOAuth('openai', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: Date.now() + 10 * 60_000
 		});
-		OpenAIOAuthService.logout();
-		expect(ProviderSettings.get('openai')).toBeUndefined();
+		await OpenAIOAuthService.logout();
+		expect(await ProviderSettings.get('openai')).toBeUndefined();
+		expect(secrets.peek('openai')).toBeUndefined();
 		expect(await OpenAIOAuthService.getValidToken()).toBeNull();
 	});
 
@@ -37,7 +46,7 @@ describe('auth-openai-oauth-lifecycle', () => {
 			email: 'x@example.com',
 			accountId: 'acc'
 		};
-		ProviderSettings.upsertOAuth('openai', creds);
+		await ProviderSettings.upsertOAuth('openai', creds);
 		const token = await OpenAIOAuthService.getValidToken();
 		expect(token).toMatchObject(creds);
 	});

--- a/apps/api/tests/integration/database/database-provider-settings.test.ts
+++ b/apps/api/tests/integration/database/database-provider-settings.test.ts
@@ -1,34 +1,102 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
+import { getSqlite } from 'src/database';
 import { ProviderSettings } from 'src/database/provider-settings';
+import { useProviderSecretTransport } from 'src/security/provider-secrets';
+
+import { useMemorySecretTransport, type MemorySecretTransport } from '../../helpers/memory-secret-transport';
+
+function readLegacyColumns(provider: string): { access_token: string | null; refresh_token: string | null } | undefined {
+	return getSqlite()
+		.prepare('SELECT access_token, refresh_token FROM provider_settings WHERE provider = ?')
+		.get(provider) as { access_token: string | null; refresh_token: string | null } | undefined;
+}
 
 describe('database-provider-settings', () => {
-	it('upsert/get/remove api key lifecycle', () => {
-		ProviderSettings.upsertApiKey('minimax', 'token-1', 'https://x');
-		expect(ProviderSettings.get('minimax')?.accessToken).toBe('token-1');
-		expect(ProviderSettings.get('minimax')?.baseUrl).toBe('https://x');
+	let secrets: MemorySecretTransport;
 
-		ProviderSettings.upsertApiKey('minimax', 'token-2');
-		expect(ProviderSettings.get('minimax')?.accessToken).toBe('token-2');
-
-		ProviderSettings.remove('minimax');
-		expect(ProviderSettings.get('minimax')).toBeUndefined();
+	beforeEach(() => {
+		secrets = useMemorySecretTransport();
 	});
 
-	it('stores oauth fields', () => {
-		ProviderSettings.upsertOAuth('openai', {
+	it('upsert/get/remove api key lifecycle', async () => {
+		await ProviderSettings.upsertApiKey('minimax', 'token-1', 'https://x');
+		expect((await ProviderSettings.get('minimax'))?.accessToken).toBe('token-1');
+		expect((await ProviderSettings.get('minimax'))?.baseUrl).toBe('https://x');
+
+		await ProviderSettings.upsertApiKey('minimax', 'token-2');
+		expect((await ProviderSettings.get('minimax'))?.accessToken).toBe('token-2');
+
+		await ProviderSettings.remove('minimax');
+		expect(await ProviderSettings.get('minimax')).toBeUndefined();
+		expect(secrets.peek('minimax')).toBeUndefined();
+	});
+
+	it('stores oauth fields', async () => {
+		await ProviderSettings.upsertOAuth('openai', {
 			accessToken: 'a',
 			refreshToken: 'r',
 			expiresAt: 1000,
-			email: 'user@example.com',
+			email: 'u@example.com',
 			accountId: 'acc'
 		});
 
-		const row = ProviderSettings.get('openai');
+		const row = await ProviderSettings.get('openai');
 		expect(row?.accessToken).toBe('a');
 		expect(row?.refreshToken).toBe('r');
 		expect(row?.expiresAt).toBe(1000);
-		expect(row?.email).toBe('user@example.com');
+		expect(row?.email).toBe('u@example.com');
 		expect(row?.accountId).toBe('acc');
+	});
+
+	it('keeps credentials out of sqlite', async () => {
+		await ProviderSettings.upsertOAuth('claude', { accessToken: 'access', refreshToken: 'refresh', expiresAt: 5 });
+		await ProviderSettings.upsertApiKey('minimax', 'api-key');
+
+		expect(readLegacyColumns('claude')).toEqual({ access_token: '', refresh_token: null });
+		expect(readLegacyColumns('minimax')).toEqual({ access_token: '', refresh_token: null });
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'access', refreshToken: 'refresh' });
+		expect(secrets.peek('minimax')).toEqual({ accessToken: 'api-key', refreshToken: null });
+	});
+
+	it('reports metadata without touching the credential store', async () => {
+		await ProviderSettings.upsertApiKey('minimax', 'api-key', 'https://china');
+		useProviderSecretTransport(null);
+
+		expect(ProviderSettings.getMetadata('minimax')?.baseUrl).toBe('https://china');
+		// Fail closed: the base URL survives, the credential does not.
+		expect(await ProviderSettings.hasCredentials('minimax')).toBe(false);
+		expect((await ProviderSettings.get('minimax'))?.accessToken).toBe('');
+	});
+
+	it('refuses to persist a credential when the store is unavailable', async () => {
+		useProviderSecretTransport(null);
+
+		await expect(ProviderSettings.upsertApiKey('minimax', 'never-stored')).rejects.toThrow(/unavailable/);
+		expect(ProviderSettings.getMetadata('minimax')).toBeUndefined();
+	});
+
+	it('migrates legacy plaintext credentials once and scrubs the columns', async () => {
+		const sqlite = getSqlite();
+		sqlite
+			.prepare('INSERT INTO provider_settings (provider, access_token, refresh_token, expires_at, created_at) VALUES (?,?,?,?,?)')
+			.run('claude', 'legacy-access', 'legacy-refresh', 9999, Date.now());
+		sqlite
+			.prepare('INSERT INTO provider_settings (provider, access_token, refresh_token, created_at) VALUES (?,?,?,?)')
+			.run('ghost', 'orphan-access', null, Date.now());
+
+		await ProviderSettings.migrateLegacySecrets();
+
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'legacy-access', refreshToken: 'legacy-refresh' });
+		expect(readLegacyColumns('claude')).toEqual({ access_token: '', refresh_token: null });
+		expect((await ProviderSettings.get('claude'))?.expiresAt).toBe(9999);
+
+		// A row for a provider the API cannot serve keeps no plaintext either.
+		expect(readLegacyColumns('ghost')).toEqual({ access_token: '', refresh_token: null });
+
+		// Second pass is a no-op and must not overwrite a credential rotated since.
+		await ProviderSettings.upsertOAuth('claude', { accessToken: 'rotated', refreshToken: 'rotated-refresh', expiresAt: 1 });
+		await ProviderSettings.migrateLegacySecrets();
+		expect(secrets.peek('claude')).toEqual({ accessToken: 'rotated', refreshToken: 'rotated-refresh' });
 	});
 });

--- a/apps/api/tests/unit/auth/auth-providers-and-index.test.ts
+++ b/apps/api/tests/unit/auth/auth-providers-and-index.test.ts
@@ -4,6 +4,7 @@ const oauthGetValidTokenMock = vi.fn();
 const oauthGetAuthStatusMock = vi.fn();
 const oauthLogoutMock = vi.fn();
 const providerGetMock = vi.fn();
+const providerHasCredentialsMock = vi.fn();
 const providerRemoveMock = vi.fn();
 
 vi.mock('src/auth/oauth', () => ({
@@ -17,6 +18,7 @@ vi.mock('src/auth/oauth', () => ({
 vi.mock('src/database/provider-settings', () => ({
 	ProviderSettings: {
 		get: (...args: unknown[]) => providerGetMock(...args),
+		hasCredentials: (...args: unknown[]) => providerHasCredentialsMock(...args),
 		remove: (...args: unknown[]) => providerRemoveMock(...args)
 	}
 }));
@@ -29,47 +31,48 @@ import { OpenAIProvider } from 'src/auth/openai-provider';
 describe('auth providers and index', () => {
 	it('claude provider delegates oauth methods', async () => {
 		oauthGetValidTokenMock.mockResolvedValueOnce({ accessToken: 'tok' });
-		oauthGetAuthStatusMock.mockReturnValueOnce({ authenticated: true });
+		oauthGetAuthStatusMock.mockResolvedValueOnce({ authenticated: true });
 
 		const provider = new ClaudeProvider();
 		expect(await provider.getAuthHeader()).toBe('Bearer tok');
-		expect(provider.isAuthenticated()).toBe(true);
-		provider.logout();
+		expect(await provider.isAuthenticated()).toBe(true);
+		await provider.logout();
 		expect(oauthLogoutMock).toHaveBeenCalled();
 	});
 
 	it('claude provider returns null auth header without token', async () => {
 		oauthGetValidTokenMock.mockResolvedValueOnce(null);
-		oauthGetAuthStatusMock.mockReturnValueOnce({ authenticated: false });
+		oauthGetAuthStatusMock.mockResolvedValueOnce({ authenticated: false });
 
 		const provider = new ClaudeProvider();
 		expect(await provider.getAuthHeader()).toBeNull();
-		expect(provider.isAuthenticated()).toBe(false);
+		expect(await provider.isAuthenticated()).toBe(false);
 	});
 
-	it('openai and minimax providers use provider settings', () => {
-		providerGetMock.mockReturnValueOnce({ accessToken: 'oa' }).mockReturnValueOnce({ accessToken: 'mm' });
+	it('openai and minimax providers use provider settings', async () => {
+		providerGetMock.mockResolvedValueOnce({ accessToken: 'oa' }).mockResolvedValueOnce({ accessToken: 'mm' });
 
 		const openai = new OpenAIProvider();
 		const minimax = new MiniMaxProvider();
-		expect(openai.getAuthHeader()).toBe('Bearer oa');
-		expect(minimax.getAuthHeader()).toBe('Bearer mm');
+		expect(await openai.getAuthHeader()).toBe('Bearer oa');
+		expect(await minimax.getAuthHeader()).toBe('Bearer mm');
 
-		openai.logout();
-		minimax.logout();
+		await openai.logout();
+		await minimax.logout();
 		expect(providerRemoveMock).toHaveBeenCalledWith('openai');
 		expect(providerRemoveMock).toHaveBeenCalledWith('minimax');
 	});
 
-	it('openai and minimax providers return null auth headers without tokens', () => {
-		providerGetMock.mockReturnValueOnce(null).mockReturnValueOnce({}).mockReturnValueOnce(null).mockReturnValueOnce({});
+	it('openai and minimax providers return null auth headers without tokens', async () => {
+		providerGetMock.mockResolvedValueOnce(null).mockResolvedValueOnce({ accessToken: '' });
+		providerHasCredentialsMock.mockResolvedValue(false);
 
 		const openai = new OpenAIProvider();
 		const minimax = new MiniMaxProvider();
-		expect(openai.getAuthHeader()).toBeNull();
-		expect(openai.isAuthenticated()).toBe(false);
-		expect(minimax.getAuthHeader()).toBeNull();
-		expect(minimax.isAuthenticated()).toBe(false);
+		expect(await openai.getAuthHeader()).toBeNull();
+		expect(await openai.isAuthenticated()).toBe(false);
+		expect(await minimax.getAuthHeader()).toBeNull();
+		expect(await minimax.isAuthenticated()).toBe(false);
 	});
 
 	it('getProvider returns undefined for unknown provider names at runtime', () => {

--- a/apps/api/tests/unit/security/credential-channel.test.ts
+++ b/apps/api/tests/unit/security/credential-channel.test.ts
@@ -1,0 +1,64 @@
+import { PROVIDER_SECRET_CHANNEL } from '@ungate/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CredentialChannelMissingError, requireCredentialChannel } from 'src/security/credential-channel';
+import { ProviderSecrets, useProviderSecretTransport } from 'src/security/provider-secrets';
+
+import { createHostWithoutIpc, FakeIpcHost } from '../../helpers/fake-ipc-host';
+
+describe('requireCredentialChannel', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		useProviderSecretTransport(null);
+	});
+
+	afterEach(() => {
+		useProviderSecretTransport(null);
+		vi.restoreAllMocks();
+	});
+
+	it('refuses to start without an ipc credential channel', async () => {
+		const host = createHostWithoutIpc();
+
+		expect(() => requireCredentialChannel(host)).toThrow(CredentialChannelMissingError);
+
+		// No transport was installed and no lifecycle handler was registered.
+		await expect(ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null })).rejects.toThrow(/unavailable/);
+		expect(host.listenerCount('disconnect')).toBe(0);
+		expect(host.exitCode).toBeNull();
+	});
+
+	it('installs the transport so credential requests reach the extension', async () => {
+		const host = new FakeIpcHost();
+
+		requireCredentialChannel(host);
+
+		const pending = ProviderSecrets.read('claude');
+		const request = host.lastRequest();
+
+		expect(request).toMatchObject({ channel: PROVIDER_SECRET_CHANNEL, action: 'get', provider: 'claude' });
+
+		host.emit('message', {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: request.id,
+			ok: true,
+			secret: { accessToken: 'access', refreshToken: null }
+		});
+
+		await expect(pending).resolves.toEqual({ accessToken: 'access', refreshToken: null });
+		expect(host.exitCode).toBeNull();
+	});
+
+	it('ends the process when the channel is lost, after rejecting in-flight requests', async () => {
+		const host = new FakeIpcHost();
+
+		requireCredentialChannel(host);
+
+		const inFlight = ProviderSecrets.write('minimax', { accessToken: 'key', refreshToken: null });
+
+		host.emit('disconnect');
+
+		await expect(inFlight).rejects.toThrow(/closed the credential channel/);
+		expect(host.exitCode).toBe(0);
+	});
+});

--- a/apps/api/tests/unit/security/ipc-secret-transport.test.ts
+++ b/apps/api/tests/unit/security/ipc-secret-transport.test.ts
@@ -1,0 +1,130 @@
+import { PROVIDER_SECRET_CHANNEL } from '@ungate/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IpcSecretTransport } from 'src/security/ipc-secret-transport';
+import { ProviderSecrets, SecretStorageUnavailableError, useProviderSecretTransport } from 'src/security/provider-secrets';
+
+import { createHostWithoutIpc, FakeIpcHost } from '../../helpers/fake-ipc-host';
+
+describe('IpcSecretTransport', () => {
+	let host: FakeIpcHost;
+
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		host = new FakeIpcHost();
+		IpcSecretTransport.install(host);
+	});
+
+	afterEach(() => {
+		useProviderSecretTransport(null);
+		vi.restoreAllMocks();
+	});
+
+	it('sends a validated request and resolves with the returned credential', async () => {
+		const pending = ProviderSecrets.read('claude');
+		const request = host.lastRequest();
+
+		expect(request).toMatchObject({ channel: PROVIDER_SECRET_CHANNEL, action: 'get', provider: 'claude' });
+		expect(request.id).toBeTypeOf('string');
+		expect(request.secret).toBeUndefined();
+
+		host.emit('message', {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: request.id,
+			ok: true,
+			secret: { accessToken: 'access', refreshToken: 'refresh' }
+		});
+
+		await expect(pending).resolves.toEqual({ accessToken: 'access', refreshToken: 'refresh' });
+	});
+
+	it('carries the credential on a set request and resolves once acknowledged', async () => {
+		const pending = ProviderSecrets.write('minimax', { accessToken: 'key', refreshToken: null });
+		const request = host.lastRequest();
+
+		expect(request).toMatchObject({
+			action: 'set',
+			provider: 'minimax',
+			secret: { accessToken: 'key', refreshToken: null }
+		});
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: true, secret: null });
+
+		await expect(pending).resolves.toBeUndefined();
+	});
+
+	it('rejects a malformed response instead of trusting it', async () => {
+		const pending = ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null });
+		const request = host.lastRequest();
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: 'yes' });
+
+		await expect(pending).rejects.toThrow(SecretStorageUnavailableError);
+	});
+
+	it('surfaces a refusal reported by the extension', async () => {
+		const pending = ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null });
+		const request = host.lastRequest();
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: false, error: 'keychain locked' });
+
+		await expect(pending).rejects.toThrow(/keychain locked/);
+	});
+
+	it('ignores responses that do not correlate with a pending request', async () => {
+		const pending = ProviderSecrets.read('openai');
+		const request = host.lastRequest();
+		let settled = false;
+
+		void pending.then(() => {
+			settled = true;
+		});
+
+		host.emit('message', { channel: 'some-other-channel', id: request.id, ok: true, secret: null });
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: 'not-a-pending-id', ok: true, secret: null });
+		host.emit('message', 'garbage');
+		await Promise.resolve();
+
+		expect(settled).toBe(false);
+
+		host.emit('message', { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: true, secret: null });
+
+		await expect(pending).resolves.toBeNull();
+	});
+
+	it('rejects in-flight and later requests once the channel disconnects', async () => {
+		const inFlight = ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null });
+
+		host.emit('disconnect');
+
+		await expect(inFlight).rejects.toThrow(SecretStorageUnavailableError);
+		await expect(ProviderSecrets.write('claude', { accessToken: 'b', refreshToken: null })).rejects.toThrow(
+			SecretStorageUnavailableError
+		);
+		// Reads deny instead of throwing so provider calls answer 401.
+		await expect(ProviderSecrets.read('claude')).resolves.toBeNull();
+	});
+});
+
+describe('ProviderSecrets without a transport', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		useProviderSecretTransport(null);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('installs nothing when the process has no ipc channel', () => {
+		expect(IpcSecretTransport.install(createHostWithoutIpc())).toBeNull();
+	});
+
+	it('denies reads and refuses writes', async () => {
+		await expect(ProviderSecrets.read('claude')).resolves.toBeNull();
+		await expect(ProviderSecrets.write('claude', { accessToken: 'a', refreshToken: null })).rejects.toThrow(
+			SecretStorageUnavailableError
+		);
+		await expect(ProviderSecrets.erase('claude')).rejects.toThrow(SecretStorageUnavailableError);
+	});
+});

--- a/apps/extension/src/api-server.ts
+++ b/apps/extension/src/api-server.ts
@@ -2,13 +2,15 @@ import * as cp from 'node:child_process';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { sleep, type ApiStatus as ServerStatus, type LogEntry } from '@ungate/shared';
+import { sleep, type ApiStatus as ServerStatus, type LogEntry, type ProviderSecretResponse } from '@ungate/shared';
 import * as vscode from 'vscode';
 
 import { RuntimeStateStore } from './runtime-state';
 import { config } from './runtime-state/config';
 import { BetterSqlite3Installer } from './utils/better-sqlite3-installer';
 import { NodeResolver } from './utils/node-resolver';
+
+import type { ProviderSecretBroker } from './provider-secret-broker';
 
 const HEALTH_CHECK_URL = (port: number) => `http://localhost:${port}/health`;
 const STARTING_STATE_TIMEOUT_MS = 10000;
@@ -38,6 +40,7 @@ export class ApiServer {
 
 	constructor(
 		private readonly context: vscode.ExtensionContext,
+		private readonly secrets: ProviderSecretBroker,
 		private readonly callbacks: ApiServerCallbacks
 	) {}
 
@@ -203,18 +206,60 @@ export class ApiServer {
 
 		this.callbacks.onLog('info', `[process] starting api via ${runtime}`);
 
-		this.process = cp.spawn(runtime, nodeArgs, { cwd, env, stdio: 'pipe', detached: true });
+		// The fourth stdio slot is the credential channel: the child asks for provider secrets
+		// instead of reading them from the database.
+		this.process = cp.spawn(runtime, nodeArgs, { cwd, env, stdio: ['pipe', 'pipe', 'pipe', 'ipc'], detached: true });
 		this.process.unref();
 		void this.writeRuntimeState('starting', null).catch(() => {});
 
 		this.process.stdout?.on('data', (data: Buffer) => this.onStdout(data));
 		this.process.stderr?.on('data', (data: Buffer) => this.onStderr(data));
 		this.process.on('exit', (code, signal) => this.onExit(code, signal));
+		this.process.on('message', (message: unknown) => {
+			void this.onChildMessage(message);
+		});
 		this.process.on('error', (err) => {
 			void this.onSpawnProcessError(err).catch(() => {});
 		});
 
 		this.startHealthCheck();
+	}
+
+	/**
+	 * Serves credential requests from the API child. Only the outcome is logged: request and
+	 * response payloads carry access and refresh tokens.
+	 */
+	private async onChildMessage(message: unknown): Promise<void> {
+		const child = this.process;
+		let response: ProviderSecretResponse | null;
+
+		try {
+			response = await this.secrets.handleApiChildMessage(message);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+
+			this.callbacks.onLog('error', `[secrets] credential request failed: ${reason}`);
+
+			return;
+		}
+
+		if (!response) {
+			return;
+		}
+
+		if (!child?.connected) {
+			this.callbacks.onLog('error', '[secrets] dropped a credential response: the api channel closed');
+
+			return;
+		}
+
+		try {
+			child.send(response);
+		} catch (err) {
+			const reason = err instanceof Error ? err.message : String(err);
+
+			this.callbacks.onLog('error', `[secrets] failed to answer a credential request: ${reason}`);
+		}
 	}
 
 	private onStdout(data: Buffer): void {

--- a/apps/extension/src/extension-controller.ts
+++ b/apps/extension/src/extension-controller.ts
@@ -15,6 +15,7 @@ import { Dashboard, type Msg } from './dashboard';
 import { extensionCommands } from './extension-commands';
 import { ExtensionStatusBar } from './extension-status-bar';
 import { OpenAiKeyFix } from './openai-key-fix';
+import { ProviderSecretBroker } from './provider-secret-broker';
 import { RuntimeStateStore } from './runtime-state';
 import { config } from './runtime-state/config';
 import { TunnelManager } from './tunnel-manager';
@@ -81,7 +82,9 @@ export class ExtensionController {
 			}
 		);
 
-		this.apiServer = new ApiServer(this.context, {
+		// The API child has no other source of provider credentials: it asks this broker over the
+		// IPC channel ApiServer opens when it spawns the process.
+		this.apiServer = new ApiServer(this.context, new ProviderSecretBroker(this.context.secrets), {
 			onLog: (level: LogEntry['level'], message: string) => {
 				this.log(message);
 				this.dashboard.pushLog('api', { timestamp: Date.now(), level, message });

--- a/apps/extension/src/provider-secret-broker.ts
+++ b/apps/extension/src/provider-secret-broker.ts
@@ -1,0 +1,98 @@
+import {
+	PROVIDER_SECRET_CHANNEL,
+	isProviderSecret,
+	parseProviderSecretRequest,
+	providerSecretKey,
+	readProviderSecretEnvelope,
+	type ModelMappingProvider,
+	type ProviderSecret,
+	type ProviderSecretResponse
+} from '@ungate/shared';
+
+/**
+ * The slice of `vscode.SecretStorage` this module needs. Narrowing it keeps the credential
+ * logic independent of the `vscode` module so it can be driven directly.
+ */
+export interface SecretStore {
+	get(key: string): Thenable<string | undefined>;
+	store(key: string, value: string): Thenable<void>;
+	delete(key: string): Thenable<void>;
+}
+
+/**
+ * Owner of the provider credentials the API child process asks for over IPC. Access and
+ * refresh tokens live in VS Code SecretStorage and nowhere else — not in SQLite, not in the
+ * runtime state file, not in the log.
+ */
+export class ProviderSecretBroker {
+	public constructor(private readonly storage: SecretStore) {}
+
+	/**
+	 * Answers one IPC message from the API child. Returns the response to send back, or null
+	 * when the message does not belong to the credential channel. Errors are reported by
+	 * provider and action only — never with a credential value.
+	 */
+	async handleApiChildMessage(message: unknown): Promise<ProviderSecretResponse | null> {
+		const envelope = readProviderSecretEnvelope(message);
+
+		if (!envelope) {
+			return null;
+		}
+
+		const request = parseProviderSecretRequest(message);
+
+		if (!request) {
+			return { channel: PROVIDER_SECRET_CHANNEL, id: envelope.id, ok: false, error: 'Malformed credential request' };
+		}
+
+		try {
+			if (request.action === 'get') {
+				return {
+					channel: PROVIDER_SECRET_CHANNEL,
+					id: request.id,
+					ok: true,
+					secret: await this.readProviderSecret(request.provider)
+				};
+			}
+
+			if (request.action === 'set') {
+				await this.storage.store(providerSecretKey(request.provider), JSON.stringify(request.secret));
+			} else {
+				await this.storage.delete(providerSecretKey(request.provider));
+			}
+
+			return { channel: PROVIDER_SECRET_CHANNEL, id: request.id, ok: true, secret: null };
+		} catch (error) {
+			const reason = error instanceof Error ? error.message : String(error);
+
+			return {
+				channel: PROVIDER_SECRET_CHANNEL,
+				id: request.id,
+				ok: false,
+				error: `Secret storage rejected ${request.action} for ${request.provider}: ${reason}`
+			};
+		}
+	}
+
+	private async readProviderSecret(provider: ModelMappingProvider): Promise<ProviderSecret | null> {
+		const raw = await this.storage.get(providerSecretKey(provider));
+
+		if (!raw) {
+			return null;
+		}
+
+		let parsed: unknown;
+
+		try {
+			parsed = JSON.parse(raw);
+		} catch {
+			return null;
+		}
+
+		if (!isProviderSecret(parsed)) {
+			return null;
+		}
+
+		return { accessToken: parsed.accessToken, refreshToken: parsed.refreshToken };
+	}
+}

--- a/apps/extension/tests/unit/api-server-health-check.test.ts
+++ b/apps/extension/tests/unit/api-server-health-check.test.ts
@@ -6,6 +6,15 @@ import { TestHelper } from './helpers/test-helper';
 
 import type { RuntimeState } from '@ungate/shared/frontend';
 
+interface SpawnedChildMock {
+	emit(event: string, payload?: unknown): void;
+	connected: boolean;
+	send: (message: unknown) => boolean;
+}
+
+/** Mirrors PROVIDER_SECRET_CHANNEL; @ungate/shared is mocked in this file. */
+const SECRET_CHANNEL = 'ungate.provider-secret';
+
 const {
 	runtimeReadMock,
 	runtimeHasLiveClientsMock,
@@ -33,6 +42,13 @@ const {
 
 				return child;
 			},
+			emit(event: string, payload?: unknown) {
+				for (const handler of handlers.get(event) ?? []) {
+					handler(payload);
+				}
+			},
+			connected: true,
+			send: vi.fn(() => true),
 			unref: vi.fn(),
 			kill: vi.fn()
 		};
@@ -144,15 +160,18 @@ function createServer(options?: { isLeaderWindow?: boolean; isExtensionHostActiv
 	onStatusChange: ReturnType<typeof vi.fn>;
 	onPortDetected: ReturnType<typeof vi.fn>;
 	onLog: ReturnType<typeof vi.fn>;
+	handleApiChildMessage: ReturnType<typeof vi.fn>;
 } {
 	const onStatusChange = vi.fn();
 	const onPortDetected = vi.fn();
 	const onLog = vi.fn();
+	const handleApiChildMessage = vi.fn().mockResolvedValue(null);
 	const server = new ApiServer(
 		{
 			extensionMode: 1,
 			extensionPath: '/tmp/ungate-extension'
 		} as never,
+		{ handleApiChildMessage } as never,
 		{
 			onLog,
 			onPortDetected,
@@ -169,7 +188,7 @@ function createServer(options?: { isLeaderWindow?: boolean; isExtensionHostActiv
 		}
 	);
 
-	return { server, onStatusChange, onPortDetected, onLog };
+	return { server, onStatusChange, onPortDetected, onLog, handleApiChildMessage };
 }
 
 describe('ApiServer.runHealthCheckCycle', () => {
@@ -278,7 +297,7 @@ describe('ApiServer.runHealthCheckCycle', () => {
 		expect(spawnSpy).not.toHaveBeenCalled();
 	});
 
-	it('passes the installed better-sqlite3 binary path to the api process', async () => {
+	it('passes the installed better-sqlite3 binary path and an ipc credential channel to the api process', async () => {
 		const runtimeState = createRuntimeState([], null);
 		const { server } = createServer();
 		const internals = getInternals(server);
@@ -297,11 +316,64 @@ describe('ApiServer.runHealthCheckCycle', () => {
 			expect.any(String),
 			expect.any(Array),
 			expect.objectContaining({
+				stdio: ['pipe', 'pipe', 'pipe', 'ipc'],
 				env: expect.objectContaining({
 					UNGATE_BETTER_SQLITE3_NATIVE_BINDING: expect.stringContaining('better_sqlite3.installed.node')
 				})
 			})
 		);
+	});
+
+	it('answers credential requests from the api child and never logs the payload', async () => {
+		const runtimeState = createRuntimeState([], null);
+		const { server, onLog, handleApiChildMessage } = createServer();
+		const internals = getInternals(server);
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeMutateMock.mockImplementation((mutator) => {
+			return Promise.resolve(mutator(structuredClone(runtimeState)));
+		});
+
+		vi.spyOn(internals, 'startHealthCheck').mockImplementation(() => {});
+
+		const response = { channel: SECRET_CHANNEL, id: 'r1', ok: true, secret: null };
+		handleApiChildMessage.mockResolvedValueOnce(response);
+
+		await server.start();
+
+		const child = spawnMock.mock.results.at(-1)?.value as SpawnedChildMock;
+		const request = { channel: SECRET_CHANNEL, id: 'r1', action: 'get', provider: 'claude' };
+
+		child.emit('message', request);
+		await flushPromises();
+
+		expect(handleApiChildMessage).toHaveBeenCalledWith(request);
+		expect(child.send).toHaveBeenCalledWith(response);
+		expect(onLog.mock.calls.flat().join(' ')).not.toContain(SECRET_CHANNEL);
+	});
+
+	it('reports a closed channel instead of answering a credential request', async () => {
+		const runtimeState = createRuntimeState([], null);
+		const { server, onLog, handleApiChildMessage } = createServer();
+		const internals = getInternals(server);
+		runtimeReadMock.mockReturnValue(runtimeState);
+		runtimeMutateMock.mockImplementation((mutator) => {
+			return Promise.resolve(mutator(structuredClone(runtimeState)));
+		});
+
+		vi.spyOn(internals, 'startHealthCheck').mockImplementation(() => {});
+
+		handleApiChildMessage.mockResolvedValueOnce({ channel: SECRET_CHANNEL, id: 'r2', ok: true, secret: null });
+
+		await server.start();
+
+		const child = spawnMock.mock.results.at(-1)?.value as SpawnedChildMock;
+		child.connected = false;
+
+		child.emit('message', { channel: SECRET_CHANNEL, id: 'r2', action: 'get', provider: 'claude' });
+		await flushPromises();
+
+		expect(child.send).not.toHaveBeenCalled();
+		expect(onLog).toHaveBeenCalledWith('error', expect.stringContaining('the api channel closed'));
 	});
 
 	it('retries startup when shared starting state is stale', async () => {

--- a/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
+++ b/apps/extension/tests/unit/extension-controller-runtime-sync.test.ts
@@ -192,9 +192,24 @@ function createRuntimeState(windowIds: string[], apiPort: number | null = 4783):
 }
 
 function createContext() {
+	const stored: Record<string, string> = {};
+
 	return {
 		subscriptions: [],
-		extensionPath: '/tmp/ungate-extension'
+		extensionPath: '/tmp/ungate-extension',
+		secrets: {
+			get: (key: string) => Promise.resolve(stored[key]),
+			store: (key: string, value: string) => {
+				stored[key] = value;
+
+				return Promise.resolve();
+			},
+			delete: (key: string) => {
+				delete stored[key];
+
+				return Promise.resolve();
+			}
+		}
 	};
 }
 

--- a/apps/extension/tests/unit/provider-secret-broker.test.ts
+++ b/apps/extension/tests/unit/provider-secret-broker.test.ts
@@ -1,0 +1,138 @@
+import { PROVIDER_SECRET_CHANNEL } from '@ungate/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ProviderSecretBroker, type SecretStore } from '../../src/provider-secret-broker';
+
+/** Stands in for vscode.SecretStorage. */
+class MemorySecretStore implements SecretStore {
+	readonly values: Record<string, string> = {};
+	failOn: string | null = null;
+
+	get(key: string): Promise<string | undefined> {
+		return Promise.resolve(this.values[key]);
+	}
+
+	store(key: string, value: string): Promise<void> {
+		if (this.failOn === key) {
+			return Promise.reject(new Error('keychain is locked'));
+		}
+
+		this.values[key] = value;
+
+		return Promise.resolve();
+	}
+
+	delete(key: string): Promise<void> {
+		delete this.values[key];
+
+		return Promise.resolve();
+	}
+}
+
+const CLAUDE_KEY = 'ungate.provider.claude';
+
+function getRequest(id: string, provider = 'claude'): unknown {
+	return { channel: PROVIDER_SECRET_CHANNEL, id, action: 'get', provider };
+}
+
+describe('ProviderSecretBroker', () => {
+	let storage: MemorySecretStore;
+	let broker: ProviderSecretBroker;
+
+	beforeEach(() => {
+		storage = new MemorySecretStore();
+		broker = new ProviderSecretBroker(storage);
+	});
+
+	it('stores, reads and deletes provider credentials under a constant key', async () => {
+		const stored = await broker.handleApiChildMessage({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r1',
+			action: 'set',
+			provider: 'claude',
+			secret: { accessToken: 'access', refreshToken: 'refresh' }
+		});
+
+		expect(stored).toEqual({ channel: PROVIDER_SECRET_CHANNEL, id: 'r1', ok: true, secret: null });
+		expect(storage.values[CLAUDE_KEY]).toBe(JSON.stringify({ accessToken: 'access', refreshToken: 'refresh' }));
+
+		const read = await broker.handleApiChildMessage(getRequest('r2'));
+
+		expect(read).toEqual({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r2',
+			ok: true,
+			secret: { accessToken: 'access', refreshToken: 'refresh' }
+		});
+
+		const deleted = await broker.handleApiChildMessage({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r3',
+			action: 'delete',
+			provider: 'claude'
+		});
+
+		expect(deleted).toEqual({ channel: PROVIDER_SECRET_CHANNEL, id: 'r3', ok: true, secret: null });
+		expect(storage.values[CLAUDE_KEY]).toBeUndefined();
+		await expect(broker.handleApiChildMessage(getRequest('r4'))).resolves.toEqual({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r4',
+			ok: true,
+			secret: null
+		});
+	});
+
+	it('ignores messages that do not belong to the credential channel', async () => {
+		await expect(broker.handleApiChildMessage({ type: 'webview-ready' })).resolves.toBeNull();
+		await expect(broker.handleApiChildMessage('garbage')).resolves.toBeNull();
+		await expect(broker.handleApiChildMessage(null)).resolves.toBeNull();
+		// Channel matches but the correlation id is missing, so there is nobody to answer.
+		await expect(broker.handleApiChildMessage({ channel: PROVIDER_SECRET_CHANNEL, action: 'get' })).resolves.toBeNull();
+	});
+
+	it('answers malformed credential requests with an error instead of acting on them', async () => {
+		const malformed: unknown[] = [
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm1', action: 'wipe', provider: 'claude' },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm2', action: 'get', provider: 'anthropic' },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm3', action: 'set', provider: 'claude' },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm4', action: 'set', provider: 'claude', secret: { accessToken: 42 } },
+			{ channel: PROVIDER_SECRET_CHANNEL, id: 'm5', action: 'delete', provider: 'claude', secret: { accessToken: 'x' } }
+		];
+
+		for (const message of malformed) {
+			await expect(broker.handleApiChildMessage(message)).resolves.toMatchObject({ ok: false });
+		}
+
+		expect(storage.values[CLAUDE_KEY]).toBeUndefined();
+	});
+
+	it('treats an unreadable stored credential as absent', async () => {
+		storage.values[CLAUDE_KEY] = 'not json';
+
+		await expect(broker.handleApiChildMessage(getRequest('r5'))).resolves.toMatchObject({ ok: true, secret: null });
+
+		storage.values[CLAUDE_KEY] = JSON.stringify({ accessToken: 7 });
+
+		await expect(broker.handleApiChildMessage(getRequest('r6'))).resolves.toMatchObject({ ok: true, secret: null });
+	});
+
+	it('reports storage failures without echoing the credential', async () => {
+		storage.failOn = CLAUDE_KEY;
+
+		const response = await broker.handleApiChildMessage({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r7',
+			action: 'set',
+			provider: 'claude',
+			secret: { accessToken: 'super-secret-token', refreshToken: null }
+		});
+
+		expect(response).toEqual({
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: 'r7',
+			ok: false,
+			error: 'Secret storage rejected set for claude: keychain is locked'
+		});
+		expect(JSON.stringify(response)).not.toContain('super-secret-token');
+	});
+});

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -3,3 +3,4 @@ export * from './runtime';
 export * from './settings';
 export * from './log';
 export * from './tunnel';
+export * from './secrets';

--- a/packages/shared/src/types/secrets.ts
+++ b/packages/shared/src/types/secrets.ts
@@ -1,0 +1,148 @@
+import { isModelMappingProvider } from '../guards/settings';
+
+import type { ModelMappingProvider } from './settings';
+
+/** Prefix of the VS Code SecretStorage keys holding per-provider credentials. */
+export const PROVIDER_SECRET_KEY_PREFIX = 'ungate.provider.';
+
+/**
+ * Discriminator carried by every message on the API child IPC channel. Both sides drop
+ * messages without it, so the channel can be shared with unrelated traffic.
+ */
+export const PROVIDER_SECRET_CHANNEL = 'ungate.provider-secret';
+
+export const PROVIDER_SECRET_ACTIONS = ['get', 'set', 'delete'] as const;
+
+export type ProviderSecretAction = (typeof PROVIDER_SECRET_ACTIONS)[number];
+
+/** The only credential fields that must never be written to SQLite. */
+export interface ProviderSecret {
+	accessToken: string;
+	refreshToken: string | null;
+}
+
+export interface ProviderSecretRequest {
+	channel: typeof PROVIDER_SECRET_CHANNEL;
+	id: string;
+	action: ProviderSecretAction;
+	provider: ModelMappingProvider;
+	/** Present exactly for `set`. */
+	secret?: ProviderSecret;
+}
+
+export type ProviderSecretResponse =
+	| { channel: typeof PROVIDER_SECRET_CHANNEL; id: string; ok: true; secret: ProviderSecret | null }
+	| { channel: typeof PROVIDER_SECRET_CHANNEL; id: string; ok: false; error: string };
+
+export function providerSecretKey(provider: ModelMappingProvider): string {
+	return `${PROVIDER_SECRET_KEY_PREFIX}${provider}`;
+}
+
+export function isProviderSecretAction(value: unknown): value is ProviderSecretAction {
+	return typeof value === 'string' && PROVIDER_SECRET_ACTIONS.includes(value as ProviderSecretAction);
+}
+
+export function isProviderSecret(value: unknown): value is ProviderSecret {
+	if (typeof value !== 'object' || value === null) {
+		return false;
+	}
+
+	const candidate = value as { accessToken?: unknown; refreshToken?: unknown };
+
+	if (typeof candidate.accessToken !== 'string') {
+		return false;
+	}
+
+	return candidate.refreshToken === null || typeof candidate.refreshToken === 'string';
+}
+
+/**
+ * Recognizes a message as belonging to the secret channel without trusting its payload.
+ * The correlation id is needed to answer malformed requests instead of leaving the
+ * sender waiting for a reply that never comes.
+ */
+export function readProviderSecretEnvelope(value: unknown): { id: string } | null {
+	if (typeof value !== 'object' || value === null) {
+		return null;
+	}
+
+	const candidate = value as { channel?: unknown; id?: unknown };
+
+	if (candidate.channel !== PROVIDER_SECRET_CHANNEL) {
+		return null;
+	}
+
+	if (typeof candidate.id !== 'string' || candidate.id.length === 0) {
+		return null;
+	}
+
+	return { id: candidate.id };
+}
+
+export function parseProviderSecretRequest(value: unknown): ProviderSecretRequest | null {
+	const envelope = readProviderSecretEnvelope(value);
+
+	if (!envelope) {
+		return null;
+	}
+
+	const candidate = value as { action?: unknown; provider?: unknown; secret?: unknown };
+
+	if (!isProviderSecretAction(candidate.action) || !isModelMappingProvider(candidate.provider)) {
+		return null;
+	}
+
+	if (candidate.action === 'set') {
+		if (!isProviderSecret(candidate.secret)) {
+			return null;
+		}
+
+		return {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: envelope.id,
+			action: 'set',
+			provider: candidate.provider,
+			secret: { accessToken: candidate.secret.accessToken, refreshToken: candidate.secret.refreshToken }
+		};
+	}
+
+	if (candidate.secret !== undefined) {
+		return null;
+	}
+
+	return {
+		channel: PROVIDER_SECRET_CHANNEL,
+		id: envelope.id,
+		action: candidate.action,
+		provider: candidate.provider
+	};
+}
+
+export function parseProviderSecretResponse(value: unknown): ProviderSecretResponse | null {
+	const envelope = readProviderSecretEnvelope(value);
+
+	if (!envelope) {
+		return null;
+	}
+
+	const candidate = value as { ok?: unknown; secret?: unknown; error?: unknown };
+
+	if (candidate.ok === true) {
+		if (candidate.secret !== null && !isProviderSecret(candidate.secret)) {
+			return null;
+		}
+
+		return {
+			channel: PROVIDER_SECRET_CHANNEL,
+			id: envelope.id,
+			ok: true,
+			secret: candidate.secret ?? null
+		};
+	}
+
+	if (candidate.ok === false && typeof candidate.error === 'string') {
+		return { channel: PROVIDER_SECRET_CHANNEL, id: envelope.id, ok: false, error: candidate.error };
+	}
+
+	return null;
+}


### PR DESCRIPTION
## Summary

- Store Claude, OpenAI, and MiniMax credentials in VS Code SecretStorage.
- Let the API child access credentials through a validated, correlated IPC channel.
- Keep only non-secret provider metadata in SQLite.
- Migrate and scrub existing plaintext access and refresh tokens before the API listens.
- Fail API startup when the extension credential channel is unavailable.

HTTP route authentication, CORS, loopback binding, and native artifact verification are intentionally outside this PR.

This is split from #42 following review feedback.

## Verification

- Extension: 78 tests passed
- API unit: 99 tests passed
- API integration: 64 tests passed
- API TypeScript build passed
- Extension build passed
